### PR TITLE
Add admin action to rename series issues slug

### DIFF
--- a/comicsdb/admin/issue.py
+++ b/comicsdb/admin/issue.py
@@ -211,9 +211,6 @@ class IssueAdmin(AdminImageMixin, admin.ModelAdmin):
 
     @admin.action(description="Add info from reprints")
     def add_reprint_info(self, request, queryset) -> None:
-        queryset = queryset.prefetch_related("reprints", "characters", "teams").order_by(
-            "reprints__cover_date"
-        )
         count = 0
         for i in queryset:
             modified = False

--- a/comicsdb/admin/series.py
+++ b/comicsdb/admin/series.py
@@ -1,6 +1,7 @@
-from django.contrib import admin
+from django.contrib import admin, messages
+from django.utils.translation import ngettext
 
-from comicsdb.models import Series, SeriesType
+from comicsdb.models import Issue, Series, SeriesType
 
 
 @admin.register(Series)
@@ -10,6 +11,8 @@ class SeriesAdmin(admin.ModelAdmin):
     list_filter = ("created_on", "modified", "series_type", "status", "publisher")
     prepopulated_fields = {"slug": ("name", "year_began")}
     autocomplete_fields = ["associated"]
+    actions = ["rename_issue_slugs"]
+    actions_on_top = True
     fieldsets = (
         (
             None,
@@ -35,6 +38,28 @@ class SeriesAdmin(admin.ModelAdmin):
         ("Related", {"fields": ("genres",)}),
     )
     filter_horizontal = ("genres",)
+
+    @admin.action(description="Rename series issues slugs")
+    def rename_issue_slugs(self, request, queryset) -> None:
+        all_issues_to_update = []
+        for qs in queryset:
+            issues = list(qs.issues.all())  # Convert queryset to list for efficient appending
+            for issue in issues:
+                issue.slug = f"{qs.slug}-{issue.number}"
+            all_issues_to_update.extend(issues)
+
+        count = Issue.objects.bulk_update(all_issues_to_update, ["slug"])
+
+        self.message_user(
+            request,
+            ngettext(
+                "%d issue was updated.",
+                "%d issues were updated.",
+                count,
+            )
+            % count,
+            messages.SUCCESS,
+        )
 
 
 @admin.register(SeriesType)


### PR DESCRIPTION
This PR adds a new admin action to rename a series issues slugs.

It also drops an unnecessary queryset from the add_reprint_info admin action.