### PR TITLE
Don't Create Add Creator Permission for New Users

### DIFF
--- a/users/admin.py
+++ b/users/admin.py
@@ -1,7 +1,5 @@
-from django.contrib import admin, messages
+from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin
-from django.contrib.auth.models import Permission
-from django.utils.translation import ngettext
 
 from users.forms import CustomUserChangeForm, CustomUserCreationForm
 from users.models import CustomUser
@@ -21,7 +19,6 @@ class CustomUserAdmin(UserAdmin):
         "date_joined",
         "groups",
     )
-    actions = ["grant_add_creator_perm"]
     fieldsets = (
         (None, {"fields": ("username", "password")}),
         (
@@ -51,32 +48,3 @@ class CustomUserAdmin(UserAdmin):
             },
         ),
     )
-
-    @admin.action(description="Grant 'add creator' permission to user")
-    def grant_add_creator_perm(self, request, queryset) -> None:
-        try:
-            permission = Permission.objects.get(name="Can add creator")
-        except Permission.DoesNotExist:
-            permission = None
-
-        if permission is not None:
-            count = 0
-            for i in queryset:
-                modified = False
-                if permission not in i.user_permissions.all():
-                    i.user_permissions.add(permission)
-                    modified = True
-
-                if modified:
-                    count += 1
-
-            self.message_user(
-                request,
-                ngettext(
-                    "%d user was updated.",
-                    "%d users were updated.",
-                    count,
-                )
-                % count,
-                messages.SUCCESS,
-            )

--- a/users/views.py
+++ b/users/views.py
@@ -2,7 +2,6 @@ import logging
 
 from django.contrib import messages
 from django.contrib.auth import login, update_session_auth_hash
-from django.contrib.auth.models import Permission
 from django.contrib.auth.views import PasswordChangeView
 from django.contrib.messages.views import SuccessMessageMixin
 from django.contrib.sites.shortcuts import get_current_site
@@ -42,13 +41,6 @@ def activate(request, uidb64, token):
 
     user.is_active = True
     user.email_confirmed = True
-    # Needed so the user can add new creators in the Issue form.
-    try:
-        permission = Permission.objects.get(name="Can add creator")
-    except Permission.DoesNotExist:
-        permission = None
-    if permission is not None:
-        user.user_permissions.add(permission)
     user.save()
     login(request, user)
     # Send pushover notification tha user activated account


### PR DESCRIPTION
This PR simply remove creating creator permissions for new users. 