### PR TITLE
Disable Creator Creation Option for Issue Form

### DIFF
--- a/comicsdb/urls/issue.py
+++ b/comicsdb/urls/issue.py
@@ -28,7 +28,7 @@ urlpatterns = [
     path("future", FutureList.as_view(), name="future"),
     re_path(
         r"^creator-autocomplete/?$",
-        CreatorAutocomplete.as_view(create_field="name", validate_create=True),
+        CreatorAutocomplete.as_view(),
         name="creator-autocomplete",
     ),
     re_path(


### PR DESCRIPTION
This PR removes the option to create a new creator from the Issue Form.

This has proven to be *way* more trouble than it's worth. Hopefully, by disabling this users will do a better job of searching for existing creators.