### PR TITLE
Add /api/whoami/ endpoint to return the authenticated user's username

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -2113,6 +2113,26 @@ Variant covers for issues.
 
 ---
 
+#### WhoAmI
+
+Returns the username of the currently authenticated user.
+
+**Base Path:** `/api/whoami/`
+
+**Actions:**
+
+- `GET /api/whoami/` - Return the authenticated user's username
+
+**Response Fields:**
+
+```json
+{
+  "username": "wanda"
+}
+```
+
+---
+
 ## Filtering
 
 ### Common Filter Patterns
@@ -2512,6 +2532,10 @@ For questions, issues, or feature requests:
 ---
 
 ## Changelog
+
+### Version 1.10
+
+- Added `GET /api/whoami/` to return the authenticated user's username
 
 ### Version 1.9
 

--- a/api/urls.py
+++ b/api/urls.py
@@ -18,6 +18,7 @@ from api.views import (
     TeamViewSet,
     UniverseViewSet,
     VariantViewset,
+    WhoAmIView,
     WishListViewSet,
 )
 
@@ -41,4 +42,7 @@ ROUTER.register("universe", UniverseViewSet)
 ROUTER.register("variant", VariantViewset)
 
 app_name = "api"
-urlpatterns = [path("", include(ROUTER.urls))]
+urlpatterns = [
+    path("whoami/", WhoAmIView.as_view(), name="whoami"),
+    path("", include(ROUTER.urls)),
+]

--- a/api/v1_0/serializers/__init__.py
+++ b/api/v1_0/serializers/__init__.py
@@ -62,6 +62,7 @@ from api.v1_0.serializers.collection import (
     ScrobbleRequestSerializer,
     ScrobbleResponseSerializer,
 )
+from api.v1_0.serializers.user import WhoAmISerializer
 
 __all__ = [
     "ArcListSerializer",
@@ -113,4 +114,5 @@ __all__ = [
     "UniverseSerializer",
     "VariantSerializer",
     "VariantsIssueSerializer",
+    "WhoAmISerializer",
 ]

--- a/api/v1_0/serializers/user.py
+++ b/api/v1_0/serializers/user.py
@@ -1,0 +1,5 @@
+from rest_framework import serializers
+
+
+class WhoAmISerializer(serializers.Serializer):
+    username = serializers.CharField(read_only=True)

--- a/api/views.py
+++ b/api/views.py
@@ -22,6 +22,7 @@ from rest_framework.pagination import PageNumberPagination
 from rest_framework.parsers import FormParser, JSONParser, MultiPartParser
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
+from rest_framework.views import APIView
 from rest_framework_condition import last_modified
 
 from api.v1_0.serializers import (
@@ -64,6 +65,7 @@ from api.v1_0.serializers import (
     UniverseReadSerializer,
     UniverseSerializer,
     VariantSerializer,
+    WhoAmISerializer,
 )
 from api.v1_0.serializers.pull_list import (
     PullListIssueSerializer,
@@ -1262,3 +1264,17 @@ class WishListViewSet(
         item = get_object_or_404(WishListItem, pk=item_pk, wish_list=wish_list)
         item.delete()
         return Response(status=status.HTTP_204_NO_CONTENT)
+
+
+class WhoAmIView(APIView):
+    """
+    get:
+    Returns the username of the currently authenticated user.
+    """
+
+    permission_classes = [IsAuthenticated]
+
+    @extend_schema(responses=WhoAmISerializer)
+    def get(self, request):
+        serializer = WhoAmISerializer(request.user)
+        return Response(serializer.data)

--- a/tests/api/test_whoami.py
+++ b/tests/api/test_whoami.py
@@ -1,0 +1,17 @@
+from django.urls import reverse
+from rest_framework import status
+
+
+def test_whoami_returns_authenticated_username(api_client, create_user):
+    user = create_user(username="wanda")
+    api_client.force_authenticate(user=user)
+
+    resp = api_client.get(reverse("api:whoami"))
+
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.data == {"username": "wanda"}
+
+
+def test_whoami_unauthorized(api_client):
+    resp = api_client.get(reverse("api:whoami"))
+    assert resp.status_code == status.HTTP_401_UNAUTHORIZED


### PR DESCRIPTION
## Summary
- Adds `GET /api/whoami/`, returning `{"username": "..."}` for the authenticated user
- Requires authentication (`IsAuthenticated`); unauthenticated requests get a 401
- Documented in api/README.md under Supporting Resources, with a new Version 1.10 changelog entry