### PR TITLE
Roll out i18n markup across all remaining apps

### DIFF
--- a/api/templates/api/throttle_enforcement_email.html
+++ b/api/templates/api/throttle_enforcement_email.html
@@ -1,10 +1,11 @@
+{% load i18n %}
 {% autoescape off %}
     <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
     <html xmlns="http://www.w3.org/1999/xhtml">
         <head>
             <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
             <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-            <title>Your Metron API access has been restricted</title>
+            <title>{% trans "Your Metron API access has been restricted" %}</title>
         </head>
         <body style="margin: 0;
                      padding: 0;
@@ -45,15 +46,13 @@
                                                color: #363636;
                                                font-weight: 600;
                                                font-family: Arial, Helvetica, sans-serif">
-                                        Hi {{ user.username }},
+                                        {% blocktrans with username=user.username %}Hi {{ username }},{% endblocktrans %}
                                     </h2>
                                     <p style="margin: 0 0 20px 0;
                                               font-size: 16px;
                                               color: #4a4a4a;
                                               font-family: Arial, Helvetica, sans-serif">
-                                        We previously warned you that your Metron API client was repeatedly
-                                        hitting our rate limits without backing off. Since that behavior has
-                                        continued, we've had to take action on this account:
+                                        {% blocktrans %}We previously warned you that your Metron API client was repeatedly hitting our rate limits without backing off. Since that behavior has continued, we've had to take action on this account:{% endblocktrans %}
                                     </p>
                                     <!-- Stats Box -->
                                     <table border="0"
@@ -71,19 +70,15 @@
                                                           font-family: Arial, Helvetica, sans-serif">
                                                     {% if days_throttled == 1 %}
                                                         {% if total_count == worst_day_count %}
-                                                            Most recently, your client received
-                                                            <strong>{{ worst_day_count }} rate-limited (429) response{{ worst_day_count|pluralize }}</strong>
-                                                            in a single day.
+                                                            {% blocktrans count counter=worst_day_count %}Most recently, your client received <strong>{{ counter }} rate-limited (429) response</strong> in a single day.{% plural %}Most recently, your client received <strong>{{ counter }} rate-limited (429) responses</strong> in a single day.{% endblocktrans %}
                                                         {% else %}
-                                                            Most recently, your client received
-                                                            <strong>{{ total_count }} rate-limited (429) response{{ total_count|pluralize }}</strong>
-                                                            recently, including <strong>{{ worst_day_count }}</strong> in a single day.
+                                                            {% blocktrans count counter=total_count %}Most recently, your client received <strong>{{ counter }} rate-limited (429) response</strong>{% plural %}Most recently, your client received <strong>{{ counter }} rate-limited (429) responses</strong>{% endblocktrans %}
+                                                            {% blocktrans with worst=worst_day_count %}recently, including <strong>{{ worst }}</strong> in a single day.{% endblocktrans %}
                                                         {% endif %}
                                                     {% else %}
-                                                        Most recently, your client received
-                                                        <strong>{{ total_count }} rate-limited (429) response{{ total_count|pluralize }}</strong>
-                                                        across <strong>{{ days_throttled }} day{{ days_throttled|pluralize }}</strong>,
-                                                        including <strong>{{ worst_day_count }}</strong> in a single day.
+                                                        {% blocktrans count counter=total_count %}Most recently, your client received <strong>{{ counter }} rate-limited (429) response</strong>{% plural %}Most recently, your client received <strong>{{ counter }} rate-limited (429) responses</strong>{% endblocktrans %}
+                                                        {% blocktrans count counter=days_throttled %}across <strong>{{ counter }} day</strong>{% plural %}across <strong>{{ counter }} days</strong>{% endblocktrans %},
+                                                        {% blocktrans with worst=worst_day_count %}including <strong>{{ worst }}</strong> in a single day.{% endblocktrans %}
                                                     {% endif %}
                                                 </p>
                                             </td>
@@ -104,13 +99,9 @@
                                                           color: #4a4a4a;
                                                           font-family: Arial, Helvetica, sans-serif">
                                                     {% if account_disabled %}
-                                                        <strong>This account has been disabled.</strong> You won't
-                                                        be able to log in or use the API until an administrator
-                                                        reinstates it.
+                                                        {% blocktrans %}<strong>This account has been disabled.</strong> You won't be able to log in or use the API until an administrator reinstates it.{% endblocktrans %}
                                                     {% else %}
-                                                        <strong>All API tokens for this account have been
-                                                        revoked.</strong> You'll need to generate a new token before
-                                                        you can use the API again.
+                                                        {% blocktrans %}<strong>All API tokens for this account have been revoked.</strong> You'll need to generate a new token before you can use the API again.{% endblocktrans %}
                                                     {% endif %}
                                                 </p>
                                             </td>
@@ -120,19 +111,13 @@
                                               font-size: 16px;
                                               color: #4a4a4a;
                                               font-family: Arial, Helvetica, sans-serif">
-                                        Before using the API again, please make sure your client respects the
-                                        <code>X-RateLimit-*</code> response headers and backs off after a 429
-                                        response instead of retrying immediately. For details on our rate limits
-                                        and how to implement a backoff strategy, see our
-                                        <a href="https://metron.cloud/wiki/api/handling-rate-limits/"
-                                           style="color: #3273dc;">Rate Limiting documentation</a>.
+                                        {% blocktrans %}Before using the API again, please make sure your client respects the <code>X-RateLimit-*</code> response headers and backs off after a 429 response instead of retrying immediately. For details on our rate limits and how to implement a backoff strategy, see our <a href="https://metron.cloud/wiki/api/handling-rate-limits/" style="color: #3273dc;">Rate Limiting documentation</a>.{% endblocktrans %}
                                     </p>
                                     <p style="margin: 0;
                                               font-size: 16px;
                                               color: #4a4a4a;
                                               font-family: Arial, Helvetica, sans-serif">
-                                        If you have any questions, or believe this was done in error, please reply
-                                        to this email so we can review it.
+                                        {% trans "If you have any questions, or believe this was done in error, please reply to this email so we can review it." %}
                                     </p>
                                 </td>
                             </tr>
@@ -143,32 +128,33 @@
                                               font-size: 14px;
                                               color: #ffffff;
                                               font-family: Arial, Helvetica, sans-serif">
-                                        <strong>Metron Comic Book Database</strong>
+                                        <strong>{% trans "Metron Comic Book Database" %}</strong>
                                     </p>
                                     <p style="margin: 0 0 15px 0;
                                               font-size: 14px;
                                               color: #b5b5b5;
                                               font-family: Arial, Helvetica, sans-serif">
-                                        A community-driven project for comic book enthusiasts
+                                        {% trans "A community-driven project for comic book enthusiasts" %}
                                     </p>
                                     <p style="margin: 0 0 10px 0;
                                               font-size: 14px;
                                               font-family: Arial, Helvetica, sans-serif">
                                         <a href="https://metron.cloud"
                                            style="color: #3273dc;
-                                                  text-decoration: none">Visit Website</a> &#8226;
+                                                  text-decoration: none">{% trans "Visit Website" %}</a> &#8226;
                                         <a href="https://github.com/Metron-Project/metron"
                                            style="color: #3273dc;
                                                   text-decoration: none">GitHub</a> &#8226;
                                         <a href="mailto:admin@metron.cloud"
                                            style="color: #3273dc;
-                                                  text-decoration: none">Contact Us</a>
+                                                  text-decoration: none">{% trans "Contact Us" %}</a>
                                     </p>
                                     <p style="margin: 15px 0 0 0;
                                               font-size: 12px;
                                               color: #7a7a7a;
                                               font-family: Arial, Helvetica, sans-serif">
-                                        &copy; {% now "Y" %} Metron Project. All rights reserved.
+                                        {% now "Y" as current_year %}
+                                        {% blocktrans %}&copy; {{ current_year }} Metron Project. All rights reserved.{% endblocktrans %}
                                     </p>
                                 </td>
                             </tr>

--- a/api/templates/api/throttle_enforcement_email.txt
+++ b/api/templates/api/throttle_enforcement_email.txt
@@ -1,36 +1,38 @@
-{% autoescape off %}Hi {{ user.username }},
+{% load i18n %}{% autoescape off %}{% blocktrans with username=user.username %}Hi {{ username }},{% endblocktrans %}
 
-We previously warned you that your Metron API client was repeatedly hitting our
+{% blocktrans %}We previously warned you that your Metron API client was repeatedly hitting our
 rate limits without backing off. Since that behavior has continued, we've had
-to take action on this account:
+to take action on this account:{% endblocktrans %}
 
-{% if days_throttled == 1 %}{% if total_count == worst_day_count %}Most recently, your client received {{ worst_day_count }} rate-limited (429) response{{ worst_day_count|pluralize }}
-in a single day.{% else %}Most recently, your client received {{ total_count }} rate-limited (429) response{{ total_count|pluralize }}
-recently, including {{ worst_day_count }} in a single day.{% endif %}{% else %}Most recently, your client received {{ total_count }} rate-limited (429) response{{ total_count|pluralize }}
-across {{ days_throttled }} day{{ days_throttled|pluralize }}, including {{ worst_day_count }}
-in a single day.{% endif %}
+{% if days_throttled == 1 %}{% if total_count == worst_day_count %}{% blocktrans count counter=worst_day_count %}Most recently, your client received {{ counter }} rate-limited (429) response
+in a single day.{% plural %}Most recently, your client received {{ counter }} rate-limited (429) responses
+in a single day.{% endblocktrans %}{% else %}{% blocktrans count counter=total_count %}Most recently, your client received {{ counter }} rate-limited (429) response{% plural %}Most recently, your client received {{ counter }} rate-limited (429) responses{% endblocktrans %}
+{% blocktrans with worst=worst_day_count %}recently, including {{ worst }} in a single day.{% endblocktrans %}{% endif %}{% else %}{% blocktrans count counter=total_count %}Most recently, your client received {{ counter }} rate-limited (429) response{% plural %}Most recently, your client received {{ counter }} rate-limited (429) responses{% endblocktrans %}
+{% blocktrans count counter=days_throttled %}across {{ counter }} day{% plural %}across {{ counter }} days{% endblocktrans %}, {% blocktrans with worst=worst_day_count %}including {{ worst }}
+in a single day.{% endblocktrans %}{% endif %}
 
-{% if account_disabled %}This account has been disabled. You won't be able to log in or use the API
-until an administrator reinstates it.{% else %}All API tokens for this account have been revoked. You'll need to generate a
-new token before you can use the API again.{% endif %}
+{% if account_disabled %}{% blocktrans %}This account has been disabled. You won't be able to log in or use the API
+until an administrator reinstates it.{% endblocktrans %}{% else %}{% blocktrans %}All API tokens for this account have been revoked. You'll need to generate a
+new token before you can use the API again.{% endblocktrans %}{% endif %}
 
-Before using the API again, please make sure your client respects the
+{% blocktrans %}Before using the API again, please make sure your client respects the
 X-RateLimit-* response headers and backs off after a 429 response instead of
 retrying immediately. For details on our rate limits and how to implement a
-backoff strategy, see:
+backoff strategy, see:{% endblocktrans %}
 
 https://metron.cloud/wiki/api/handling-rate-limits/
 
-If you have any questions, or believe this was done in error, please reply to
-this email so we can review it.
+{% blocktrans %}If you have any questions, or believe this was done in error, please reply to
+this email so we can review it.{% endblocktrans %}
 
 ---
-Metron Comic Book Database
-A community-driven project for comic book enthusiasts
+{% trans "Metron Comic Book Database" %}
+{% trans "A community-driven project for comic book enthusiasts" %}
 
-Website: https://metron.cloud
+{% trans "Website:" %} https://metron.cloud
 GitHub: https://github.com/Metron-Project/metron
-Contact: admin@metron.cloud
+{% trans "Contact:" %} admin@metron.cloud
 
-(c) {% now "Y" %} Metron Project. All rights reserved.
+{% now "Y" as current_year %}
+{% blocktrans %}(c) {{ current_year }} Metron Project. All rights reserved.{% endblocktrans %}
 {% endautoescape %}

--- a/api/templates/api/throttle_notice_email.html
+++ b/api/templates/api/throttle_notice_email.html
@@ -1,10 +1,11 @@
+{% load i18n %}
 {% autoescape off %}
     <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
     <html xmlns="http://www.w3.org/1999/xhtml">
         <head>
             <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
             <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-            <title>Your Metron API client is being rate-limited</title>
+            <title>{% trans "Your Metron API client is being rate-limited" %}</title>
         </head>
         <body style="margin: 0;
                      padding: 0;
@@ -45,23 +46,16 @@
                                                color: #363636;
                                                font-weight: 600;
                                                font-family: Arial, Helvetica, sans-serif">
-                                        Hi {{ user.username }},
+                                        {% blocktrans with username=user.username %}Hi {{ username }},{% endblocktrans %}
                                     </h2>
                                     <p style="margin: 0 0 20px 0;
                                               font-size: 16px;
                                               color: #4a4a4a;
                                               font-family: Arial, Helvetica, sans-serif">
                                         {% if days_throttled == 1 %}
-                                            We've noticed that your Metron API client hit our rate limits hard,
-                                            with {{ worst_day_count }} rate-limited (429) responses in a single
-                                            day. When a client keeps retrying immediately after a 429 response
-                                            instead of backing off, it adds unnecessary load to the site for
-                                            everyone.
+                                            {% blocktrans with count=worst_day_count %}We've noticed that your Metron API client hit our rate limits hard, with {{ count }} rate-limited (429) responses in a single day. When a client keeps retrying immediately after a 429 response instead of backing off, it adds unnecessary load to the site for everyone.{% endblocktrans %}
                                         {% else %}
-                                            We've noticed that your Metron API client has repeatedly hit our rate
-                                            limits over the past several days. When a client keeps retrying
-                                            immediately after a 429 response instead of backing off, it adds
-                                            unnecessary load to the site for everyone.
+                                            {% trans "We've noticed that your Metron API client has repeatedly hit our rate limits over the past several days. When a client keeps retrying immediately after a 429 response instead of backing off, it adds unnecessary load to the site for everyone." %}
                                         {% endif %}
                                     </p>
                                     <!-- Stats Box -->
@@ -80,19 +74,15 @@
                                                           font-family: Arial, Helvetica, sans-serif">
                                                     {% if days_throttled == 1 %}
                                                         {% if total_count == worst_day_count %}
-                                                            Your client received
-                                                            <strong>{{ worst_day_count }} rate-limited (429) response{{ worst_day_count|pluralize }}</strong>
-                                                            in a single day.
+                                                            {% blocktrans count counter=worst_day_count %}Your client received <strong>{{ counter }} rate-limited (429) response</strong> in a single day.{% plural %}Your client received <strong>{{ counter }} rate-limited (429) responses</strong> in a single day.{% endblocktrans %}
                                                         {% else %}
-                                                            Your client received
-                                                            <strong>{{ total_count }} rate-limited (429) response{{ total_count|pluralize }}</strong>
-                                                            recently, including <strong>{{ worst_day_count }}</strong> in a single day.
+                                                            {% blocktrans count counter=total_count %}Your client received <strong>{{ counter }} rate-limited (429) response</strong>{% plural %}Your client received <strong>{{ counter }} rate-limited (429) responses</strong>{% endblocktrans %}
+                                                            {% blocktrans with worst=worst_day_count %}recently, including <strong>{{ worst }}</strong> in a single day.{% endblocktrans %}
                                                         {% endif %}
                                                     {% else %}
-                                                        Your client received
-                                                        <strong>{{ total_count }} rate-limited (429) response{{ total_count|pluralize }}</strong>
-                                                        across <strong>{{ days_throttled }} day{{ days_throttled|pluralize }}</strong>,
-                                                        including <strong>{{ worst_day_count }}</strong> in a single day.
+                                                        {% blocktrans count counter=total_count %}Your client received <strong>{{ counter }} rate-limited (429) response</strong>{% plural %}Your client received <strong>{{ counter }} rate-limited (429) responses</strong>{% endblocktrans %}
+                                                        {% blocktrans count counter=days_throttled %}across <strong>{{ counter }} day</strong>{% plural %}across <strong>{{ counter }} days</strong>{% endblocktrans %},
+                                                        {% blocktrans with worst=worst_day_count %}including <strong>{{ worst }}</strong> in a single day.{% endblocktrans %}
                                                     {% endif %}
                                                 </p>
                                             </td>
@@ -112,11 +102,7 @@
                                                           font-size: 14px;
                                                           color: #4a4a4a;
                                                           font-family: Arial, Helvetica, sans-serif">
-                                                    Every API response includes <code>X-RateLimit-*</code> headers
-                                                    showing your current limit, remaining requests, and when the
-                                                    window resets. A 429 response means you've exceeded that limit
-                                                    for the current window - the fix is to slow down and wait
-                                                    before retrying, rather than retrying immediately.
+                                                    {% blocktrans %}Every API response includes <code>X-RateLimit-*</code> headers showing your current limit, remaining requests, and when the window resets. A 429 response means you've exceeded that limit for the current window - the fix is to slow down and wait before retrying, rather than retrying immediately.{% endblocktrans %}
                                                 </p>
                                             </td>
                                         </tr>
@@ -125,10 +111,7 @@
                                               font-size: 16px;
                                               color: #4a4a4a;
                                               font-family: Arial, Helvetica, sans-serif">
-                                        For details on our current rate limits and how to implement a backoff
-                                        strategy, see our
-                                        <a href="https://metron.cloud/wiki/api/handling-rate-limits/"
-                                           style="color: #3273dc;">Rate Limiting documentation</a>.
+                                        {% blocktrans %}For details on our current rate limits and how to implement a backoff strategy, see our <a href="https://metron.cloud/wiki/api/handling-rate-limits/" style="color: #3273dc;">Rate Limiting documentation</a>.{% endblocktrans %}
                                     </p>
                                     <!-- Warning Box -->
                                     <table border="0"
@@ -144,9 +127,7 @@
                                                           font-size: 14px;
                                                           color: #4a4a4a;
                                                           font-family: Arial, Helvetica, sans-serif">
-                                                    <strong>Important:</strong> If this behavior continues, we may
-                                                    revoke API access for this account to protect the site for
-                                                    other users.
+                                                    {% blocktrans %}<strong>Important:</strong> If this behavior continues, we may revoke API access for this account to protect the site for other users.{% endblocktrans %}
                                                 </p>
                                             </td>
                                         </tr>
@@ -155,8 +136,7 @@
                                               font-size: 16px;
                                               color: #4a4a4a;
                                               font-family: Arial, Helvetica, sans-serif">
-                                        If you have any questions, or believe you're seeing this in error, just
-                                        reply to this email.
+                                        {% trans "If you have any questions, or believe you're seeing this in error, just reply to this email." %}
                                     </p>
                                 </td>
                             </tr>
@@ -167,32 +147,33 @@
                                               font-size: 14px;
                                               color: #ffffff;
                                               font-family: Arial, Helvetica, sans-serif">
-                                        <strong>Metron Comic Book Database</strong>
+                                        <strong>{% trans "Metron Comic Book Database" %}</strong>
                                     </p>
                                     <p style="margin: 0 0 15px 0;
                                               font-size: 14px;
                                               color: #b5b5b5;
                                               font-family: Arial, Helvetica, sans-serif">
-                                        A community-driven project for comic book enthusiasts
+                                        {% trans "A community-driven project for comic book enthusiasts" %}
                                     </p>
                                     <p style="margin: 0 0 10px 0;
                                               font-size: 14px;
                                               font-family: Arial, Helvetica, sans-serif">
                                         <a href="https://metron.cloud"
                                            style="color: #3273dc;
-                                                  text-decoration: none">Visit Website</a> &#8226;
+                                                  text-decoration: none">{% trans "Visit Website" %}</a> &#8226;
                                         <a href="https://github.com/Metron-Project/metron"
                                            style="color: #3273dc;
                                                   text-decoration: none">GitHub</a> &#8226;
                                         <a href="mailto:admin@metron.cloud"
                                            style="color: #3273dc;
-                                                  text-decoration: none">Contact Us</a>
+                                                  text-decoration: none">{% trans "Contact Us" %}</a>
                                     </p>
                                     <p style="margin: 15px 0 0 0;
                                               font-size: 12px;
                                               color: #7a7a7a;
                                               font-family: Arial, Helvetica, sans-serif">
-                                        &copy; {% now "Y" %} Metron Project. All rights reserved.
+                                        {% now "Y" as current_year %}
+                                        {% blocktrans %}&copy; {{ current_year }} Metron Project. All rights reserved.{% endblocktrans %}
                                     </p>
                                 </td>
                             </tr>

--- a/api/templates/api/throttle_notice_email.txt
+++ b/api/templates/api/throttle_notice_email.txt
@@ -1,42 +1,44 @@
-{% autoescape off %}Hi {{ user.username }},
+{% load i18n %}{% autoescape off %}{% blocktrans with username=user.username %}Hi {{ username }},{% endblocktrans %}
 
-{% if days_throttled == 1 %}We've noticed that your Metron API client hit our rate limits hard, with
-{{ worst_day_count }} rate-limited (429) responses in a single day. When a client keeps
+{% if days_throttled == 1 %}{% blocktrans with count=worst_day_count %}We've noticed that your Metron API client hit our rate limits hard, with
+{{ count }} rate-limited (429) responses in a single day. When a client keeps
 retrying immediately after a 429 response instead of backing off, it adds
-unnecessary load to the site for everyone.{% else %}We've noticed that your Metron API client has repeatedly hit our rate limits over
+unnecessary load to the site for everyone.{% endblocktrans %}{% else %}{% blocktrans %}We've noticed that your Metron API client has repeatedly hit our rate limits over
 the past several days. When a client keeps retrying immediately after a 429
 response instead of backing off, it adds unnecessary load to the site for
-everyone.{% endif %}
+everyone.{% endblocktrans %}{% endif %}
 
-{% if days_throttled == 1 %}{% if total_count == worst_day_count %}Your client received {{ worst_day_count }} rate-limited (429) response{{ worst_day_count|pluralize }}
-in a single day.{% else %}Your client received {{ total_count }} rate-limited (429) response{{ total_count|pluralize }}
-recently, including {{ worst_day_count }} in a single day.{% endif %}{% else %}Your client received {{ total_count }} rate-limited (429) response{{ total_count|pluralize }}
-across {{ days_throttled }} day{{ days_throttled|pluralize }}, including {{ worst_day_count }}
-in a single day.{% endif %}
+{% if days_throttled == 1 %}{% if total_count == worst_day_count %}{% blocktrans count counter=worst_day_count %}Your client received {{ counter }} rate-limited (429) response
+in a single day.{% plural %}Your client received {{ counter }} rate-limited (429) responses
+in a single day.{% endblocktrans %}{% else %}{% blocktrans count counter=total_count %}Your client received {{ counter }} rate-limited (429) response{% plural %}Your client received {{ counter }} rate-limited (429) responses{% endblocktrans %}
+{% blocktrans with worst=worst_day_count %}recently, including {{ worst }} in a single day.{% endblocktrans %}{% endif %}{% else %}{% blocktrans count counter=total_count %}Your client received {{ counter }} rate-limited (429) response{% plural %}Your client received {{ counter }} rate-limited (429) responses{% endblocktrans %}
+{% blocktrans count counter=days_throttled %}across {{ counter }} day{% plural %}across {{ counter }} days{% endblocktrans %}, {% blocktrans with worst=worst_day_count %}including {{ worst }}
+in a single day.{% endblocktrans %}{% endif %}
 
-Every API response includes X-RateLimit-* headers showing your current limit,
+{% blocktrans %}Every API response includes X-RateLimit-* headers showing your current limit,
 remaining requests, and when the window resets. A 429 response also means you've
 exceeded that limit for the current window - the fix is to slow down and wait
-before retrying, rather than retrying immediately.
+before retrying, rather than retrying immediately.{% endblocktrans %}
 
-For details on our current rate limits and how to implement a backoff strategy,
-see:
+{% blocktrans %}For details on our current rate limits and how to implement a backoff strategy,
+see:{% endblocktrans %}
 
 https://metron.cloud/wiki/api/handling-rate-limits/
 
-IMPORTANT: If this behavior continues, we may revoke API access for this account
-to protect the site for other users.
+{% blocktrans %}IMPORTANT: If this behavior continues, we may revoke API access for this account
+to protect the site for other users.{% endblocktrans %}
 
-If you have any questions, or believe you're seeing this in error, just reply to
-this email.
+{% blocktrans %}If you have any questions, or believe you're seeing this in error, just reply to
+this email.{% endblocktrans %}
 
 ---
-Metron Comic Book Database
-A community-driven project for comic book enthusiasts
+{% trans "Metron Comic Book Database" %}
+{% trans "A community-driven project for comic book enthusiasts" %}
 
-Website: https://metron.cloud
+{% trans "Website:" %} https://metron.cloud
 GitHub: https://github.com/Metron-Project/metron
-Contact: admin@metron.cloud
+{% trans "Contact:" %} admin@metron.cloud
 
-(c) {% now "Y" %} Metron Project. All rights reserved.
+{% now "Y" as current_year %}
+{% blocktrans %}(c) {{ current_year }} Metron Project. All rights reserved.{% endblocktrans %}
 {% endautoescape %}

--- a/api/v1_0/serializers/collection.py
+++ b/api/v1_0/serializers/collection.py
@@ -1,3 +1,4 @@
+from django.utils.translation import gettext as _
 from rest_framework import serializers
 
 from api.v1_0.serializers.issue import IssueListSeriesSerializer
@@ -93,7 +94,9 @@ class CollectionAddItemSerializer(serializers.Serializer):
     def validate_issue_id(self, value):
         """Verify issue exists."""
         if not Issue.objects.filter(pk=value).exists():
-            raise serializers.ValidationError(f"Issue with id {value} does not exist.")
+            raise serializers.ValidationError(
+                _("Issue with id %(id)s does not exist.") % {"id": value}
+            )
         return value
 
 
@@ -211,7 +214,9 @@ class ScrobbleRequestSerializer(serializers.Serializer):
         try:
             Issue.objects.get(pk=value)
         except Issue.DoesNotExist as err:
-            raise serializers.ValidationError(f"Issue with id {value} does not exist.") from err
+            raise serializers.ValidationError(
+                _("Issue with id %(id)s does not exist.") % {"id": value}
+            ) from err
         return value
 
 

--- a/api/v1_0/serializers/issue.py
+++ b/api/v1_0/serializers/issue.py
@@ -1,6 +1,7 @@
 import json
 from decimal import Decimal
 
+from django.utils.translation import gettext as _
 from djmoney.money import Money
 from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
@@ -108,16 +109,19 @@ class PriceField(serializers.Field):
             if amount in (None, ""):
                 return None
 
-            valid_currencies = [c for c, _ in CURRENCY_CHOICES]
+            valid_currencies = [c for c, _name in CURRENCY_CHOICES]
             if currency not in valid_currencies:
                 raise serializers.ValidationError(
-                    f"Invalid currency '{currency}'. Supported: {', '.join(valid_currencies)}"
+                    _("Invalid currency '%(currency)s'. Supported: %(valid)s")
+                    % {"currency": currency, "valid": ", ".join(valid_currencies)}
                 )
 
             try:
                 return Money(Decimal(str(amount)), currency)
             except (ValueError, TypeError) as e:
-                raise serializers.ValidationError(f"Invalid price format: {e}") from e
+                raise serializers.ValidationError(
+                    _("Invalid price format: %(error)s") % {"error": e}
+                ) from e
 
         # Handle simple decimal/string format (backward compatible)
         # Convert to string and strip whitespace
@@ -128,7 +132,9 @@ class PriceField(serializers.Field):
         try:
             return Money(Decimal(data_str), "USD")
         except (ValueError, TypeError) as e:
-            raise serializers.ValidationError(f"Invalid price format: {e}") from e
+            raise serializers.ValidationError(
+                _("Invalid price format: %(error)s") % {"error": e}
+            ) from e
 
 
 class VariantsIssueSerializer(serializers.ModelSerializer):

--- a/api/v1_0/serializers/wish_list.py
+++ b/api/v1_0/serializers/wish_list.py
@@ -1,3 +1,4 @@
+from django.utils.translation import gettext as _
 from rest_framework import serializers
 
 from api.v1_0.serializers.collection import CollectionIssueSerializer
@@ -74,7 +75,9 @@ class WishListAddItemSerializer(serializers.Serializer):
 
     def validate_issue_id(self, value):
         if not Issue.objects.filter(pk=value).exists():
-            raise serializers.ValidationError(f"Issue with id {value} does not exist.")
+            raise serializers.ValidationError(
+                _("Issue with id %(id)s does not exist.") % {"id": value}
+            )
         return value
 
 

--- a/comicsdb/forms/character.py
+++ b/comicsdb/forms/character.py
@@ -1,4 +1,5 @@
 from django.forms import ClearableFileInput, ModelForm
+from django.utils.translation import gettext_lazy as _
 
 from comicsdb.forms.creator import CreatorsWidget
 from comicsdb.forms.team import TeamsWidget
@@ -27,5 +28,5 @@ class CharacterForm(ModelForm):
             "image": ClearableFileInput(),
         }
         help_texts = {
-            "alias": "Separate multiple aliases by a comma",
+            "alias": _("Separate multiple aliases by a comma"),
         }

--- a/comicsdb/forms/creator.py
+++ b/comicsdb/forms/creator.py
@@ -1,4 +1,5 @@
 from django.forms import ClearableFileInput, DateInput, ModelForm
+from django.utils.translation import gettext_lazy as _
 
 from comicsdb.autocomplete import CreatorAutocomplete
 from comicsdb.forms.widgets import SafeAutocompleteWidget
@@ -30,5 +31,5 @@ class CreatorForm(ModelForm):
             "image": ClearableFileInput(),
         }
         help_texts = {
-            "alias": "Separate multiple aliases by a comma",
+            "alias": _("Separate multiple aliases by a comma"),
         }

--- a/comicsdb/forms/credits.py
+++ b/comicsdb/forms/credits.py
@@ -4,6 +4,7 @@ from django.forms import (
     ModelMultipleChoiceField,
     inlineformset_factory,
 )
+from django.utils.translation import gettext_lazy as _
 
 from comicsdb.autocomplete import CreatorAutocomplete, RoleAutocomplete
 from comicsdb.forms.widgets import SafeAutocompleteWidget
@@ -17,7 +18,7 @@ class CreditsForm(ModelForm):
         widget=SafeAutocompleteWidget(
             ac_class=CreatorAutocomplete,
             attrs={
-                "placeholder": "Autocomplete...",
+                "placeholder": _("Autocomplete..."),
             },
         ),
     )

--- a/comicsdb/forms/publisher.py
+++ b/comicsdb/forms/publisher.py
@@ -1,4 +1,5 @@
 from django.forms import ClearableFileInput, ModelForm, ValidationError
+from django.utils.translation import gettext_lazy as _
 
 from comicsdb.autocomplete import PublisherAutocomplete
 from comicsdb.forms.widgets import SafeAutocompleteWidget
@@ -24,5 +25,5 @@ class PublisherForm(ModelForm):
         country = self.cleaned_data["country"]
         allowed = {"US", "GB"}
         if country and str(country) not in allowed:
-            raise ValidationError("Currently only US and UK Publishers are supported")
+            raise ValidationError(_("Currently only US and UK Publishers are supported"))
         return country

--- a/comicsdb/forms/series.py
+++ b/comicsdb/forms/series.py
@@ -1,5 +1,6 @@
 from django.contrib.postgres.forms import SimpleArrayField
 from django.forms import CharField, ModelChoiceField, ModelForm, ValidationError
+from django.utils.translation import gettext_lazy as _
 
 from comicsdb.autocomplete import ImprintAutocomplete, PublisherAutocomplete, SeriesAutocomplete
 from comicsdb.forms.widgets import SafeAutocompleteWidget
@@ -26,20 +27,20 @@ MultiSeriesWidget = SafeAutocompleteWidget(
 class SeriesForm(ModelForm):
     publisher = ModelChoiceField(
         queryset=Publisher.objects.all(),
-        label="Publisher",
+        label=_("Publisher"),
         widget=SafeAutocompleteWidget(ac_class=PublisherAutocomplete),
     )
     imprint = ModelChoiceField(
         queryset=Imprint.objects.all(),
-        label="Imprint",
+        label=_("Imprint"),
         widget=SafeAutocompleteWidget(ac_class=ImprintAutocomplete),
         required=False,
     )
     alt_names = SimpleArrayField(
         CharField(max_length=255),
         delimiter=";",
-        label="Alternative Names",
-        help_text="Separate multiple alternative names by a semicolon",
+        label=_("Alternative Names"),
+        help_text=_("Separate multiple alternative names by a semicolon"),
         required=False,
     )
 
@@ -67,25 +68,29 @@ class SeriesForm(ModelForm):
             "associated": MultiSeriesWidget,
         }
         help_texts = {
-            "volume": "This is <strong>not</strong> the year the series began. "
-            "If you have a question, contact the site administrator.",
-            "sort_name": """Most of the time it will be the same as the series name,
-            but if the title starts with an article like 'The' it might be remove so
-            that it is listed with like named series.""",
-            "year_end": "Leave blank if a One-Shot, Annual, or Ongoing Series.",
-            "associated": (
+            "volume": _(
+                "This is <strong>not</strong> the year the series began. "
+                "If you have a question, contact the site administrator."
+            ),
+            "sort_name": _(
+                "Most of the time it will be the same as the series name, "
+                "but if the title starts with an article like 'The' it might be remove so "
+                "that it is listed with like named series."
+            ),
+            "year_end": _("Leave blank if a One-Shot, Annual, or Ongoing Series."),
+            "associated": _(
                 "Associate the series with another series. For example, "
                 "an annual with it's primary series."
             ),
-            "genres": "Hold down “Control”, or “Command” on a Mac, to select more than one.",
-            "collection": (
+            "genres": _("Hold down “Control”, or “Command” on a Mac, to select more than one."),
+            "collection": _(
                 "Whether a series has a collection title. "
                 "Normally this only applies to Trade Paperbacks. "
                 "For example, the 2015 Deathstroke Trade Paperback which has a collection "
                 "title of 'Gods of War'."
             ),
         }
-        labels = {"associated": "Associated Series", "collection": "Allow collection title?"}
+        labels = {"associated": _("Associated Series"), "collection": _("Allow collection title?")}
 
         field_order = [
             "name",
@@ -116,7 +121,7 @@ class SeriesForm(ModelForm):
             # Don't allow cv_id information for Trade Paperbacks. Refer to:
             # https://github.com/Metron-Project/metron/issues/219
             if series_type.id == TPB:
-                msg = (
+                msg = _(
                     "Adding a Comic Vine ID  is not allowed for Trade Paperbacks, "
                     "due to the consolidation work being done there."
                 )
@@ -132,5 +137,7 @@ class SeriesForm(ModelForm):
             # If adding an associated series and self.series_type is a TPB, OMNI, or HC
             # raise a validation error.
             if series_type.id in [HC, OMNI, TPB]:
-                raise ValidationError("Collections are not allowed to have an associated series.")
+                raise ValidationError(
+                    _("Collections are not allowed to have an associated series.")
+                )
         return assoc

--- a/comicsdb/forms/universe.py
+++ b/comicsdb/forms/universe.py
@@ -1,4 +1,5 @@
 from django.forms import ClearableFileInput, ModelForm
+from django.utils.translation import gettext_lazy as _
 
 from comicsdb.autocomplete import UniverseAutocomplete
 from comicsdb.forms.widgets import SafeAutocompleteWidget
@@ -24,8 +25,12 @@ class UniverseForm(ModelForm):
         )  # CV doesn't have universe resource
         widgets = {"image": ClearableFileInput()}
         help_texts = {
-            "name": "Do not use a hyphen to separate text in this field. For example, "
-            "<i>'Earth 2'</i> should <b>not</b> be <i>'Earth-2'</i>.",
-            "designation": "Do not use a hyphen to separate text in this field. For example, "
-            "<i>'Earth 2'</i> should <b>not</b> be <i>'Earth-2'</i>.",
+            "name": _(
+                "Do not use a hyphen to separate text in this field. For example, "
+                "<i>'Earth 2'</i> should <b>not</b> be <i>'Earth-2'</i>."
+            ),
+            "designation": _(
+                "Do not use a hyphen to separate text in this field. For example, "
+                "<i>'Earth 2'</i> should <b>not</b> be <i>'Earth-2'</i>."
+            ),
         }

--- a/comicsdb/models/announcement.py
+++ b/comicsdb/models/announcement.py
@@ -1,13 +1,14 @@
 from django.db import models
 from django.db.models import Q
 from django.utils import timezone
+from django.utils.translation import gettext_lazy as _
 
 DisplayTypes = [
-    ("primary", "Primary"),
-    ("success", "Success"),
-    ("link", "Link"),
-    ("warning", "Warning"),
-    ("danger", "Danger"),
+    ("primary", _("Primary")),
+    ("success", _("Success")),
+    ("link", _("Link")),
+    ("warning", _("Warning")),
+    ("danger", _("Danger")),
 ]
 
 

--- a/comicsdb/models/attribution.py
+++ b/comicsdb/models/attribution.py
@@ -1,14 +1,15 @@
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
 from django.db import models
+from django.utils.translation import gettext_lazy as _
 
 
 class Attribution(models.Model):
     class Source(models.TextChoices):
-        MARVEL = "M", "Marvel"
-        WIKIPEDIA = "W", "Wikipedia"
-        GCD = "G", "Grand Comics Database"
-        DC = "D", "DC"
+        MARVEL = "M", _("Marvel")
+        WIKIPEDIA = "W", _("Wikipedia")
+        GCD = "G", _("Grand Comics Database")
+        DC = "D", _("DC")
 
     source = models.CharField(max_length=1, choices=Source.choices, default=Source.WIKIPEDIA)
     url = models.URLField()

--- a/comicsdb/models/common.py
+++ b/comicsdb/models/common.py
@@ -3,6 +3,7 @@ import itertools
 from django.db import models
 from django.db.models.functions import Now
 from django.utils.text import slugify
+from django.utils.translation import gettext_lazy as _
 
 MIN_RATING = 1
 MAX_RATING = 5
@@ -40,9 +41,9 @@ def pre_save_slug(sender, instance, **kwargs):
 class CommonInfo(models.Model):
     name = models.CharField(max_length=255)
     slug = models.SlugField(max_length=255, unique=True)
-    desc = models.TextField("Description", blank=True)
-    cv_id = models.PositiveIntegerField("Comic Vine ID", null=True, blank=True, unique=True)
-    gcd_id = models.PositiveIntegerField("GCD ID", null=True, blank=True, unique=True)
+    desc = models.TextField(_("Description"), blank=True)
+    cv_id = models.PositiveIntegerField(_("Comic Vine ID"), null=True, blank=True, unique=True)
+    gcd_id = models.PositiveIntegerField(_("GCD ID"), null=True, blank=True, unique=True)
     modified = models.DateTimeField(auto_now=True)
     created_on = models.DateTimeField(db_default=Now())
 
@@ -55,7 +56,7 @@ class AbstractRating(models.Model):
 
     rating = models.PositiveSmallIntegerField(
         choices=RATING_CHOICES,
-        help_text="Star rating (1-5)",
+        help_text=_("Star rating (1-5)"),
     )
     created_on = models.DateTimeField(db_default=Now())
     modified = models.DateTimeField(auto_now=True)

--- a/comicsdb/models/credits.py
+++ b/comicsdb/models/credits.py
@@ -1,4 +1,5 @@
 from django.db import models
+from django.utils.translation import gettext_lazy as _
 
 from comicsdb.models.creator import Creator
 from comicsdb.models.issue import Issue
@@ -27,7 +28,7 @@ class Credits(models.Model):
         indexes = [models.Index(fields=["issue", "creator"], name="issue_creator_idx")]
         ordering = ["issue", "creator__name"]
         unique_together = ["issue", "creator"]
-        verbose_name_plural = "Credits"
+        verbose_name_plural = _("Credits")
 
     def __str__(self) -> str:
         return f"{self.issue}: {self.creator}"

--- a/comicsdb/models/series.py
+++ b/comicsdb/models/series.py
@@ -10,6 +10,7 @@ from django.db.models.functions import Upper
 from django.db.models.signals import pre_save
 from django.urls import reverse
 from django.utils.text import slugify
+from django.utils.translation import gettext_lazy as _
 from simple_history.models import HistoricalRecords
 
 from comicsdb.db_functions import ArrayToString
@@ -38,18 +39,21 @@ class SeriesType(models.Model):
 
 class Series(CommonInfo):
     class Status(models.IntegerChoices):
-        CANCELLED = 1
-        COMPLETED = 2
-        HIATUS = 3
-        ONGOING = 4
+        CANCELLED = 1, _("Cancelled")
+        COMPLETED = 2, _("Completed")
+        HIATUS = 3, _("Hiatus")
+        ONGOING = 4, _("Ongoing")
 
     sort_name = models.CharField(max_length=255)
     alt_names = ArrayField(
-        models.CharField(max_length=255), blank=True, default=list, verbose_name="Alternative Names"
+        models.CharField(max_length=255),
+        blank=True,
+        default=list,
+        verbose_name=_("Alternative Names"),
     )
-    volume = models.PositiveSmallIntegerField("Volume Number")
-    year_began = models.PositiveSmallIntegerField("Year Began")
-    year_end = models.PositiveSmallIntegerField("Year Ended", null=True, blank=True)
+    volume = models.PositiveSmallIntegerField(_("Volume Number"))
+    year_began = models.PositiveSmallIntegerField(_("Year Began"))
+    year_end = models.PositiveSmallIntegerField(_("Year Ended"), null=True, blank=True)
     series_type = models.ForeignKey(SeriesType, on_delete=models.CASCADE)
     status = models.IntegerField(choices=Status.choices, default=Status.ONGOING)
     publisher = models.ForeignKey(Publisher, on_delete=models.CASCADE, related_name="series")
@@ -57,10 +61,12 @@ class Series(CommonInfo):
         Imprint, on_delete=models.SET_NULL, null=True, blank=True, related_name="series"
     )
     collection = models.BooleanField(
-        "Allow Collection Title",
+        _("Allow Collection Title"),
         db_default=False,
-        help_text="Whether a series has a collection title. "
-        "Normally this only applies to Trade Paperbacks.",
+        help_text=_(
+            "Whether a series has a collection title. "
+            "Normally this only applies to Trade Paperbacks."
+        ),
     )
     genres = models.ManyToManyField(Genre, blank=True, related_name="series")
     associated = models.ManyToManyField("self", blank=True)
@@ -111,7 +117,7 @@ class Series(CommonInfo):
         ]
         ordering = ["sort_name", "year_began"]
         unique_together = ["publisher", "name", "volume", "series_type"]
-        verbose_name_plural = "Series"
+        verbose_name_plural = _("Series")
 
 
 def generate_series_slug(instance):

--- a/comicsdb/templates/comicsdb/arc_detail.html
+++ b/comicsdb/templates/comicsdb/arc_detail.html
@@ -1,6 +1,6 @@
 {% extends parent_template|default:"base.html" %}
 {% load thumbnail %}
-{% load static %}
+{% load i18n static %}
 {% block title %}
     {{ arc.name }}
 {% endblock title %}
@@ -10,31 +10,31 @@
         <h1 class="title">{{ arc }}</h1>
     </header>
     {# Navigation Bar #}
-    <nav class="level mb-5" aria-label="Story arc navigation">
+    <nav class="level mb-5" aria-label="{% trans 'Story arc navigation' %}">
         <div class="level-left">
             {% if navigation.previous_arc %}
                 <a class="button is-link"
                    href="{% url 'arc:detail' navigation.previous_arc.slug %}"
-                   aria-label="Go to {{ navigation.previous_arc }}">
+                   aria-label="{% blocktrans with previous_arc=navigation.previous_arc %}Go to {{ previous_arc }}{% endblocktrans %}">
                     <span class="icon is-small"><i class="fas fa-arrow-left" aria-hidden="true"></i></span>
-                    <span>Previous Arc</span>
+                    <span>{% trans "Previous Arc" %}</span>
                 </a>
             {% else %}
                 <button class="button" disabled aria-disabled="true">
                     <span class="icon is-small"><i class="fas fa-arrow-left" aria-hidden="true"></i></span>
-                    <span>Previous Arc</span>
+                    <span>{% trans "Previous Arc" %}</span>
                 </button>
             {% endif %}
             {% if navigation.next_arc %}
                 <a class="button is-link ml-2"
                    href="{% url 'arc:detail' navigation.next_arc.slug %}"
-                   aria-label="Go to {{ navigation.next_arc }}">
-                    <span>Next Arc</span>
+                   aria-label="{% blocktrans with next_arc=navigation.next_arc %}Go to {{ next_arc }}{% endblocktrans %}">
+                    <span>{% trans "Next Arc" %}</span>
                     <span class="icon is-small"><i class="fas fa-arrow-right" aria-hidden="true"></i></span>
                 </a>
             {% else %}
                 <button class="button ml-2" disabled aria-disabled="true">
-                    <span>Next Arc</span>
+                    <span>{% trans "Next Arc" %}</span>
                     <span class="icon is-small"><i class="fas fa-arrow-right" aria-hidden="true"></i></span>
                 </button>
             {% endif %}
@@ -44,9 +44,9 @@
                 <div class="buttons">
                     <a class="button is-primary"
                        href="{% url 'arc:create' %}"
-                       title="Add a new story arc">
+                       title="{% trans 'Add a new story arc' %}">
                         <span class="icon is-small"><i class="fas fa-plus" aria-hidden="true"></i></span>
-                        <span>New</span>
+                        <span>{% trans "New" %}</span>
                     </a>
                     <div class="dropdown is-right" id="arc-actions-dropdown">
                         <div class="dropdown-trigger">
@@ -54,7 +54,7 @@
                                     aria-haspopup="true"
                                     aria-controls="arc-actions-menu"
                                     hx-on:click="document.getElementById('arc-actions-dropdown').classList.toggle('is-active')">
-                                <span>Actions</span>
+                                <span>{% trans "Actions" %}</span>
                                 <span class="icon is-small"><i class="fas fa-angle-down" aria-hidden="true"></i></span>
                             </button>
                         </div>
@@ -63,19 +63,19 @@
                                 <a class="dropdown-item"
                                    href="{% url 'arc:update' arc.slug %}">
                                     <span class="icon is-small"><i class="fas fa-edit" aria-hidden="true"></i></span>
-                                    <span>Edit</span>
+                                    <span>{% trans "Edit" %}</span>
                                 </a>
                                 <a class="dropdown-item"
                                    href="{% url 'arc:history' arc.slug %}">
                                     <span class="icon is-small"><i class="fas fa-history" aria-hidden="true"></i></span>
-                                    <span>History</span>
+                                    <span>{% trans "History" %}</span>
                                 </a>
                                 {% if perms.comicsdb.delete_arc %}
                                     <hr class="dropdown-divider">
                                     <a class="dropdown-item has-text-danger"
                                        href="{% url 'arc:delete' arc.slug %}">
                                         <span class="icon is-small"><i class="fas fa-trash" aria-hidden="true"></i></span>
-                                        <span>Delete</span>
+                                        <span>{% trans "Delete" %}</span>
                                     </a>
                                 {% endif %}
                             </div>
@@ -109,7 +109,7 @@
                         {% endthumbnail %}
                     {% else %}
                         <img src="{% static 'site/img/image-not-found.webp' %}"
-                             alt="No image for {{ arc.name }}"
+                             alt="{% blocktrans %}No image for {{ arc.name }}{% endblocktrans %}"
                              loading="lazy">
                     {% endif %}
                 </figure>
@@ -119,21 +119,21 @@
         <div class="column">
             {# Summary #}
             <div class="box">
-                <h2 class="title is-5">Summary</h2>
+                <h2 class="title is-5">{% trans "Summary" %}</h2>
                 {% if arc.desc %}
                     <div class="content">{{ arc.desc|linebreaksbr }}</div>
                 {% else %}
-                    <p class="has-text-grey">No information available.</p>
+                    <p class="has-text-grey">{% trans "No information available." %}</p>
                 {% endif %}
                 <footer class="content is-small is-italic mt-4">
-                    Last edited on <time datetime="{{ arc.modified|date:'c' }}">{{ arc.modified }}</time> by
+                    {% blocktrans with modified_time=arc.modified %}Last edited on <time datetime="{{ modified_time|date:'c' }}">{{ modified_time }}</time> by{% endblocktrans %}
                     <a href="{% url 'user-detail' username=arc.edited_by.username %}">{{ arc.edited_by.username }}</a>
                 </footer>
             </div>
             {# Issues List #}
             {% if issue_count > 0 %}
                 <div class="box">
-                    <h2 class="title is-5">Issues ({{ issue_count }})</h2>
+                    <h2 class="title is-5">{% blocktrans %}Issues ({{ issue_count }}){% endblocktrans %}</h2>
                     <div class="content">
                         <ul id="issues-list">
                             {% for issue in issues %}
@@ -150,7 +150,7 @@
                                         hx-target="#issues-list"
                                         hx-swap="beforeend"
                                         hx-indicator="#issues-spinner">
-                                    <span>Load More Issues</span>
+                                    <span>{% trans "Load More Issues" %}</span>
                                 </button>
                                 <span id="issues-spinner" class="htmx-indicator ml-2">
                                     <i class="fas fa-spinner fa-spin"></i>
@@ -170,9 +170,9 @@
         {# Metadata Sidebar #}
         <div class="column is-one-fifth">
             <div class="box">
-                <h2 class="title is-6">Story Arc Details</h2>
+                <h2 class="title is-6">{% trans "Story Arc Details" %}</h2>
                 <dl>
-                    <dt class="has-text-weight-bold">Number of Issues:</dt>
+                    <dt class="has-text-weight-bold">{% trans "Number of Issues:" %}</dt>
                     <dd class="mb-3">
                         {{ arc.issue_count }}
                     </dd>
@@ -180,21 +180,21 @@
             </div>
             {# Identification Numbers #}
             <div class="box">
-                <h2 class="title is-6">Identification Numbers</h2>
+                <h2 class="title is-6">{% trans "Identification Numbers" %}</h2>
                 <dl>
-                    <dt class="has-text-weight-bold">Metron:</dt>
+                    <dt class="has-text-weight-bold">{% trans "Metron:" %}</dt>
                     <dd class="mb-2 is-flex is-align-items-center is-justify-content-space-between">
                         <span class="is-family-monospace">{{ arc.id }}</span>
                         <button type="button"
                                 class="button is-small is-light copy-id"
                                 data-copy="{{ arc.id }}"
-                                title="Copy Metron ID"
-                                aria-label="Copy Metron ID">
+                                title="{% trans 'Copy Metron ID' %}"
+                                aria-label="{% trans 'Copy Metron ID' %}">
                             <span class="icon is-small"><i class="fas fa-copy"></i></span>
                         </button>
                     </dd>
                     {% if arc.cv_id %}
-                        <dt class="has-text-weight-bold">Comic Vine:</dt>
+                        <dt class="has-text-weight-bold">{% trans "Comic Vine:" %}</dt>
                         <dd class="mb-2 is-flex is-align-items-center is-justify-content-space-between">
                             <a class="is-family-monospace"
                                href="https://comicvine.gamespot.com/story-arc/4045-{{ arc.cv_id }}/"
@@ -206,15 +206,15 @@
                             <button type="button"
                                     class="button is-small is-light copy-id"
                                     data-copy="{{ arc.cv_id }}"
-                                    title="Copy Comic Vine ID"
-                                    aria-label="Copy Comic Vine ID">
+                                    title="{% trans 'Copy Comic Vine ID' %}"
+                                    aria-label="{% trans 'Copy Comic Vine ID' %}">
                                 <span class="icon is-small"><i class="fas fa-copy"></i></span>
                             </button>
                         </dd>
                     {% endif %}
                     {% if arc.gcd_id %}
                         <dt class="has-text-weight-bold">
-                            <abbr title="Grand Comics Database">GCD</abbr>:
+                            <abbr title="{% trans 'Grand Comics Database' %}">GCD</abbr>:
                         </dt>
                         <dd class="is-flex is-align-items-center is-justify-content-space-between">
                             <a class="is-family-monospace"
@@ -227,8 +227,8 @@
                             <button type="button"
                                     class="button is-small is-light copy-id"
                                     data-copy="{{ arc.gcd_id }}"
-                                    title="Copy GCD ID"
-                                    aria-label="Copy GCD ID">
+                                    title="{% trans 'Copy GCD ID' %}"
+                                    aria-label="{% trans 'Copy GCD ID' %}">
                                 <span class="icon is-small"><i class="fas fa-copy"></i></span>
                             </button>
                         </dd>

--- a/comicsdb/templates/comicsdb/arc_list.html
+++ b/comicsdb/templates/comicsdb/arc_list.html
@@ -1,17 +1,23 @@
 {% extends parent_template|default:"base.html" %}
-{% load static %}
-{% block title %}Story Arcs - Metron{% endblock %}
+{% load i18n static %}
+{% block title %}{% trans "Story Arcs - Metron" %}{% endblock %}
 {% block content %}
     <header class="block has-text-centered">
-        <h1 class="title">Story Arcs List</h1>
+        <h1 class="title">{% trans "Story Arcs List" %}</h1>
     </header>
+    {% trans "Story Arc" as list_title %}
+    {% trans "Story Arcs" as list_title_plural %}
+    {% trans "Find an arc" as list_search_placeholder %}
+    {% trans "Issue" as issue_label %}
+    {% trans "Issues" as issue_label_plural %}
+    {% trans "Add a new story arc" as list_create_title %}
     {% if arc_list %}
         <section>
-            {% include "comicsdb/partials/list_header.html" with title="Story Arc" count=page_obj.paginator.count search_url="arc:search" search_placeholder="Find an arc" create_url="arc:create" create_title="Add a new story arc" %}
-            {% include "comicsdb/partials/card_grid.html" with items=arc_list detail_url_name="arc:detail" image_ratio="is-2by3" default_image="site/img/image-not-found.webp" count_url_name="arc:issue" count_label="Issue" %}
+            {% include "comicsdb/partials/list_header.html" with title=list_title title_plural=list_title_plural count=page_obj.paginator.count search_url="arc:search" search_placeholder=list_search_placeholder create_url="arc:create" create_title=list_create_title %}
+            {% include "comicsdb/partials/card_grid.html" with items=arc_list detail_url_name="arc:detail" image_ratio="is-2by3" default_image="site/img/image-not-found.webp" count_url_name="arc:issue" count_label=issue_label count_label_plural=issue_label_plural %}
         </section>
     {% else %}
-        {% include "comicsdb/partials/empty_state.html" with item_type="Story Arc" create_url="arc:create" create_title="Add a new story arc" %}
+        {% include "comicsdb/partials/empty_state.html" with item_type=list_title item_type_plural=list_title_plural create_url="arc:create" create_title=list_create_title %}
     {% endif %}
 {% endblock %}
 {% block pagination %}

--- a/comicsdb/templates/comicsdb/attribution.html
+++ b/comicsdb/templates/comicsdb/attribution.html
@@ -1,59 +1,35 @@
+{% load i18n %}
 {% comment %}
     Displays attribution information for various data sources
     Usage: {% include "comicsdb/attribution.html" with object=attributions %}
 {% endcomment %}
 {% if object %}
     <div class="box">
-        <h2 class="title is-5">Attribution</h2>
+        <h2 class="title is-5">{% trans "Attribution" %}</h2>
         <div class="content">
             {% for attribution in object %}
                 {% if attribution.source == "W" %}
                     <p>
-                        This article uses material from
-                        <a href="{{ attribution.url }}"
-                           target="_blank"
-                           rel="noopener noreferrer">Wikipedia</a>,
-                        which is released under the
-                        <a href="https://creativecommons.org/licenses/by-sa/3.0/"
-                           target="_blank"
-                           rel="noopener noreferrer">Creative Commons Attribution-Share-Alike License 3.0</a>.
+                        {% blocktrans with url=attribution.url %}This article uses material from <a href="{{ url }}" target="_blank" rel="noopener noreferrer">Wikipedia</a>, which is released under the <a href="https://creativecommons.org/licenses/by-sa/3.0/" target="_blank" rel="noopener noreferrer">Creative Commons Attribution-Share-Alike License 3.0</a>.{% endblocktrans %}
                     </p>
                 {% elif attribution.source == "M" %}
                     <p>
-                        Some data provided by
-                        <a href="{{ attribution.url }}"
-                           target="_blank"
-                           rel="noopener noreferrer">Marvel</a>.
+                        {% blocktrans with url=attribution.url %}Some data provided by <a href="{{ url }}" target="_blank" rel="noopener noreferrer">Marvel</a>.{% endblocktrans %}
                         &copy; 2014 Marvel
                     </p>
                 {% elif attribution.source == "G" %}
                     <p>
-                        This article uses material from the
-                        <a href="{{ attribution.url }}"
-                           target="_blank"
-                           rel="noopener noreferrer">Grand Comics Database&#8482;</a>,
-                        which is released under the
-                        <a href="https://creativecommons.org/licenses/by-sa/4.0/"
-                           target="_blank"
-                           rel="noopener noreferrer">
-                            Creative Commons Attribution-ShareAlike 4.0 International License (CC BY-SA 4.0)
-                        </a>.
+                        {% blocktrans with url=attribution.url %}This article uses material from the <a href="{{ url }}" target="_blank" rel="noopener noreferrer">Grand Comics Database&#8482;</a>, which is released under the <a href="https://creativecommons.org/licenses/by-sa/4.0/" target="_blank" rel="noopener noreferrer">Creative Commons Attribution-ShareAlike 4.0 International License (CC BY-SA 4.0)</a>.{% endblocktrans %}
                     </p>
                 {% elif attribution.source == "D" %}
                     <p>
-                        Some data provided by
-                        <a href="{{ attribution.url }}"
-                           target="_blank"
-                           rel="noopener noreferrer">DC</a>.
+                        {% blocktrans with url=attribution.url %}Some data provided by <a href="{{ url }}" target="_blank" rel="noopener noreferrer">DC</a>.{% endblocktrans %}
                         &copy; &amp; &trade; DC
                     </p>
                 {% else %}
                     {# Fallback for unknown source types #}
                     <p>
-                        Data provided by
-                        <a href="{{ attribution.url }}"
-                           target="_blank"
-                           rel="noopener noreferrer">external source</a>.
+                        {% blocktrans with url=attribution.url %}Data provided by <a href="{{ url }}" target="_blank" rel="noopener noreferrer">external source</a>.{% endblocktrans %}
                     </p>
                 {% endif %}
             {% endfor %}

--- a/comicsdb/templates/comicsdb/character_detail.html
+++ b/comicsdb/templates/comicsdb/character_detail.html
@@ -1,6 +1,6 @@
 {% extends parent_template|default:"base.html" %}
 {% load thumbnail %}
-{% load static %}
+{% load i18n static %}
 {% load humanize %}
 {% block title %}
     {{ character.name }}
@@ -11,31 +11,31 @@
         <h1 class="title">{{ character }}</h1>
     </header>
     {# Navigation Bar #}
-    <nav class="level mb-5" aria-label="Character navigation">
+    <nav class="level mb-5" aria-label="{% trans 'Character navigation' %}">
         <div class="level-left">
             {% if navigation.previous_character %}
                 <a class="button is-link"
                    href="{% url 'character:detail' navigation.previous_character.slug %}"
-                   aria-label="Go to {{ navigation.previous_character }}">
+                   aria-label="{% blocktrans with previous_character=navigation.previous_character %}Go to {{ previous_character }}{% endblocktrans %}">
                     <span class="icon is-small"><i class="fas fa-arrow-left" aria-hidden="true"></i></span>
-                    <span>Previous Character</span>
+                    <span>{% trans "Previous Character" %}</span>
                 </a>
             {% else %}
                 <button class="button" disabled aria-disabled="true">
                     <span class="icon is-small"><i class="fas fa-arrow-left" aria-hidden="true"></i></span>
-                    <span>Previous Character</span>
+                    <span>{% trans "Previous Character" %}</span>
                 </button>
             {% endif %}
             {% if navigation.next_character %}
                 <a class="button is-link ml-2"
                    href="{% url 'character:detail' navigation.next_character.slug %}"
-                   aria-label="Go to {{ navigation.next_character }}">
-                    <span>Next Character</span>
+                   aria-label="{% blocktrans with next_character=navigation.next_character %}Go to {{ next_character }}{% endblocktrans %}">
+                    <span>{% trans "Next Character" %}</span>
                     <span class="icon is-small"><i class="fas fa-arrow-right" aria-hidden="true"></i></span>
                 </a>
             {% else %}
                 <button class="button ml-2" disabled aria-disabled="true">
-                    <span>Next Character</span>
+                    <span>{% trans "Next Character" %}</span>
                     <span class="icon is-small"><i class="fas fa-arrow-right" aria-hidden="true"></i></span>
                 </button>
             {% endif %}
@@ -45,9 +45,9 @@
                 <div class="buttons">
                     <a class="button is-primary"
                        href="{% url 'character:create' %}"
-                       title="Add a new character">
+                       title="{% trans 'Add a new character' %}">
                         <span class="icon is-small"><i class="fas fa-plus" aria-hidden="true"></i></span>
-                        <span>New</span>
+                        <span>{% trans "New" %}</span>
                     </a>
                     <div class="dropdown is-right" id="character-actions-dropdown">
                         <div class="dropdown-trigger">
@@ -55,7 +55,7 @@
                                     aria-haspopup="true"
                                     aria-controls="character-actions-menu"
                                     hx-on:click="document.getElementById('character-actions-dropdown').classList.toggle('is-active')">
-                                <span>Actions</span>
+                                <span>{% trans "Actions" %}</span>
                                 <span class="icon is-small"><i class="fas fa-angle-down" aria-hidden="true"></i></span>
                             </button>
                         </div>
@@ -64,19 +64,19 @@
                                 <a class="dropdown-item"
                                    href="{% url 'character:update' character.slug %}">
                                     <span class="icon is-small"><i class="fas fa-edit" aria-hidden="true"></i></span>
-                                    <span>Edit</span>
+                                    <span>{% trans "Edit" %}</span>
                                 </a>
                                 <a class="dropdown-item"
                                    href="{% url 'character:history' character.slug %}">
                                     <span class="icon is-small"><i class="fas fa-history" aria-hidden="true"></i></span>
-                                    <span>History</span>
+                                    <span>{% trans "History" %}</span>
                                 </a>
                                 {% if perms.comicsdb.delete_character %}
                                     <hr class="dropdown-divider">
                                     <a class="dropdown-item has-text-danger"
                                        href="{% url 'character:delete' character.slug %}">
                                         <span class="icon is-small"><i class="fas fa-trash" aria-hidden="true"></i></span>
-                                        <span>Delete</span>
+                                        <span>{% trans "Delete" %}</span>
                                     </a>
                                 {% endif %}
                             </div>
@@ -110,7 +110,7 @@
                         {% endthumbnail %}
                     {% else %}
                         <img src="{% static 'site/img/image-not-found.webp' %}"
-                             alt="No image for {{ character.name }}"
+                             alt="{% blocktrans %}No image for {{ character.name }}{% endblocktrans %}"
                              loading="lazy">
                     {% endif %}
                 </figure>
@@ -120,21 +120,21 @@
         <div class="column">
             {# Summary #}
             <div class="box">
-                <h2 class="title is-5">Summary</h2>
+                <h2 class="title is-5">{% trans "Summary" %}</h2>
                 {% if character.desc %}
                     <div class="content">{{ character.desc|linebreaksbr }}</div>
                 {% else %}
-                    <p class="has-text-grey">No information available.</p>
+                    <p class="has-text-grey">{% trans "No information available." %}</p>
                 {% endif %}
                 <footer class="content is-small is-italic mt-4">
-                    Last edited on <time datetime="{{ character.modified|date:'c' }}">{{ character.modified }}</time> by
+                    {% blocktrans with modified_time=character.modified %}Last edited on <time datetime="{{ modified_time|date:'c' }}">{{ modified_time }}</time> by{% endblocktrans %}
                     <a href="{% url 'user-detail' username=character.edited_by.username %}">{{ character.edited_by.username }}</a>
                 </footer>
             </div>
             {# Series Appearances #}
             {% if appearances %}
                 <div class="box">
-                    <h2 class="title is-5">Series Appearances ({{ series_count }})</h2>
+                    <h2 class="title is-5">{% blocktrans %}Series Appearances ({{ series_count }}){% endblocktrans %}</h2>
                     <div class="content">
                         <ul id="series-list">
                             {% for series in appearances %}
@@ -148,12 +148,12 @@
                                         {% elif series.issues__series__series_type == 8 %}
                                             HC
                                         {% elif series.issues__series__series_type == 12 %}
-                                            Digital
+                                            {% trans "Digital" %}
                                         {% endif %}
                                         ({{ series.issues__series__year_began }})
                                     </a>:
                                     <a href="{% url 'character:series' character=character.slug series=series.issues__series__slug %}">
-                                        {{ series.issues__count }} issue{{ series.issues__count|pluralize }}
+                                        {% blocktrans count counter=series.issues__count %}{{ counter }} issue{% plural %}{{ counter }} issues{% endblocktrans %}
                                     </a>
                                 </li>
                             {% endfor %}
@@ -165,7 +165,7 @@
                                         hx-target="#series-list"
                                         hx-swap="beforeend"
                                         hx-indicator="#series-spinner">
-                                    <span>Load More Series</span>
+                                    <span>{% trans "Load More Series" %}</span>
                                 </button>
                                 <span id="series-spinner" class="htmx-indicator ml-2">
                                     <i class="fas fa-spinner fa-spin"></i>
@@ -185,22 +185,28 @@
         {# Metadata Sidebar #}
         <div class="column is-one-fifth">
             <div class="box">
-                <h2 class="title is-6">Character Details</h2>
+                <h2 class="title is-6">{% trans "Character Details" %}</h2>
                 <dl>
-                    <dt class="has-text-weight-bold">Number of Issues:</dt>
+                    <dt class="has-text-weight-bold">{% trans "Number of Issues:" %}</dt>
                     <dd class="mb-3">
                         {{ character.issue_count|intcomma }}
                     </dd>
                     {% if character.issue_count > 0 %}
                         {% with first=character.first_appearance %}
-                            <dt class="has-text-weight-bold">First Appearance:</dt>
+                            <dt class="has-text-weight-bold">{% trans "First Appearance:" %}</dt>
                             <dd class="mb-3">
                                 <a href="{% url 'issue:detail' first.slug %}">{{ first }}</a>
                             </dd>
                         {% endwith %}
                     {% endif %}
                     {% if character.alias %}
-                        <dt class="has-text-weight-bold">Alias{{ character.alias|pluralize:"es" }}:</dt>
+                        <dt class="has-text-weight-bold">
+                            {% if character.alias|length > 1 %}
+                                {% trans "Aliases:" %}
+                            {% else %}
+                                {% trans "Alias:" %}
+                            {% endif %}
+                        </dt>
                         <dd class="mb-3">
                             {{ character.alias|join:", " }}
                         </dd>
@@ -209,7 +215,13 @@
                 {# Creators #}
                 {% with creators=character.creators.all %}
                     {% if creators %}
-                        <h3 class="title is-6 mt-4">Creator{{ creators|pluralize }}</h3>
+                        <h3 class="title is-6 mt-4">
+                            {% if creators|length > 1 %}
+                                {% trans "Creators" %}
+                            {% else %}
+                                {% trans "Creator" %}
+                            {% endif %}
+                        </h3>
                         <ul class="menu-list">
                             {% for creator in creators %}
                                 <li>
@@ -222,7 +234,13 @@
                 {# Teams #}
                 {% with teams=character.teams.all %}
                     {% if teams %}
-                        <h3 class="title is-6 mt-4">Team{{ teams|pluralize }}</h3>
+                        <h3 class="title is-6 mt-4">
+                            {% if teams|length > 1 %}
+                                {% trans "Teams" %}
+                            {% else %}
+                                {% trans "Team" %}
+                            {% endif %}
+                        </h3>
                         <ul class="menu-list">
                             {% for team in teams %}
                                 <li>
@@ -235,7 +253,13 @@
                 {# Universes #}
                 {% with universes=character.universes.all %}
                     {% if universes %}
-                        <h3 class="title is-6 mt-4">Universe{{ universes|pluralize }}</h3>
+                        <h3 class="title is-6 mt-4">
+                            {% if universes|length > 1 %}
+                                {% trans "Universes" %}
+                            {% else %}
+                                {% trans "Universe" %}
+                            {% endif %}
+                        </h3>
                         <ul class="menu-list">
                             {% for universe in universes %}
                                 <li>
@@ -248,21 +272,21 @@
             </div>
             {# Identification Numbers #}
             <div class="box">
-                <h2 class="title is-6">Identification Numbers</h2>
+                <h2 class="title is-6">{% trans "Identification Numbers" %}</h2>
                 <dl>
-                    <dt class="has-text-weight-bold">Metron:</dt>
+                    <dt class="has-text-weight-bold">{% trans "Metron:" %}</dt>
                     <dd class="mb-2 is-flex is-align-items-center is-justify-content-space-between">
                         <span class="is-family-monospace">{{ character.id }}</span>
                         <button type="button"
                                 class="button is-small is-light copy-id"
                                 data-copy="{{ character.id }}"
-                                title="Copy Metron ID"
-                                aria-label="Copy Metron ID">
+                                title="{% trans 'Copy Metron ID' %}"
+                                aria-label="{% trans 'Copy Metron ID' %}">
                             <span class="icon is-small"><i class="fas fa-copy"></i></span>
                         </button>
                     </dd>
                     {% if character.cv_id %}
-                        <dt class="has-text-weight-bold">Comic Vine:</dt>
+                        <dt class="has-text-weight-bold">{% trans "Comic Vine:" %}</dt>
                         <dd class="mb-2 is-flex is-align-items-center is-justify-content-space-between">
                             <a class="is-family-monospace"
                                href="https://comicvine.gamespot.com/character/4005-{{ character.cv_id }}/"
@@ -274,15 +298,15 @@
                             <button type="button"
                                     class="button is-small is-light copy-id"
                                     data-copy="{{ character.cv_id }}"
-                                    title="Copy Comic Vine ID"
-                                    aria-label="Copy Comic Vine ID">
+                                    title="{% trans 'Copy Comic Vine ID' %}"
+                                    aria-label="{% trans 'Copy Comic Vine ID' %}">
                                 <span class="icon is-small"><i class="fas fa-copy"></i></span>
                             </button>
                         </dd>
                     {% endif %}
                     {% if character.gcd_id %}
                         <dt class="has-text-weight-bold">
-                            <abbr title="Grand Comics Database">GCD</abbr>:
+                            <abbr title="{% trans 'Grand Comics Database' %}">GCD</abbr>:
                         </dt>
                         <dd class="is-flex is-align-items-center is-justify-content-space-between">
                             <a class="is-family-monospace"
@@ -295,8 +319,8 @@
                             <button type="button"
                                     class="button is-small is-light copy-id"
                                     data-copy="{{ character.gcd_id }}"
-                                    title="Copy GCD ID"
-                                    aria-label="Copy GCD ID">
+                                    title="{% trans 'Copy GCD ID' %}"
+                                    aria-label="{% trans 'Copy GCD ID' %}">
                                 <span class="icon is-small"><i class="fas fa-copy"></i></span>
                             </button>
                         </dd>

--- a/comicsdb/templates/comicsdb/character_list.html
+++ b/comicsdb/templates/comicsdb/character_list.html
@@ -1,17 +1,23 @@
 {% extends parent_template|default:"base.html" %}
-{% load static %}
-{% block title %}Characters - Metron{% endblock %}
+{% load i18n static %}
+{% block title %}{% trans "Characters - Metron" %}{% endblock %}
 {% block content %}
     <header class="block has-text-centered">
-        <h1 class="title">Characters List</h1>
+        <h1 class="title">{% trans "Characters List" %}</h1>
     </header>
+    {% trans "Character" as list_title %}
+    {% trans "Characters" as list_title_plural %}
+    {% trans "Find a character" as list_search_placeholder %}
+    {% trans "Issue" as issue_label %}
+    {% trans "Issues" as issue_label_plural %}
+    {% trans "Add a new character" as list_create_title %}
     {% if character_list %}
         <section>
-            {% include "comicsdb/partials/list_header.html" with title="Character" count=page_obj.paginator.count search_url="character:search" search_placeholder="Find a character" create_url="character:create" create_title="Add a new character" %}
-            {% include "comicsdb/partials/card_grid.html" with items=character_list detail_url_name="character:detail" image_ratio="is-2by3" default_image="site/img/image-not-found.webp" count_type="issue" count_url_name="character:issue" count_label="Issue" %}
+            {% include "comicsdb/partials/list_header.html" with title=list_title title_plural=list_title_plural count=page_obj.paginator.count search_url="character:search" search_placeholder=list_search_placeholder create_url="character:create" create_title=list_create_title %}
+            {% include "comicsdb/partials/card_grid.html" with items=character_list detail_url_name="character:detail" image_ratio="is-2by3" default_image="site/img/image-not-found.webp" count_type="issue" count_url_name="character:issue" count_label=issue_label count_label_plural=issue_label_plural %}
         </section>
     {% else %}
-        {% include "comicsdb/partials/empty_state.html" with item_type="Character" create_url="character:create" create_title="Add a new character" %}
+        {% include "comicsdb/partials/empty_state.html" with item_type=list_title item_type_plural=list_title_plural create_url="character:create" create_title=list_create_title %}
     {% endif %}
 {% endblock %}
 {% block pagination %}

--- a/comicsdb/templates/comicsdb/confirm_delete.html
+++ b/comicsdb/templates/comicsdb/confirm_delete.html
@@ -1,6 +1,7 @@
 {% extends parent_template|default:"base.html" %}
+{% load i18n %}
 {% block title %}
-    Confirm Deletion
+    {% trans "Confirm Deletion" %}
 {% endblock title %}
 {% block content %}
     {# Page Header #}
@@ -10,7 +11,7 @@
                 <i class="fas fa-exclamation-triangle fa-2x"></i>
             </span>
         </h1>
-        <h2 class="title is-3">Confirm Deletion</h2>
+        <h2 class="title is-3">{% trans "Confirm Deletion" %}</h2>
     </header>
     {# Confirmation Content #}
     <div class="columns is-centered">
@@ -18,13 +19,13 @@
             <div class="box">
                 <article class="message is-danger">
                     <div class="message-header">
-                        <p>Warning: This action cannot be undone</p>
+                        <p>{% trans "Warning: This action cannot be undone" %}</p>
                     </div>
                     <div class="message-body">
                         <p class="mb-4">
-                            Are you sure you want to permanently delete <strong>"{{ object }}"</strong>?
+                            {% blocktrans %}Are you sure you want to permanently delete <strong>"{{ object }}"</strong>?{% endblocktrans %}
                         </p>
-                        <p class="has-text-grey">This will remove all associated data and cannot be recovered.</p>
+                        <p class="has-text-grey">{% trans "This will remove all associated data and cannot be recovered." %}</p>
                     </div>
                 </article>
                 <form method="post" class="mt-5">
@@ -35,17 +36,17 @@
                                 <span class="icon">
                                     <i class="fas fa-trash" aria-hidden="true"></i>
                                 </span>
-                                <span>Yes, Delete</span>
+                                <span>{% trans "Yes, Delete" %}</span>
                             </button>
                         </div>
                         <div class="control">
                             <a class="button is-light is-medium"
                                href="{{ object.get_absolute_url }}"
-                               title="Cancel and return">
+                               title="{% trans 'Cancel and return' %}">
                                 <span class="icon">
                                     <i class="fas fa-times" aria-hidden="true"></i>
                                 </span>
-                                <span>Cancel</span>
+                                <span>{% trans "Cancel" %}</span>
                             </a>
                         </div>
                     </div>
@@ -53,11 +54,11 @@
             </div>
             {# Additional Information #}
             <div class="notification is-warning is-light">
-                <p class="has-text-weight-bold mb-2">Before you delete:</p>
+                <p class="has-text-weight-bold mb-2">{% trans "Before you delete:" %}</p>
                 <ul>
-                    <li>Make sure this is the correct item to delete</li>
-                    <li>Consider if other records depend on this data</li>
-                    <li>This action is permanent and irreversible</li>
+                    <li>{% trans "Make sure this is the correct item to delete" %}</li>
+                    <li>{% trans "Consider if other records depend on this data" %}</li>
+                    <li>{% trans "This action is permanent and irreversible" %}</li>
                 </ul>
             </div>
         </div>

--- a/comicsdb/templates/comicsdb/creator_detail.html
+++ b/comicsdb/templates/comicsdb/creator_detail.html
@@ -1,6 +1,6 @@
 {% extends parent_template|default:"base.html" %}
 {% load thumbnail %}
-{% load static %}
+{% load i18n static %}
 {% load humanize %}
 {% block title %}
     {{ creator.name }}
@@ -11,31 +11,31 @@
         <h1 class="title">{{ creator.name }}</h1>
     </header>
     {# Navigation Bar #}
-    <nav class="level mb-5" aria-label="Creator navigation">
+    <nav class="level mb-5" aria-label="{% trans 'Creator navigation' %}">
         <div class="level-left">
             {% if navigation.previous_creator %}
                 <a class="button is-link"
                    href="{% url 'creator:detail' navigation.previous_creator.slug %}"
-                   aria-label="Go to {{ navigation.previous_creator }}">
+                   aria-label="{% blocktrans with previous_creator=navigation.previous_creator %}Go to {{ previous_creator }}{% endblocktrans %}">
                     <span class="icon is-small"><i class="fas fa-arrow-left" aria-hidden="true"></i></span>
-                    <span>Previous Creator</span>
+                    <span>{% trans "Previous Creator" %}</span>
                 </a>
             {% else %}
                 <button class="button" disabled aria-disabled="true">
                     <span class="icon is-small"><i class="fas fa-arrow-left" aria-hidden="true"></i></span>
-                    <span>Previous Creator</span>
+                    <span>{% trans "Previous Creator" %}</span>
                 </button>
             {% endif %}
             {% if navigation.next_creator %}
                 <a class="button is-link ml-2"
                    href="{% url 'creator:detail' navigation.next_creator.slug %}"
-                   aria-label="Go to {{ navigation.next_creator }}">
-                    <span>Next Creator</span>
+                   aria-label="{% blocktrans with next_creator=navigation.next_creator %}Go to {{ next_creator }}{% endblocktrans %}">
+                    <span>{% trans "Next Creator" %}</span>
                     <span class="icon is-small"><i class="fas fa-arrow-right" aria-hidden="true"></i></span>
                 </a>
             {% else %}
                 <button class="button ml-2" disabled aria-disabled="true">
-                    <span>Next Creator</span>
+                    <span>{% trans "Next Creator" %}</span>
                     <span class="icon is-small"><i class="fas fa-arrow-right" aria-hidden="true"></i></span>
                 </button>
             {% endif %}
@@ -45,9 +45,9 @@
                 <div class="buttons">
                     <a class="button is-primary"
                        href="{% url 'creator:create' %}"
-                       title="Add a new creator">
+                       title="{% trans 'Add a new creator' %}">
                         <span class="icon is-small"><i class="fas fa-plus" aria-hidden="true"></i></span>
-                        <span>New</span>
+                        <span>{% trans "New" %}</span>
                     </a>
                     <div class="dropdown is-right" id="creator-actions-dropdown">
                         <div class="dropdown-trigger">
@@ -55,7 +55,7 @@
                                     aria-haspopup="true"
                                     aria-controls="creator-actions-menu"
                                     hx-on:click="document.getElementById('creator-actions-dropdown').classList.toggle('is-active')">
-                                <span>Actions</span>
+                                <span>{% trans "Actions" %}</span>
                                 <span class="icon is-small"><i class="fas fa-angle-down" aria-hidden="true"></i></span>
                             </button>
                         </div>
@@ -64,19 +64,19 @@
                                 <a class="dropdown-item"
                                    href="{% url 'creator:update' creator.slug %}">
                                     <span class="icon is-small"><i class="fas fa-edit" aria-hidden="true"></i></span>
-                                    <span>Edit</span>
+                                    <span>{% trans "Edit" %}</span>
                                 </a>
                                 <a class="dropdown-item"
                                    href="{% url 'creator:history' creator.slug %}">
                                     <span class="icon is-small"><i class="fas fa-history" aria-hidden="true"></i></span>
-                                    <span>History</span>
+                                    <span>{% trans "History" %}</span>
                                 </a>
                                 {% if perms.comicsdb.delete_creator %}
                                     <hr class="dropdown-divider">
                                     <a class="dropdown-item has-text-danger"
                                        href="{% url 'creator:delete' creator.slug %}">
                                         <span class="icon is-small"><i class="fas fa-trash" aria-hidden="true"></i></span>
-                                        <span>Delete</span>
+                                        <span>{% trans "Delete" %}</span>
                                     </a>
                                 {% endif %}
                             </div>
@@ -110,7 +110,7 @@
                         {% endthumbnail %}
                     {% else %}
                         <img src="{% static 'site/img/creator-not-found.webp' %}"
-                             alt="No image for {{ creator.name }}"
+                             alt="{% blocktrans %}No image for {{ creator.name }}{% endblocktrans %}"
                              loading="lazy">
                     {% endif %}
                 </figure>
@@ -120,21 +120,21 @@
         <div class="column">
             {# Summary #}
             <div class="box">
-                <h2 class="title is-5">Summary</h2>
+                <h2 class="title is-5">{% trans "Summary" %}</h2>
                 {% if creator.desc %}
                     <div class="content">{{ creator.desc|linebreaksbr }}</div>
                 {% else %}
-                    <p class="has-text-grey">No information available.</p>
+                    <p class="has-text-grey">{% trans "No information available." %}</p>
                 {% endif %}
                 <footer class="content is-small is-italic mt-4">
-                    Last edited on <time datetime="{{ creator.modified|date:'c' }}">{{ creator.modified }}</time> by
+                    {% blocktrans with modified_time=creator.modified %}Last edited on <time datetime="{{ modified_time|date:'c' }}">{{ modified_time }}</time> by{% endblocktrans %}
                     <a href="{% url 'user-detail' username=creator.edited_by.username %}">{{ creator.edited_by.username }}</a>
                 </footer>
             </div>
             {# Series Credits #}
             {% if credits %}
                 <div class="box">
-                    <h2 class="title is-5">Series ({{ series_count }})</h2>
+                    <h2 class="title is-5">{% blocktrans %}Series ({{ series_count }}){% endblocktrans %}</h2>
                     <div class="content">
                         <ul id="series-list">
                             {% for series in credits %}
@@ -148,12 +148,12 @@
                                         {% elif series.issue__series__series_type == 8 %}
                                             HC
                                         {% elif series.issue__series__series_type == 12 %}
-                                            Digital
+                                            {% trans "Digital" %}
                                         {% endif %}
                                         ({{ series.issue__series__year_began }})
                                     </a>:
                                     <a href="{% url 'creator:series' creator=creator.slug series=series.issue__series__slug %}">
-                                        {{ series.issue__count }} issue{{ series.issue__count|pluralize }}
+                                        {% blocktrans count counter=series.issue__count %}{{ counter }} issue{% plural %}{{ counter }} issues{% endblocktrans %}
                                     </a>
                                 </li>
                             {% endfor %}
@@ -165,7 +165,7 @@
                                         hx-target="#series-list"
                                         hx-swap="beforeend"
                                         hx-indicator="#series-spinner">
-                                    <span>Load More Series</span>
+                                    <span>{% trans "Load More Series" %}</span>
                                 </button>
                                 <span id="series-spinner" class="htmx-indicator ml-2">
                                     <i class="fas fa-spinner fa-spin"></i>
@@ -185,26 +185,32 @@
         {# Metadata Sidebar #}
         <div class="column is-one-fifth">
             <div class="box">
-                <h2 class="title is-6">Creator Details</h2>
+                <h2 class="title is-6">{% trans "Creator Details" %}</h2>
                 <dl>
                     {% if creator.birth %}
-                        <dt class="has-text-weight-bold">Birth:</dt>
+                        <dt class="has-text-weight-bold">{% trans "Birth:" %}</dt>
                         <dd class="mb-3">
                             <time datetime="{{ creator.birth|date:'Y-m-d' }}">{{ creator.birth|date:"SHORT_DATE_FORMAT" }}</time>
                         </dd>
                     {% endif %}
                     {% if creator.death %}
-                        <dt class="has-text-weight-bold">Death:</dt>
+                        <dt class="has-text-weight-bold">{% trans "Death:" %}</dt>
                         <dd class="mb-3">
                             <time datetime="{{ creator.death|date:'Y-m-d' }}">{{ creator.death|date:"SHORT_DATE_FORMAT" }}</time>
                         </dd>
                     {% endif %}
-                    <dt class="has-text-weight-bold">Number of Issues:</dt>
+                    <dt class="has-text-weight-bold">{% trans "Number of Issues:" %}</dt>
                     <dd class="mb-3">
                         {{ creator.issue_count|intcomma }}
                     </dd>
                     {% if creator.alias %}
-                        <dt class="has-text-weight-bold">Alias{{ creator.alias|pluralize:"es" }}:</dt>
+                        <dt class="has-text-weight-bold">
+                            {% if creator.alias|length > 1 %}
+                                {% trans "Aliases:" %}
+                            {% else %}
+                                {% trans "Alias:" %}
+                            {% endif %}
+                        </dt>
                         <dd class="mb-3">
                             {{ creator.alias|join:", " }}
                         </dd>
@@ -213,21 +219,21 @@
             </div>
             {# Identification Numbers #}
             <div class="box">
-                <h2 class="title is-6">Identification Numbers</h2>
+                <h2 class="title is-6">{% trans "Identification Numbers" %}</h2>
                 <dl>
-                    <dt class="has-text-weight-bold">Metron:</dt>
+                    <dt class="has-text-weight-bold">{% trans "Metron:" %}</dt>
                     <dd class="mb-2 is-flex is-align-items-center is-justify-content-space-between">
                         <span class="is-family-monospace">{{ creator.id }}</span>
                         <button type="button"
                                 class="button is-small is-light copy-id"
                                 data-copy="{{ creator.id }}"
-                                title="Copy Metron ID"
-                                aria-label="Copy Metron ID">
+                                title="{% trans 'Copy Metron ID' %}"
+                                aria-label="{% trans 'Copy Metron ID' %}">
                             <span class="icon is-small"><i class="fas fa-copy"></i></span>
                         </button>
                     </dd>
                     {% if creator.cv_id %}
-                        <dt class="has-text-weight-bold">Comic Vine:</dt>
+                        <dt class="has-text-weight-bold">{% trans "Comic Vine:" %}</dt>
                         <dd class="mb-2 is-flex is-align-items-center is-justify-content-space-between">
                             <a class="is-family-monospace"
                                href="https://comicvine.gamespot.com/person/4040-{{ creator.cv_id }}/"
@@ -239,15 +245,15 @@
                             <button type="button"
                                     class="button is-small is-light copy-id"
                                     data-copy="{{ creator.cv_id }}"
-                                    title="Copy Comic Vine ID"
-                                    aria-label="Copy Comic Vine ID">
+                                    title="{% trans 'Copy Comic Vine ID' %}"
+                                    aria-label="{% trans 'Copy Comic Vine ID' %}">
                                 <span class="icon is-small"><i class="fas fa-copy"></i></span>
                             </button>
                         </dd>
                     {% endif %}
                     {% if creator.gcd_id %}
                         <dt class="has-text-weight-bold">
-                            <abbr title="Grand Comics Database">GCD</abbr>:
+                            <abbr title="{% trans 'Grand Comics Database' %}">GCD</abbr>:
                         </dt>
                         <dd class="is-flex is-align-items-center is-justify-content-space-between">
                             <a class="is-family-monospace"
@@ -260,8 +266,8 @@
                             <button type="button"
                                     class="button is-small is-light copy-id"
                                     data-copy="{{ creator.gcd_id }}"
-                                    title="Copy GCD ID"
-                                    aria-label="Copy GCD ID">
+                                    title="{% trans 'Copy GCD ID' %}"
+                                    aria-label="{% trans 'Copy GCD ID' %}">
                                 <span class="icon is-small"><i class="fas fa-copy"></i></span>
                             </button>
                         </dd>

--- a/comicsdb/templates/comicsdb/creator_list.html
+++ b/comicsdb/templates/comicsdb/creator_list.html
@@ -1,17 +1,23 @@
 {% extends parent_template|default:"base.html" %}
-{% load static %}
-{% block title %}Creators - Metron{% endblock %}
+{% load i18n static %}
+{% block title %}{% trans "Creators - Metron" %}{% endblock %}
 {% block content %}
     <header class="block has-text-centered">
-        <h1 class="title">Creators List</h1>
+        <h1 class="title">{% trans "Creators List" %}</h1>
     </header>
+    {% trans "Creator" as list_title %}
+    {% trans "Creators" as list_title_plural %}
+    {% trans "Find a creator" as list_search_placeholder %}
+    {% trans "Issue" as issue_label %}
+    {% trans "Issues" as issue_label_plural %}
+    {% trans "Add a new creator" as list_create_title %}
     {% if creator_list %}
         <section>
-            {% include "comicsdb/partials/list_header.html" with title="Creator" count=page_obj.paginator.count search_url="creator:search" search_placeholder="Find a creator" create_url="creator:create" create_title="Add a new creator" %}
-            {% include "comicsdb/partials/card_grid.html" with items=creator_list detail_url_name="creator:detail" image_ratio="is-square" default_image="site/img/creator-not-found.webp" count_url_name="creator:issue" count_label="Issue" %}
+            {% include "comicsdb/partials/list_header.html" with title=list_title title_plural=list_title_plural count=page_obj.paginator.count search_url="creator:search" search_placeholder=list_search_placeholder create_url="creator:create" create_title=list_create_title %}
+            {% include "comicsdb/partials/card_grid.html" with items=creator_list detail_url_name="creator:detail" image_ratio="is-square" default_image="site/img/creator-not-found.webp" count_url_name="creator:issue" count_label=issue_label count_label_plural=issue_label_plural %}
         </section>
     {% else %}
-        {% include "comicsdb/partials/empty_state.html" with item_type="Creator" create_url="creator:create" create_title="Add a new creator" %}
+        {% include "comicsdb/partials/empty_state.html" with item_type=list_title item_type_plural=list_title_plural create_url="creator:create" create_title=list_create_title %}
     {% endif %}
 {% endblock %}
 {% block pagination %}

--- a/comicsdb/templates/comicsdb/history_list.html
+++ b/comicsdb/templates/comicsdb/history_list.html
@@ -1,12 +1,12 @@
 {% extends parent_template|default:"base.html" %}
-{% load static %}
+{% load i18n static %}
 {% block title %}
-    Edit History - {{ object }}
+    {% blocktrans %}Edit History - {{ object }}{% endblocktrans %}
 {% endblock title %}
 {% block content %}
     {# Page Header #}
     <header class="block">
-        <h1 class="title">Edit History</h1>
+        <h1 class="title">{% trans "Edit History" %}</h1>
         <h2 class="subtitle">
             <a href="{{ object.get_absolute_url }}">{{ object }}</a>
         </h2>
@@ -18,10 +18,10 @@
                 <table class="table is-fullwidth is-hoverable">
                     <thead>
                         <tr>
-                            <th>Date</th>
-                            <th>User</th>
-                            <th>Change Type</th>
-                            <th>Actions</th>
+                            <th>{% trans "Date" %}</th>
+                            <th>{% trans "User" %}</th>
+                            <th>{% trans "Change Type" %}</th>
+                            <th>{% trans "Actions" %}</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -34,23 +34,23 @@
                                     {% if history.history_user %}
                                         <a href="{% url 'user-detail' username=history.history_user.username %}">{{ history.history_user.username }}</a>
                                     {% else %}
-                                        <span class="has-text-grey-light">Unknown</span>
+                                        <span class="has-text-grey-light">{% trans "Unknown" %}</span>
                                     {% endif %}
                                 </td>
                                 <td>
                                     {% if history.history_type == "+" %}
-                                        <span class="tag is-success">Created</span>
+                                        <span class="tag is-success">{% trans "Created" %}</span>
                                     {% elif history.history_type == "~" %}
-                                        <span class="tag is-info">Updated</span>
+                                        <span class="tag is-info">{% trans "Updated" %}</span>
                                     {% elif history.history_type == "-" %}
-                                        <span class="tag is-danger">Deleted</span>
+                                        <span class="tag is-danger">{% trans "Deleted" %}</span>
                                     {% endif %}
                                 </td>
                                 <td>
                                     {% if history.delta %}
                                         <a href="javascript:void(0);"
                                            class="button is-small is-light"
-                                           onclick="showChanges('{{ history.history_id }}')">View Changes</a>
+                                           onclick="showChanges('{{ history.history_id }}')">{% trans "View Changes" %}</a>
                                     {% endif %}
                                 </td>
                             </tr>
@@ -58,7 +58,7 @@
                                 <tr id="changes-{{ history.history_id }}" style="display: none;">
                                     <td colspan="4">
                                         <div class="content">
-                                            <h4 class="title is-6">Changed Fields:</h4>
+                                            <h4 class="title is-6">{% trans "Changed Fields:" %}</h4>
                                             <ul>
                                                 {% for change in history.delta.changes %}
                                                     <li>
@@ -80,14 +80,14 @@
         </div>
     {% else %}
         <div class="notification is-info">
-            <p>No edit history available for this {{ model_name }}.</p>
+            <p>{% blocktrans %}No edit history available for this {{ model_name }}.{% endblocktrans %}</p>
         </div>
     {% endif %}
     {# Back Button #}
     <div class="buttons">
         <a class="button is-link" href="{{ object.get_absolute_url }}">
             <span class="icon is-small"><i class="fas fa-arrow-left" aria-hidden="true"></i></span>
-            <span>Back to {{ model_name }}</span>
+            <span>{% blocktrans %}Back to {{ model_name }}{% endblocktrans %}</span>
         </a>
     </div>
 {% endblock %}

--- a/comicsdb/templates/comicsdb/home.html
+++ b/comicsdb/templates/comicsdb/home.html
@@ -1,18 +1,18 @@
 {% extends parent_template|default:"base.html" %}
-{% load static %}
+{% load i18n static %}
 {% load cache %}
 {% block headcss %}
     <link rel="stylesheet" href="{% static 'site/css/home/index.css' %}">
 {% endblock %}
 {% block sitedesc %}
-    <meta name="description"
-          content="Metron is a community-based comic book database with a public REST API. Search and discover comic books with comprehensive metadata.">
+    {% trans "Metron is a community-based comic book database with a public REST API. Search and discover comic books with comprehensive metadata." as home_description %}
+    <meta name="description" content="{{ home_description }}">
 {% endblock %}
 {% block sitekeywords %}
     <meta name="keywords"
           content="Comics,Comic Book Database,API,REST,Metron,Community,Open Source">
 {% endblock %}
-{% block title %}Metron - Comic Book Database{% endblock %}
+{% block title %}{% trans "Metron - Comic Book Database" %}{% endblock %}
 {% block hero %}
     {# Announcements #}
     {% cache 1800 announcements_cache %}
@@ -22,7 +22,7 @@
                 <div class="notification is-{{ announcement.display_type }} is-light"
                      role="alert">
                     <button class="delete"
-                            aria-label="Dismiss announcement"
+                            aria-label="{% trans 'Dismiss announcement' %}"
                             onclick="this.parentElement.remove();"></button>
                     {{ announcement.content|safe }}
                 </div>
@@ -35,27 +35,27 @@
         <div class="home-hero-body">
             <div class="container has-text-centered">
                 <img src="{% static 'site/img/metron-300.png' %}"
-                     alt="Metron logo"
+                     alt="{% trans 'Metron logo' %}"
                      class="home-hero-logo"
                      width="120"
                      height="120">
                 <h1 class="home-hero-title">Metron</h1>
-                <p class="home-hero-tagline">Comic Book Database</p>
+                <p class="home-hero-tagline">{% trans "Comic Book Database" %}</p>
                 <p class="home-hero-subtitle">
-                    Built by the community, for the community.
+                    {% trans "Built by the community, for the community." %}
                 </p>
                 <div class="buttons are-medium is-centered home-hero-buttons">
                     <a href="{% url 'issue:list' %}" class="button is-light is-outlined">
                         <span class="icon"><i class="fas fa-book-open"></i></span>
-                        <span>Browse Comics</span>
+                        <span>{% trans "Browse Comics" %}</span>
                     </a>
                     <a href="{% url 'wiki:root' %}" class="button is-white">
                         <span class="icon"><i class="fas fa-book"></i></span>
-                        <span>Read the Wiki</span>
+                        <span>{% trans "Read the Wiki" %}</span>
                     </a>
                     <a href="{% url 'signup' %}" class="button is-link is-light">
                         <span class="icon"><i class="fas fa-user-plus"></i></span>
-                        <span>Sign Up Free</span>
+                        <span>{% trans "Sign Up Free" %}</span>
                     </a>
                 </div>
             </div>
@@ -67,34 +67,21 @@
     <section id="about" class="section">
         <div class="container">
             <div class="has-text-centered mb-5">
-                <h2 class="title is-2">What is Metron?</h2>
+                <h2 class="title is-2">{% trans "What is Metron?" %}</h2>
                 <p class="subtitle is-5 home-section-intro">
-                    A community-built, open database for comic book metadata — free from corporate control.
+                    {% trans "A community-built, open database for comic book metadata — free from corporate control." %}
                 </p>
                 <div class="home-section-divider"></div>
             </div>
             <div class="content home-about-content">
                 <p>
-                    <strong>Metron</strong> is a community-based site whose goal is to build an open database
-                    with a <a href="https://en.wikipedia.org/wiki/Representational_state_transfer"
-    target="_blank"
-    rel="noopener noreferrer">REST</a> API for comic books.
+                    {% blocktrans %}<strong>Metron</strong> is a community-based site whose goal is to build an open database with a <a href="https://en.wikipedia.org/wiki/Representational_state_transfer" target="_blank" rel="noopener noreferrer">REST</a> API for comic books.{% endblocktrans %}
                 </p>
                 <p>
-                    Originally, when this project was created, the only comic book database that provided a REST API for users was
-                    <a href="https://comicvine.gamespot.com/"
-                       target="_blank"
-                       rel="noopener noreferrer">Comic Vine</a>. Unfortunately, it's a corporately-owned service and
-                    the community that uses it has no control over the resources provided to maintain it or ensure its
-                    continued accessibility. This project was started to create an alternative.
+                    {% blocktrans %}Originally, when this project was created, the only comic book database that provided a REST API for users was <a href="https://comicvine.gamespot.com/" target="_blank" rel="noopener noreferrer">Comic Vine</a>. Unfortunately, it's a corporately-owned service and the community that uses it has no control over the resources provided to maintain it or ensure its continued accessibility. This project was started to create an alternative.{% endblocktrans %}
                 </p>
                 <p>
-                    <strong>Note:</strong> Recently, the <a href="https://www.comics.org/"
-    target="_blank"
-    rel="noopener noreferrer">Grand Comics Database</a> created an
-                    <a href="https://github.com/GrandComicsDatabase/gcd-django/wiki/API"
-                       target="_blank"
-                       rel="noopener noreferrer">API</a>, which you may wish to explore as an alternative.
+                    {% blocktrans %}<strong>Note:</strong> Recently, the <a href="https://www.comics.org/" target="_blank" rel="noopener noreferrer">Grand Comics Database</a> created an <a href="https://github.com/GrandComicsDatabase/gcd-django/wiki/API" target="_blank" rel="noopener noreferrer">API</a>, which you may wish to explore as an alternative.{% endblocktrans %}
                 </p>
             </div>
         </div>
@@ -103,9 +90,9 @@
     <section id="features" class="section has-background-section-alt">
         <div class="container">
             <div class="has-text-centered mb-5">
-                <h2 class="title is-2">What Metron Offers</h2>
+                <h2 class="title is-2">{% trans "What Metron Offers" %}</h2>
                 <p class="subtitle is-5 home-section-intro">
-                    Everything you need to discover, track, and organize your comic collection.
+                    {% trans "Everything you need to discover, track, and organize your comic collection." %}
                 </p>
                 <div class="home-section-divider"></div>
             </div>
@@ -118,28 +105,24 @@
                                     <i class="fas fa-satellite-dish fa-2x"></i>
                                 </span>
                             </div>
-                            <p class="title is-4 has-text-centered">REST API</p>
+                            <p class="title is-4 has-text-centered">{% trans "REST API" %}</p>
                             <div class="content">
                                 <p>
-                                    Access comic book metadata programmatically. Use the Python wrapper
-                                    <a href="https://github.com/Metron-Project/mokkari"
-                                       target="_blank"
-                                       rel="noopener noreferrer">Mokkari</a>
-                                    to integrate Metron data into your projects with ease.
+                                    {% blocktrans %}Access comic book metadata programmatically. Use the Python wrapper <a href="https://github.com/Metron-Project/mokkari" target="_blank" rel="noopener noreferrer">Mokkari</a> to integrate Metron data into your projects with ease.{% endblocktrans %}
                                 </p>
                             </div>
                         </div>
                         <div class="card-footer">
                             <a href="{% url 'wiki:root' %}" class="card-footer-item">
                                 <span class="icon"><i class="fas fa-book"></i></span>
-                                <span>Read the Wiki</span>
+                                <span>{% trans "Read the Wiki" %}</span>
                             </a>
                             <a href="https://metron.cloud/wiki/software/"
                                class="card-footer-item"
                                target="_blank"
                                rel="noopener noreferrer">
                                 <span class="icon"><i class="fas fa-cubes"></i></span>
-                                <span>Software</span>
+                                <span>{% trans "Software" %}</span>
                             </a>
                         </div>
                     </div>
@@ -152,18 +135,17 @@
                                     <i class="fas fa-boxes fa-2x"></i>
                                 </span>
                             </div>
-                            <p class="title is-4 has-text-centered">Collections</p>
+                            <p class="title is-4 has-text-centered">{% trans "Collections" %}</p>
                             <div class="content">
                                 <p>
-                                    Catalog and organize the comics you own. Track grades, purchase history, reading
-                                    status, and personal ratings for your physical or digital library.
+                                    {% trans "Catalog and organize the comics you own. Track grades, purchase history, reading status, and personal ratings for your physical or digital library." %}
                                 </p>
                             </div>
                         </div>
                         <div class="card-footer">
                             <a href="{% url 'user_collection:list' %}" class="card-footer-item">
                                 <span class="icon"><i class="fas fa-boxes"></i></span>
-                                <span>View Collection</span>
+                                <span>{% trans "View Collection" %}</span>
                             </a>
                         </div>
                     </div>
@@ -176,18 +158,17 @@
                                     <i class="fas fa-tasks fa-2x"></i>
                                 </span>
                             </div>
-                            <p class="title is-4 has-text-centered">Reading Lists</p>
+                            <p class="title is-4 has-text-centered">{% trans "Reading Lists" %}</p>
                             <div class="content">
                                 <p>
-                                    Create custom lists of issues to read, mark your progress, and share your reading
-                                    order with others. Perfect for story arcs and event crossovers.
+                                    {% trans "Create custom lists of issues to read, mark your progress, and share your reading order with others. Perfect for story arcs and event crossovers." %}
                                 </p>
                             </div>
                         </div>
                         <div class="card-footer">
                             <a href="{% url 'reading-list:list' %}" class="card-footer-item">
                                 <span class="icon"><i class="fas fa-tasks"></i></span>
-                                <span>View Reading Lists</span>
+                                <span>{% trans "View Reading Lists" %}</span>
                             </a>
                         </div>
                     </div>
@@ -200,18 +181,17 @@
                                     <i class="fas fa-heart fa-2x"></i>
                                 </span>
                             </div>
-                            <p class="title is-4 has-text-centered">Wish List</p>
+                            <p class="title is-4 has-text-centered">{% trans "Wish List" %}</p>
                             <div class="content">
                                 <p>
-                                    Keep track of issues you want to acquire. Never lose track of the comics you're
-                                    hunting for while shopping or trading with other collectors.
+                                    {% trans "Keep track of issues you want to acquire. Never lose track of the comics you're hunting for while shopping or trading with other collectors." %}
                                 </p>
                             </div>
                         </div>
                         <div class="card-footer">
                             <a href="{% url 'wish-list:detail' %}" class="card-footer-item">
                                 <span class="icon"><i class="fas fa-heart"></i></span>
-                                <span>View Wish List</span>
+                                <span>{% trans "View Wish List" %}</span>
                             </a>
                         </div>
                     </div>
@@ -224,19 +204,17 @@
                                     <i class="fas fa-rss fa-2x"></i>
                                 </span>
                             </div>
-                            <p class="title is-4 has-text-centered">Pull List</p>
+                            <p class="title is-4 has-text-centered">{% trans "Pull List" %}</p>
                             <div class="content">
                                 <p>
-                                    Follow the series you love. Add ongoing titles to your pull list and get a
-                                    consolidated view of everything you're currently collecting — so you never
-                                    miss a new release.
+                                    {% trans "Follow the series you love. Add ongoing titles to your pull list and get a consolidated view of everything you're currently collecting — so you never miss a new release." %}
                                 </p>
                             </div>
                         </div>
                         <div class="card-footer">
                             <a href="{% url 'pull-list:detail' %}" class="card-footer-item">
                                 <span class="icon"><i class="fas fa-rss"></i></span>
-                                <span>View Pull List</span>
+                                <span>{% trans "View Pull List" %}</span>
                             </a>
                         </div>
                     </div>
@@ -249,18 +227,17 @@
                                     <i class="fas fa-bolt fa-2x"></i>
                                 </span>
                             </div>
-                            <p class="title is-4 has-text-centered">Quick Scrobble</p>
+                            <p class="title is-4 has-text-centered">{% trans "Quick Scrobble" %}</p>
                             <div class="content">
                                 <p>
-                                    Mark issues as read instantly via the API — great for comic servers and automation.
-                                    Manage reading history programmatically at <code>/api/collection/</code>.
+                                    {% blocktrans %}Mark issues as read instantly via the API — great for comic servers and automation. Manage reading history programmatically at <code>/api/collection/</code>.{% endblocktrans %}
                                 </p>
                             </div>
                         </div>
                         <div class="card-footer">
                             <a href="{% url 'wiki:root' %}" class="card-footer-item">
                                 <span class="icon"><i class="fas fa-book"></i></span>
-                                <span>Read the Wiki</span>
+                                <span>{% trans "Read the Wiki" %}</span>
                             </a>
                         </div>
                     </div>
@@ -272,7 +249,7 @@
     <section id="timeline" class="section has-text-centered">
         <div class="container">
             <article class="box">
-                <header class="title">Interactive Timeline</header>
+                <header class="title">{% trans "Interactive Timeline" %}</header>
                 <div class="mini-timeline">
                     <i class="fa fa-asterisk"></i>
                     <i class="fa fa-code"></i>
@@ -281,11 +258,11 @@
                     <i class="fa fa-bug"></i>
                 </div>
                 <p class="subtitle">
-                    Discover the history of our community, and learn about the events that made our community what it is today.
+                    {% trans "Discover the history of our community, and learn about the events that made our community what it is today." %}
                 </p>
                 <div class="buttons are-medium is-centered">
                     <a href="{% url 'timeline:timeline' %}" class="button is-primary">
-                        <span>Check it out!</span>
+                        <span>{% trans "Check it out!" %}</span>
                         <span class="icon"><i class="fas fa-arrow-right"></i></span>
                     </a>
                 </div>
@@ -296,9 +273,9 @@
     <section id="community" class="section has-background-section-alt">
         <div class="container">
             <div class="has-text-centered mb-5">
-                <h2 class="title is-2">Get Involved</h2>
+                <h2 class="title is-2">{% trans "Get Involved" %}</h2>
                 <p class="subtitle is-5 home-section-intro">
-                    Metron is a community project — everyone is welcome to contribute.
+                    {% trans "Metron is a community project — everyone is welcome to contribute." %}
                 </p>
                 <div class="home-section-divider"></div>
             </div>
@@ -309,18 +286,18 @@
                             <span class="icon is-large home-feature-icon mb-3">
                                 <i class="fas fa-database fa-2x"></i>
                             </span>
-                            <p class="title is-5 mt-3">Add Comic Data</p>
+                            <p class="title is-5 mt-3">{% trans "Add Comic Data" %}</p>
                             <div class="content">
                                 <p>
-                                    Sign up for an account and help grow the database.
-                                    Read the <a href="{% url 'wiki:root' %}">Wiki</a> to learn the contribution guidelines before getting started.
+                                    {% url 'wiki:root' as wiki_root_url %}
+                                    {% blocktrans %}Sign up for an account and help grow the database. Read the <a href="{{ wiki_root_url }}">Wiki</a> to learn the contribution guidelines before getting started.{% endblocktrans %}
                                 </p>
                             </div>
                         </div>
                         <div class="card-footer">
                             <a href="{% url 'signup' %}" class="card-footer-item">
                                 <span class="icon"><i class="fas fa-user-plus"></i></span>
-                                <span>Create Account</span>
+                                <span>{% trans "Create Account" %}</span>
                             </a>
                         </div>
                     </div>
@@ -331,18 +308,10 @@
                             <span class="icon is-large home-feature-icon mb-3">
                                 <i class="fab fa-github fa-2x"></i>
                             </span>
-                            <p class="title is-5 mt-3">Contribute Code</p>
+                            <p class="title is-5 mt-3">{% trans "Contribute Code" %}</p>
                             <div class="content">
                                 <p>
-                                    Metron is built with
-                                    <a href="https://www.djangoproject.com/"
-                                       target="_blank"
-                                       rel="noopener noreferrer">Django</a>.
-                                    Check out the source on
-                                    <a href="https://github.com/Metron-Project/metron"
-                                       target="_blank"
-                                       rel="noopener noreferrer">GitHub</a>
-                                    and help improve the platform.
+                                    {% blocktrans %}Metron is built with <a href="https://www.djangoproject.com/" target="_blank" rel="noopener noreferrer">Django</a>. Check out the source on <a href="https://github.com/Metron-Project/metron" target="_blank" rel="noopener noreferrer">GitHub</a> and help improve the platform.{% endblocktrans %}
                                 </p>
                             </div>
                         </div>
@@ -352,7 +321,7 @@
                                target="_blank"
                                rel="noopener noreferrer">
                                 <span class="icon"><i class="fab fa-github"></i></span>
-                                <span>View on GitHub</span>
+                                <span>{% trans "View on GitHub" %}</span>
                             </a>
                         </div>
                     </div>
@@ -363,14 +332,10 @@
                             <span class="icon is-large home-feature-icon mb-3">
                                 <i class="fas fa-hand-holding-usd fa-2x"></i>
                             </span>
-                            <p class="title is-5 mt-3">Support the Project</p>
+                            <p class="title is-5 mt-3">{% trans "Support the Project" %}</p>
                             <div class="content">
                                 <p>
-                                    Help cover server and development costs by donating through
-                                    <a href="https://opencollective.com/metron"
-                                       target="_blank"
-                                       rel="noopener noreferrer">OpenCollective</a>.
-                                    Every contribution helps keep Metron running.
+                                    {% blocktrans %}Help cover server and development costs by donating through <a href="https://opencollective.com/metron" target="_blank" rel="noopener noreferrer">OpenCollective</a>. Every contribution helps keep Metron running.{% endblocktrans %}
                                 </p>
                             </div>
                         </div>
@@ -380,7 +345,7 @@
                                target="_blank"
                                rel="noopener noreferrer">
                                 <span class="icon"><i class="fas fa-heart"></i></span>
-                                <span>Donate</span>
+                                <span>{% trans "Donate" %}</span>
                             </a>
                         </div>
                     </div>
@@ -388,11 +353,11 @@
             </div>
             {# Contact / Questions #}
             <div class="mt-6">
-                <h3 class="title is-4 has-text-centered">Have Questions?</h3>
+                <h3 class="title is-4 has-text-centered">{% trans "Have Questions?" %}</h3>
                 <div class="columns is-centered">
                     <div class="column is-8-desktop">
                         <div class="box home-contact-box">
-                            <p class="has-text-centered mb-4">Feel free to reach out through any of these channels:</p>
+                            <p class="has-text-centered mb-4">{% trans "Feel free to reach out through any of these channels:" %}</p>
                             <div class="columns is-mobile is-centered">
                                 <div class="column has-text-centered">
                                     <a href="https://matrix.to/#/#metrondb:matrix.org"
@@ -402,7 +367,7 @@
                                         <span class="icon is-large home-feature-icon">
                                             <i class="fas fa-comments fa-2x"></i>
                                         </span>
-                                        <p class="mt-2">Matrix Chat</p>
+                                        <p class="mt-2">{% trans "Matrix Chat" %}</p>
                                     </a>
                                 </div>
                                 <div class="column has-text-centered">
@@ -413,7 +378,7 @@
                                         <span class="icon is-large home-feature-icon">
                                             <i class="fab fa-github fa-2x"></i>
                                         </span>
-                                        <p class="mt-2">GitHub Discussions</p>
+                                        <p class="mt-2">{% trans "GitHub Discussions" %}</p>
                                     </a>
                                 </div>
                                 <div class="column has-text-centered">
@@ -421,7 +386,7 @@
                                         <span class="icon is-large home-feature-icon">
                                             <i class="fas fa-envelope fa-2x"></i>
                                         </span>
-                                        <p class="mt-2">Email Admin</p>
+                                        <p class="mt-2">{% trans "Email Admin" %}</p>
                                     </a>
                                 </div>
                             </div>

--- a/comicsdb/templates/comicsdb/imprint_detail.html
+++ b/comicsdb/templates/comicsdb/imprint_detail.html
@@ -1,7 +1,7 @@
 {% extends parent_template|default:"base.html" %}
 {% load humanize %}
 {% load thumbnail %}
-{% load static %}
+{% load i18n static %}
 {% block title %}
     {{ imprint.name }}
 {% endblock title %}
@@ -11,31 +11,31 @@
         <h1 class="title">{{ imprint }}</h1>
     </header>
     {# Navigation Bar #}
-    <nav class="level mb-5" aria-label="Imprint navigation">
+    <nav class="level mb-5" aria-label="{% trans 'Imprint navigation' %}">
         <div class="level-left">
             {% if navigation.previous_imprint %}
                 <a class="button is-link"
                    href="{% url 'imprint:detail' navigation.previous_imprint.slug %}"
-                   aria-label="Go to {{ navigation.previous_imprint }}">
+                   aria-label="{% blocktrans with previous_imprint=navigation.previous_imprint %}Go to {{ previous_imprint }}{% endblocktrans %}">
                     <span class="icon is-small"><i class="fas fa-arrow-left" aria-hidden="true"></i></span>
-                    <span>Previous Imprint</span>
+                    <span>{% trans "Previous Imprint" %}</span>
                 </a>
             {% else %}
                 <button class="button" disabled aria-disabled="true">
                     <span class="icon is-small"><i class="fas fa-arrow-left" aria-hidden="true"></i></span>
-                    <span>Previous Imprint</span>
+                    <span>{% trans "Previous Imprint" %}</span>
                 </button>
             {% endif %}
             {% if navigation.next_imprint %}
                 <a class="button is-link ml-2"
                    href="{% url 'imprint:detail' navigation.next_imprint.slug %}"
-                   aria-label="Go to {{ navigation.next_imprint }}">
-                    <span>Next Imprint</span>
+                   aria-label="{% blocktrans with next_imprint=navigation.next_imprint %}Go to {{ next_imprint }}{% endblocktrans %}">
+                    <span>{% trans "Next Imprint" %}</span>
                     <span class="icon is-small"><i class="fas fa-arrow-right" aria-hidden="true"></i></span>
                 </a>
             {% else %}
                 <button class="button ml-2" disabled aria-disabled="true">
-                    <span>Next Imprint</span>
+                    <span>{% trans "Next Imprint" %}</span>
                     <span class="icon is-small"><i class="fas fa-arrow-right" aria-hidden="true"></i></span>
                 </button>
             {% endif %}
@@ -44,16 +44,16 @@
             <div class="buttons">
                 <a class="button is-link"
                    href="{% url 'imprint:series' imprint.slug %}"
-                   title="View series list for this imprint">
+                   title="{% trans 'View series list for this imprint' %}">
                     <span class="icon is-small"><i class="fas fa-list" aria-hidden="true"></i></span>
-                    <span>Series List</span>
+                    <span>{% trans "Series List" %}</span>
                 </a>
                 {% if user.is_authenticated %}
                     <a class="button is-primary"
                        href="{% url 'imprint:create' %}"
-                       title="Add a new imprint">
+                       title="{% trans 'Add a new imprint' %}">
                         <span class="icon is-small"><i class="fas fa-plus" aria-hidden="true"></i></span>
-                        <span>New</span>
+                        <span>{% trans "New" %}</span>
                     </a>
                     <div class="dropdown is-right" id="imprint-actions-dropdown">
                         <div class="dropdown-trigger">
@@ -61,7 +61,7 @@
                                     aria-haspopup="true"
                                     aria-controls="imprint-actions-menu"
                                     hx-on:click="document.getElementById('imprint-actions-dropdown').classList.toggle('is-active')">
-                                <span>Actions</span>
+                                <span>{% trans "Actions" %}</span>
                                 <span class="icon is-small"><i class="fas fa-angle-down" aria-hidden="true"></i></span>
                             </button>
                         </div>
@@ -70,19 +70,19 @@
                                 <a class="dropdown-item"
                                    href="{% url 'imprint:update' imprint.slug %}">
                                     <span class="icon is-small"><i class="fas fa-edit" aria-hidden="true"></i></span>
-                                    <span>Edit</span>
+                                    <span>{% trans "Edit" %}</span>
                                 </a>
                                 <a class="dropdown-item"
                                    href="{% url 'imprint:history' imprint.slug %}">
                                     <span class="icon is-small"><i class="fas fa-history" aria-hidden="true"></i></span>
-                                    <span>History</span>
+                                    <span>{% trans "History" %}</span>
                                 </a>
                                 {% if perms.comicsdb.delete_imprint %}
                                     <hr class="dropdown-divider">
                                     <a class="dropdown-item has-text-danger"
                                        href="{% url 'imprint:delete' imprint.slug %}">
                                         <span class="icon is-small"><i class="fas fa-trash" aria-hidden="true"></i></span>
-                                        <span>Delete</span>
+                                        <span>{% trans "Delete" %}</span>
                                     </a>
                                 {% endif %}
                             </div>
@@ -116,7 +116,7 @@
                         {% endthumbnail %}
                     {% else %}
                         <img src="{% static 'site/img/image-not-found.webp' %}"
-                             alt="No image for {{ imprint.name }}"
+                             alt="{% blocktrans %}No image for {{ imprint.name }}{% endblocktrans %}"
                              loading="lazy">
                     {% endif %}
                 </figure>
@@ -126,14 +126,14 @@
         <div class="column">
             {# Summary #}
             <div class="box">
-                <h2 class="title is-5">Summary</h2>
+                <h2 class="title is-5">{% trans "Summary" %}</h2>
                 {% if imprint.desc %}
                     <div class="content">{{ imprint.desc|linebreaksbr }}</div>
                 {% else %}
-                    <p class="has-text-grey">No information available.</p>
+                    <p class="has-text-grey">{% trans "No information available." %}</p>
                 {% endif %}
                 <footer class="content is-small is-italic mt-4">
-                    Last edited on <time datetime="{{ imprint.modified|date:'c' }}">{{ imprint.modified }}</time> by
+                    {% blocktrans with modified_time=imprint.modified %}Last edited on <time datetime="{{ modified_time|date:'c' }}">{{ modified_time }}</time> by{% endblocktrans %}
                     <a href="{% url 'user-detail' username=imprint.edited_by.username %}">{{ imprint.edited_by.username }}</a>
                 </footer>
             </div>
@@ -147,20 +147,20 @@
         {# Metadata Sidebar #}
         <div class="column is-one-fifth">
             <div class="box">
-                <h2 class="title is-6">Imprint Details</h2>
+                <h2 class="title is-6">{% trans "Imprint Details" %}</h2>
                 <dl>
-                    <dt class="has-text-weight-bold">Publisher:</dt>
+                    <dt class="has-text-weight-bold">{% trans "Publisher:" %}</dt>
                     <dd class="mb-3">
                         <a href="{% url 'publisher:detail' imprint.publisher.slug %}">{{ imprint.publisher }}</a>
                     </dd>
                     {% if imprint.founded %}
-                        <dt class="has-text-weight-bold">Founded:</dt>
+                        <dt class="has-text-weight-bold">{% trans "Founded:" %}</dt>
                         <dd class="mb-3">
                             {{ imprint.founded }}
                         </dd>
                     {% endif %}
                     {% if imprint.series_count > 0 %}
-                        <dt class="has-text-weight-bold">Number of Series:</dt>
+                        <dt class="has-text-weight-bold">{% trans "Number of Series:" %}</dt>
                         <dd class="mb-3">
                             {{ imprint.series_count|intcomma }}
                         </dd>
@@ -169,21 +169,21 @@
             </div>
             {# Identification Numbers #}
             <div class="box">
-                <h2 class="title is-6">Identification Numbers</h2>
+                <h2 class="title is-6">{% trans "Identification Numbers" %}</h2>
                 <dl>
-                    <dt class="has-text-weight-bold">Metron:</dt>
+                    <dt class="has-text-weight-bold">{% trans "Metron:" %}</dt>
                     <dd class="mb-2 is-flex is-align-items-center is-justify-content-space-between">
                         <span class="is-family-monospace">{{ imprint.id }}</span>
                         <button type="button"
                                 class="button is-small is-light copy-id"
                                 data-copy="{{ imprint.id }}"
-                                title="Copy Metron ID"
-                                aria-label="Copy Metron ID">
+                                title="{% trans 'Copy Metron ID' %}"
+                                aria-label="{% trans 'Copy Metron ID' %}">
                             <span class="icon is-small"><i class="fas fa-copy"></i></span>
                         </button>
                     </dd>
                     {% if imprint.cv_id %}
-                        <dt class="has-text-weight-bold">Comic Vine:</dt>
+                        <dt class="has-text-weight-bold">{% trans "Comic Vine:" %}</dt>
                         <dd class="mb-2 is-flex is-align-items-center is-justify-content-space-between">
                             <a class="is-family-monospace"
                                href="https://comicvine.gamespot.com/publisher/4010-{{ imprint.cv_id }}/"
@@ -195,15 +195,15 @@
                             <button type="button"
                                     class="button is-small is-light copy-id"
                                     data-copy="{{ imprint.cv_id }}"
-                                    title="Copy Comic Vine ID"
-                                    aria-label="Copy Comic Vine ID">
+                                    title="{% trans 'Copy Comic Vine ID' %}"
+                                    aria-label="{% trans 'Copy Comic Vine ID' %}">
                                 <span class="icon is-small"><i class="fas fa-copy"></i></span>
                             </button>
                         </dd>
                     {% endif %}
                     {% if imprint.gcd_id %}
                         <dt class="has-text-weight-bold">
-                            <abbr title="Grand Comics Database">GCD</abbr>:
+                            <abbr title="{% trans 'Grand Comics Database' %}">GCD</abbr>:
                         </dt>
                         <dd class="is-flex is-align-items-center is-justify-content-space-between">
                             <a class="is-family-monospace"
@@ -216,8 +216,8 @@
                             <button type="button"
                                     class="button is-small is-light copy-id"
                                     data-copy="{{ imprint.gcd_id }}"
-                                    title="Copy GCD ID"
-                                    aria-label="Copy GCD ID">
+                                    title="{% trans 'Copy GCD ID' %}"
+                                    aria-label="{% trans 'Copy GCD ID' %}">
                                 <span class="icon is-small"><i class="fas fa-copy"></i></span>
                             </button>
                         </dd>

--- a/comicsdb/templates/comicsdb/imprint_list.html
+++ b/comicsdb/templates/comicsdb/imprint_list.html
@@ -1,17 +1,22 @@
 {% extends parent_template|default:"base.html" %}
-{% load static %}
-{% block title %}Imprints - Metron{% endblock %}
+{% load i18n static %}
+{% block title %}{% trans "Imprints - Metron" %}{% endblock %}
 {% block content %}
     <header class="block has-text-centered">
-        <h1 class="title">Imprints List</h1>
+        <h1 class="title">{% trans "Imprints List" %}</h1>
     </header>
+    {% trans "Imprint" as list_title %}
+    {% trans "Imprints" as list_title_plural %}
+    {% trans "Find an imprint" as list_search_placeholder %}
+    {% trans "Series" as series_label %}
+    {% trans "Add a new imprint" as list_create_title %}
     {% if imprint_list %}
         <section>
-            {% include "comicsdb/partials/list_header.html" with title="Imprint" count=page_obj.paginator.count search_url="imprint:search" search_placeholder="Find an imprint" create_url="imprint:create" create_title="Add a new imprint" %}
-            {% include "comicsdb/partials/card_grid.html" with items=imprint_list detail_url_name="imprint:detail" image_ratio="is-2by3" default_image="site/img/image-not-found.webp" count_type="series" count_url_name="imprint:series" count_label="Series" %}
+            {% include "comicsdb/partials/list_header.html" with title=list_title title_plural=list_title_plural count=page_obj.paginator.count search_url="imprint:search" search_placeholder=list_search_placeholder create_url="imprint:create" create_title=list_create_title %}
+            {% include "comicsdb/partials/card_grid.html" with items=imprint_list detail_url_name="imprint:detail" image_ratio="is-2by3" default_image="site/img/image-not-found.webp" count_type="series" count_url_name="imprint:series" count_label=series_label count_label_plural=series_label %}
         </section>
     {% else %}
-        {% include "comicsdb/partials/empty_state.html" with item_type="Imprint" create_url="imprint:create" create_title="Add a new imprint" %}
+        {% include "comicsdb/partials/empty_state.html" with item_type=list_title item_type_plural=list_title_plural create_url="imprint:create" create_title=list_create_title %}
     {% endif %}
 {% endblock %}
 {% block pagination %}

--- a/comicsdb/templates/comicsdb/issue_detail.html
+++ b/comicsdb/templates/comicsdb/issue_detail.html
@@ -1,9 +1,9 @@
 {% extends parent_template|default:"base.html" %}
 {% load thumbnail %}
 {% load humanize %}
-{% load static %}
+{% load i18n static %}
 {% block sitedesc %}
-    <meta name="description" content="{{ issue }} Information">
+    <meta name="description" content="{% blocktrans %}{{ issue }} Information{% endblocktrans %}">
 {% endblock sitedesc %}
 {% block sitekeywords %}
     <meta name="keywords"
@@ -35,7 +35,7 @@
             {% endif %}
         </div>
         <button class="modal-close is-large"
-                aria-label="close"
+                aria-label="{% trans 'close' %}"
                 hx-on:click="this.closest('.modal').classList.remove('is-active'); document.documentElement.classList.remove('is-clipped');">
         </button>
     </div>
@@ -49,7 +49,7 @@
                 <a href="{% url 'series:detail' issue.series.slug %}">{{ issue.series }}</a>
             </li>
             <li class="is-active">
-                <a href="#" aria-current="page">Issue #{{ issue.number }}</a>
+                <a href="#" aria-current="page">{% blocktrans with issue_number=issue.number %}Issue #{{ issue_number }}{% endblocktrans %}</a>
             </li>
         </ul>
     </nav>
@@ -68,31 +68,31 @@
         </p>
     </header>
     {# Navigation Bar #}
-    <nav class="level mb-5" aria-label="Issue navigation">
+    <nav class="level mb-5" aria-label="{% trans 'Issue navigation' %}">
         <div class="level-left">
             {% if navigation.previous_issue %}
                 <a class="button is-link"
                    href="{% url 'issue:detail' navigation.previous_issue.slug %}"
-                   aria-label="Go to {{ navigation.previous_issue }}">
+                   aria-label="{% blocktrans with previous_issue=navigation.previous_issue %}Go to {{ previous_issue }}{% endblocktrans %}">
                     <span class="icon is-small"><i class="fas fa-arrow-left" aria-hidden="true"></i></span>
-                    <span>Previous Issue</span>
+                    <span>{% trans "Previous Issue" %}</span>
                 </a>
             {% else %}
                 <button class="button" disabled aria-disabled="true">
                     <span class="icon is-small"><i class="fas fa-arrow-left" aria-hidden="true"></i></span>
-                    <span>Previous Issue</span>
+                    <span>{% trans "Previous Issue" %}</span>
                 </button>
             {% endif %}
             {% if navigation.next_issue %}
                 <a class="button is-link ml-2"
                    href="{% url 'issue:detail' navigation.next_issue.slug %}"
-                   aria-label="Go to {{ navigation.next_issue }}">
-                    <span>Next Issue</span>
+                   aria-label="{% blocktrans with next_issue=navigation.next_issue %}Go to {{ next_issue }}{% endblocktrans %}">
+                    <span>{% trans "Next Issue" %}</span>
                     <span class="icon is-small"><i class="fas fa-arrow-right" aria-hidden="true"></i></span>
                 </a>
             {% else %}
                 <button class="button ml-2" disabled aria-disabled="true">
-                    <span>Next Issue</span>
+                    <span>{% trans "Next Issue" %}</span>
                     <span class="icon is-small"><i class="fas fa-arrow-right" aria-hidden="true"></i></span>
                 </button>
             {% endif %}
@@ -103,9 +103,9 @@
                     {% include "wish_list/partials/wish_list_button.html" with issue=issue on_wish_list=on_wish_list %}
                     <a class="button is-primary"
                        href="{% url 'issue:create' %}"
-                       title="Add a new issue">
+                       title="{% trans 'Add a new issue' %}">
                         <span class="icon is-small"><i class="fas fa-plus" aria-hidden="true"></i></span>
-                        <span>New</span>
+                        <span>{% trans "New" %}</span>
                     </a>
                     {% if issue.series.series_type.name != "Trade Paperback" and issue.series.series_type.name != "Omnibus" and issue.series.series_type.name != "Hardcover" and issue.series.publisher.name != "DC Comics" and issue.series.publisher.name != "Marvel" %}
                         {% if navigation.previous_issue and not issue.credits_set.exists %}
@@ -115,18 +115,18 @@
                                 {% csrf_token %}
                                 <button class="button is-link"
                                         type="submit"
-                                        title="Duplicate credits from previous issue">
+                                        title="{% trans 'Duplicate credits from previous issue' %}">
                                     <span class="icon is-small"><i class="fas fa-clone" aria-hidden="true"></i></span>
-                                    <span>Duplicate Credits</span>
+                                    <span>{% trans "Duplicate Credits" %}</span>
                                 </button>
                             </form>
                         {% else %}
                             <button class="button is-link"
                                     disabled
                                     aria-disabled="true"
-                                    title="No previous issue or credits already exist">
+                                    title="{% trans 'No previous issue or credits already exist' %}">
                                 <span class="icon is-small"><i class="fas fa-clone" aria-hidden="true"></i></span>
-                                <span>Duplicate Credits</span>
+                                <span>{% trans "Duplicate Credits" %}</span>
                             </button>
                         {% endif %}
                     {% endif %}
@@ -138,18 +138,18 @@
                                 {% csrf_token %}
                                 <button class="button is-link"
                                         type="submit"
-                                        title="Sync resources from reprints">
+                                        title="{% trans 'Sync resources from reprints' %}">
                                     <span class="icon is-small"><i class="fas fa-copy" aria-hidden="true"></i></span>
-                                    <span>Sync</span>
+                                    <span>{% trans "Sync" %}</span>
                                 </button>
                             </form>
                         {% else %}
                             <button class="button is-link"
                                     disabled
                                     aria-disabled="true"
-                                    title="No sync available">
+                                    title="{% trans 'No sync available' %}">
                                 <span class="icon is-small"><i class="fas fa-copy" aria-hidden="true"></i></span>
-                                <span>Sync</span>
+                                <span>{% trans "Sync" %}</span>
                             </button>
                         {% endif %}
                     {% endif %}
@@ -159,7 +159,7 @@
                                     aria-haspopup="true"
                                     aria-controls="issue-actions-menu"
                                     hx-on:click="document.getElementById('issue-actions-dropdown').classList.toggle('is-active')">
-                                <span>Actions</span>
+                                <span>{% trans "Actions" %}</span>
                                 <span class="icon is-small"><i class="fas fa-angle-down" aria-hidden="true"></i></span>
                             </button>
                         </div>
@@ -168,19 +168,19 @@
                                 <a class="dropdown-item"
                                    href="{% url 'issue:update' issue.slug %}">
                                     <span class="icon is-small"><i class="fas fa-edit" aria-hidden="true"></i></span>
-                                    <span>Edit</span>
+                                    <span>{% trans "Edit" %}</span>
                                 </a>
                                 <a class="dropdown-item"
                                    href="{% url 'issue:history' issue.slug %}">
                                     <span class="icon is-small"><i class="fas fa-history" aria-hidden="true"></i></span>
-                                    <span>History</span>
+                                    <span>{% trans "History" %}</span>
                                 </a>
                                 {% if perms.comicsdb.delete_issue %}
                                     <hr class="dropdown-divider">
                                     <a class="dropdown-item has-text-danger"
                                        href="{% url 'issue:delete' issue.slug %}">
                                         <span class="icon is-small"><i class="fas fa-trash" aria-hidden="true"></i></span>
-                                        <span>Delete</span>
+                                        <span>{% trans "Delete" %}</span>
                                     </a>
                                 {% endif %}
                             </div>
@@ -207,7 +207,7 @@
                 {% if issue.image %}
                     {% thumbnail issue.image "320x480" format="WEBP" as im %}
                         <figure class="image {% if im.width > im.height %}is-3by2{% else %}is-2by3{% endif %}">
-                            <a aria-label="View larger cover image"
+                            <a aria-label="{% trans 'View larger cover image' %}"
                                hx-on:click="var modal = document.getElementById('modal-bis'); modal.classList.add('is-active'); document.documentElement.classList.add('is-clipped'); modal.focus();">
                                 <img src="{{ im.url }}"
                                      width="{{ im.width }}"
@@ -218,14 +218,14 @@
                         </figure>
                     {% endthumbnail %}
                     <p class="has-text-centered mt-3">
-                        <strong class="is-size-6">Main Cover</strong>
+                        <strong class="is-size-6">{% trans "Main Cover" %}</strong>
                         <br>
-                        <small class="has-text-grey">Click to enlarge</small>
+                        <small class="has-text-grey">{% trans "Click to enlarge" %}</small>
                     </p>
                 {% else %}
                     <figure class="image is-2by3">
                         <img src="{% static 'site/img/image-not-found.webp' %}"
-                             alt="No image for {{ issue }}"
+                             alt="{% blocktrans %}No image for {{ issue }}{% endblocktrans %}"
                              loading="lazy">
                     </figure>
                 {% endif %}
@@ -248,7 +248,7 @@
                             {% else %}
                                 <figure class="image is-2by3">
                                     <img src="{% static 'site/img/image-not-found.webp' %}"
-                                         alt="No image for {{ variant.name }}"
+                                         alt="{% blocktrans %}No image for {{ variant.name }}{% endblocktrans %}"
                                          loading="lazy">
                                 </figure>
                             {% endif %}
@@ -258,11 +258,11 @@
                                 </p>
                                 {% if variant.price or variant.sku or variant.upc %}
                                     <p class="is-size-7 has-text-grey mt-1">
-                                        {% if variant.price %}Price: {{ variant.price }}{% endif %}
+                                        {% if variant.price %}{% blocktrans with price=variant.price %}Price: {{ price }}{% endblocktrans %}{% endif %}
                                         {% if variant.price and variant.sku %}<br>{% endif %}
-                                        {% if variant.sku %}SKU: {{ variant.sku }}{% endif %}
+                                        {% if variant.sku %}{% blocktrans with sku=variant.sku %}SKU: {{ sku }}{% endblocktrans %}{% endif %}
                                         {% if variant.sku and variant.upc %}<br>{% endif %}
-                                        {% if variant.upc %}UPC: {{ variant.upc }}{% endif %}
+                                        {% if variant.upc %}{% blocktrans with upc=variant.upc %}UPC: {{ upc }}{% endblocktrans %}{% endif %}
                                     </p>
                                 {% endif %}
                             </div>
@@ -277,34 +277,40 @@
             <div class="box">
                 {# Collection Title #}
                 {% if issue.title %}
-                    <h2 class="title is-5">Collection Title</h2>
+                    <h2 class="title is-5">{% trans "Collection Title" %}</h2>
                     <p class="mb-4">{{ issue.title }}</p>
                 {% endif %}
                 {# Story Titles #}
                 {% if issue.name %}
                     {% with names=issue.name %}
-                        <h2 class="title is-5">Stor{{ names|pluralize:"y,ies" }} Title{{ names|pluralize }}</h2>
+                        <h2 class="title is-5">
+                            {% if names|length > 1 %}
+                                {% trans "Story Titles" %}
+                            {% else %}
+                                {% trans "Story Title" %}
+                            {% endif %}
+                        </h2>
                         <ul class="mb-4">
                             {% for story in names %}<li>{{ story }}</li>{% endfor %}
                         </ul>
                     {% endwith %}
                 {% endif %}
                 {# Summary #}
-                <h2 class="title is-5">Summary</h2>
+                <h2 class="title is-5">{% trans "Summary" %}</h2>
                 {% if issue.desc %}
                     <div class="content">{{ issue.desc|linebreaksbr }}</div>
                 {% else %}
-                    <p class="has-text-grey">No summary available.</p>
+                    <p class="has-text-grey">{% trans "No summary available." %}</p>
                 {% endif %}
                 <footer class="content is-small is-italic mt-4">
-                    Last edited on <time datetime="{{ issue.modified|date:'c' }}">{{ issue.modified }}</time> by
+                    {% blocktrans with modified_time=issue.modified %}Last edited on <time datetime="{{ modified_time|date:'c' }}">{{ modified_time }}</time> by{% endblocktrans %}
                     <a href="{% url 'user-detail' username=issue.edited_by.username %}">{{ issue.edited_by.username }}</a>
                 </footer>
             </div>
             {# Credits #}
             {% if credits_count > 0 %}
                 <div class="box">
-                    <h2 class="title is-5">Credit{{ credits_count|pluralize }} ({{ credits_count }})</h2>
+                    <h2 class="title is-5">{% blocktrans count counter=credits_count %}Credit ({{ counter }}){% plural %}Credits ({{ counter }}){% endblocktrans %}</h2>
                     <div id="credits-container" class="columns is-multiline">
                         {% for credit in credits %}
                             <div class="column is-4">
@@ -323,7 +329,7 @@
                                             {% else %}
                                                 <img class="is-rounded"
                                                      src="{% static 'site/img/creator-not-found.webp' %}"
-                                                     alt="No image for {{ credit.creator }}"
+                                                     alt="{% blocktrans %}No image for {{ credit.creator }}{% endblocktrans %}"
                                                      loading="lazy">
                                             {% endif %}
                                         </div>
@@ -352,7 +358,7 @@
                                     hx-target="#credits-container"
                                     hx-swap="beforeend"
                                     hx-indicator="#credits-spinner">
-                                <span>Load More Credits</span>
+                                <span>{% trans "Load More Credits" %}</span>
                             </button>
                             <span id="credits-spinner" class="htmx-indicator ml-2">
                                 <i class="fas fa-spinner fa-spin"></i>
@@ -364,7 +370,7 @@
             {# Characters #}
             {% if characters_count > 0 %}
                 <div class="box">
-                    <h2 class="title is-5">Character{{ characters_count|pluralize }} ({{ characters_count }})</h2>
+                    <h2 class="title is-5">{% blocktrans count counter=characters_count %}Character ({{ counter }}){% plural %}Characters ({{ counter }}){% endblocktrans %}</h2>
                     <div id="characters-container" class="columns is-multiline">
                         {% for character in characters %}
                             <div class="column is-4">
@@ -383,7 +389,7 @@
                                             {% else %}
                                                 <img class="is-rounded"
                                                      src="{% static 'site/img/creator-not-found.webp' %}"
-                                                     alt="No image for {{ character }}"
+                                                     alt="{% blocktrans %}No image for {{ character }}{% endblocktrans %}"
                                                      loading="lazy">
                                             {% endif %}
                                         </div>
@@ -402,7 +408,7 @@
                                     hx-target="#characters-container"
                                     hx-swap="beforeend"
                                     hx-indicator="#characters-spinner">
-                                <span>Load More Characters</span>
+                                <span>{% trans "Load More Characters" %}</span>
                             </button>
                             <span id="characters-spinner" class="htmx-indicator ml-2">
                                 <i class="fas fa-spinner fa-spin"></i>
@@ -414,7 +420,7 @@
             {# Teams #}
             {% if teams_count > 0 %}
                 <div class="box">
-                    <h2 class="title is-5">Team{{ teams_count|pluralize }} ({{ teams_count }})</h2>
+                    <h2 class="title is-5">{% blocktrans count counter=teams_count %}Team ({{ counter }}){% plural %}Teams ({{ counter }}){% endblocktrans %}</h2>
                     <div id="teams-container" class="columns is-multiline">
                         {% for team in teams %}
                             <div class="column is-4">
@@ -433,7 +439,7 @@
                                             {% else %}
                                                 <img class="is-rounded"
                                                      src="{% static 'site/img/creator-not-found.webp' %}"
-                                                     alt="No image for {{ team }}"
+                                                     alt="{% blocktrans %}No image for {{ team }}{% endblocktrans %}"
                                                      loading="lazy">
                                             {% endif %}
                                         </div>
@@ -452,7 +458,7 @@
                                     hx-target="#teams-container"
                                     hx-swap="beforeend"
                                     hx-indicator="#teams-spinner">
-                                <span>Load More Teams</span>
+                                <span>{% trans "Load More Teams" %}</span>
                             </button>
                             <span id="teams-spinner" class="htmx-indicator ml-2">
                                 <i class="fas fa-spinner fa-spin"></i>
@@ -464,7 +470,7 @@
             {# Universes #}
             {% if universes_count > 0 %}
                 <div class="box">
-                    <h2 class="title is-5">Universe{{ universes_count|pluralize }} ({{ universes_count }})</h2>
+                    <h2 class="title is-5">{% blocktrans count counter=universes_count %}Universe ({{ counter }}){% plural %}Universes ({{ counter }}){% endblocktrans %}</h2>
                     <div id="universes-container" class="columns is-multiline">
                         {% for universe in universes %}
                             <div class="column is-4">
@@ -483,7 +489,7 @@
                                             {% else %}
                                                 <img class="is-rounded"
                                                      src="{% static 'site/img/creator-not-found.webp' %}"
-                                                     alt="No image for {{ universe }}"
+                                                     alt="{% blocktrans %}No image for {{ universe }}{% endblocktrans %}"
                                                      loading="lazy">
                                             {% endif %}
                                         </div>
@@ -502,7 +508,7 @@
                                     hx-target="#universes-container"
                                     hx-swap="beforeend"
                                     hx-indicator="#universes-spinner">
-                                <span>Load More Universes</span>
+                                <span>{% trans "Load More Universes" %}</span>
                             </button>
                             <span id="universes-spinner" class="htmx-indicator ml-2">
                                 <i class="fas fa-spinner fa-spin"></i>
@@ -515,15 +521,15 @@
             {% with reprints=issue.reprints.all %}
                 {% if reprints %}
                     <div class="box">
-                        <h2 class="title is-5">Reprint{{ reprints|pluralize }} ({{ reprints.count }})</h2>
+                        <h2 class="title is-5">{% blocktrans count counter=reprints.count %}Reprint ({{ counter }}){% plural %}Reprints ({{ counter }}){% endblocktrans %}</h2>
                         <div class="content">
                             <ul>
                                 {% for reprint in reprints %}
                                     <li>
                                         {% if reprint.cover_date < issue.cover_date %}
-                                            from
+                                            {% trans "from" %}
                                         {% else %}
-                                            in
+                                            {% trans "in" %}
                                         {% endif %}
                                         <a href="{% url 'issue:detail' reprint.slug %}">{{ reprint }}</a>
                                         <span class="has-text-grey-light">— {{ reprint.cover_date|date:"M Y" }}</span>
@@ -544,35 +550,35 @@
         {# Right Column - Metadata #}
         <div class="column is-one-fifth">
             <div class="box">
-                <h2 class="title is-6">Issue Details</h2>
+                <h2 class="title is-6">{% trans "Issue Details" %}</h2>
                 <dl>
-                    <dt class="has-text-weight-bold">Series:</dt>
+                    <dt class="has-text-weight-bold">{% trans "Series:" %}</dt>
                     <dd class="mb-3">
                         <a href="{% url 'series:detail' issue.series.slug %}">{{ issue.series }}</a>
                     </dd>
-                    <dt class="has-text-weight-bold">Number:</dt>
+                    <dt class="has-text-weight-bold">{% trans "Number:" %}</dt>
                     <dd class="mb-3">
                         {{ issue.number }}
                     </dd>
                     {% if issue.alt_number %}
-                        <dt class="has-text-weight-bold">Alternative Number:</dt>
+                        <dt class="has-text-weight-bold">{% trans "Alternative Number:" %}</dt>
                         <dd class="mb-3">
                             {{ issue.alt_number }}
                         </dd>
                     {% endif %}
-                    <dt class="has-text-weight-bold">Cover Date:</dt>
+                    <dt class="has-text-weight-bold">{% trans "Cover Date:" %}</dt>
                     <dd class="mb-3">
                         <time datetime="{{ issue.cover_date|date:'Y-m-d' }}">{{ issue.cover_date|date:"SHORT_DATE_FORMAT" }}</time>
                     </dd>
                     {% if issue.store_date %}
-                        <dt class="has-text-weight-bold">In Store Date:</dt>
+                        <dt class="has-text-weight-bold">{% trans "In Store Date:" %}</dt>
                         <dd class="mb-3">
                             <time datetime="{{ issue.store_date|date:'Y-m-d' }}">{{ issue.store_date|date:"SHORT_DATE_FORMAT" }}</time>
                         </dd>
                     {% endif %}
                     {% if issue.foc_date %}
                         <dt class="has-text-weight-bold">
-                            <abbr title="Final Order Cutoff">FOC</abbr> Date:
+                            <abbr title="{% trans 'Final Order Cutoff' %}">FOC</abbr> {% trans "Date:" %}
                         </dt>
                         <dd class="mb-3">
                             <time datetime="{{ issue.foc_date|date:'Y-m-d' }}"
@@ -582,35 +588,35 @@
                         </dd>
                     {% endif %}
                     {% if issue.price %}
-                        <dt class="has-text-weight-bold">Cover Price:</dt>
+                        <dt class="has-text-weight-bold">{% trans "Cover Price:" %}</dt>
                         <dd class="mb-3">
                             {{ issue.price }}
                         </dd>
                     {% endif %}
                     {% if issue.page %}
-                        <dt class="has-text-weight-bold">Page Count:</dt>
+                        <dt class="has-text-weight-bold">{% trans "Page Count:" %}</dt>
                         <dd class="mb-3">
                             {{ issue.page|intcomma }}
                         </dd>
                     {% endif %}
-                    <dt class="has-text-weight-bold">Rating:</dt>
+                    <dt class="has-text-weight-bold">{% trans "Rating:" %}</dt>
                     <dd class="mb-3" title="{{ issue.rating.short_description }}">
                         {{ issue.rating.name }}
                     </dd>
                     {% if issue.sku %}
-                        <dt class="has-text-weight-bold">Distributor SKU:</dt>
+                        <dt class="has-text-weight-bold">{% trans "Distributor SKU:" %}</dt>
                         <dd class="mb-3">
                             {{ issue.sku }}
                         </dd>
                     {% endif %}
                     {% if issue.isbn %}
-                        <dt class="has-text-weight-bold">ISBN:</dt>
+                        <dt class="has-text-weight-bold">{% trans "ISBN:" %}</dt>
                         <dd class="mb-3">
                             {{ issue.isbn }}
                         </dd>
                     {% endif %}
                     {% if issue.upc %}
-                        <dt class="has-text-weight-bold">UPC:</dt>
+                        <dt class="has-text-weight-bold">{% trans "UPC:" %}</dt>
                         <dd class="mb-3">
                             {{ issue.upc }}
                         </dd>
@@ -619,7 +625,13 @@
                 {# Story Arcs #}
                 {% with arcs=issue.arcs.all %}
                     {% if arcs %}
-                        <h3 class="title is-6 mt-4">Story Arc{{ arcs|pluralize }}</h3>
+                        <h3 class="title is-6 mt-4">
+                            {% if arcs|length > 1 %}
+                                {% trans "Story Arcs" %}
+                            {% else %}
+                                {% trans "Story Arc" %}
+                            {% endif %}
+                        </h3>
                         <ul class="menu-list">
                             {% for arc in arcs %}
                                 <li>
@@ -633,21 +645,21 @@
                 {% include "partials/rating_widget.html" with rated_object=issue rate_url_name="issue-ratings:rate" rate_url_arg=issue.pk user_rating=user_rating average_rating=average_rating rating_count=rating_count show_ratings=True can_rate=can_rate %}
             </div>
             <div class="box">
-                <h2 class="title is-6">Identification Numbers</h2>
+                <h2 class="title is-6">{% trans "Identification Numbers" %}</h2>
                 <dl>
-                    <dt class="has-text-weight-bold">Metron:</dt>
+                    <dt class="has-text-weight-bold">{% trans "Metron:" %}</dt>
                     <dd class="mb-2 is-flex is-align-items-center is-justify-content-space-between">
                         <span class="is-family-monospace">{{ issue.id }}</span>
                         <button type="button"
                                 class="button is-small is-light copy-id"
                                 data-copy="{{ issue.id }}"
-                                title="Copy Metron ID"
-                                aria-label="Copy Metron ID">
+                                title="{% trans 'Copy Metron ID' %}"
+                                aria-label="{% trans 'Copy Metron ID' %}">
                             <span class="icon is-small"><i class="fas fa-copy"></i></span>
                         </button>
                     </dd>
                     {% if issue.cv_id %}
-                        <dt class="has-text-weight-bold">Comic Vine:</dt>
+                        <dt class="has-text-weight-bold">{% trans "Comic Vine:" %}</dt>
                         <dd class="mb-2 is-flex is-align-items-center is-justify-content-space-between">
                             <a class="is-family-monospace"
                                href="https://comicvine.gamespot.com/issue/4000-{{ issue.cv_id }}/"
@@ -659,15 +671,15 @@
                             <button type="button"
                                     class="button is-small is-light copy-id"
                                     data-copy="{{ issue.cv_id }}"
-                                    title="Copy Comic Vine ID"
-                                    aria-label="Copy Comic Vine ID">
+                                    title="{% trans 'Copy Comic Vine ID' %}"
+                                    aria-label="{% trans 'Copy Comic Vine ID' %}">
                                 <span class="icon is-small"><i class="fas fa-copy"></i></span>
                             </button>
                         </dd>
                     {% endif %}
                     {% if issue.gcd_id %}
                         <dt class="has-text-weight-bold">
-                            <abbr title="Grand Comics Database">GCD</abbr>:
+                            <abbr title="{% trans 'Grand Comics Database' %}">GCD</abbr>:
                         </dt>
                         <dd class="is-flex is-align-items-center is-justify-content-space-between">
                             <a class="is-family-monospace"
@@ -680,8 +692,8 @@
                             <button type="button"
                                     class="button is-small is-light copy-id"
                                     data-copy="{{ issue.gcd_id }}"
-                                    title="Copy GCD ID"
-                                    aria-label="Copy GCD ID">
+                                    title="{% trans 'Copy GCD ID' %}"
+                                    aria-label="{% trans 'Copy GCD ID' %}">
                                 <span class="icon is-small"><i class="fas fa-copy"></i></span>
                             </button>
                         </dd>

--- a/comicsdb/templates/comicsdb/issue_form.html
+++ b/comicsdb/templates/comicsdb/issue_form.html
@@ -1,8 +1,8 @@
 {% extends parent_template|default:"base.html" %}
-{% load static %}
+{% load i18n static %}
 {% load bulma_tags %}
 {% block title %}
-    Issue Form
+    {% trans "Issue Form" %}
 {% endblock title %}
 {% block headcss %}
     {{ form.media.css }}
@@ -18,33 +18,33 @@
         <!-- Sticky action bar — Save / Cancel always reachable + section nav -->
         <div class="usab-actionbar">
             <div class="usab-actionbar__top">
-                <h1 class="usab-actionbar__title">Issue Form</h1>
+                <h1 class="usab-actionbar__title">{% trans "Issue Form" %}</h1>
                 <div class="usab-actionbar__actions">
                     <button type="button" class="button" onclick="history.back()">
                         <span class="icon"><i class="fas fa-times"></i></span>
-                        <span>Cancel</span>
+                        <span>{% trans "Cancel" %}</span>
                     </button>
                     <button class="button is-info" type="submit">
                         <span class="icon"><i class="fas fa-check"></i></span>
-                        <span>Save Issue</span>
+                        <span>{% trans "Save Issue" %}</span>
                     </button>
                 </div>
             </div>
-            <nav class="usab-nav" aria-label="Form sections">
-                <a href="#section-primary" class="is-active">Primary</a>
-                <a href="#section-credits">Credits</a>
-                <a href="#section-variants">Variants</a>
-                <a href="#section-attribution">Attribution</a>
+            <nav class="usab-nav" aria-label="{% trans 'Form sections' %}">
+                <a href="#section-primary" class="is-active">{% trans "Primary" %}</a>
+                <a href="#section-credits">{% trans "Credits" %}</a>
+                <a href="#section-variants">{% trans "Variants" %}</a>
+                <a href="#section-attribution">{% trans "Attribution" %}</a>
             </nav>
         </div>
         <!-- Primary Information Section -->
         <div class="box" id="section-primary">
-            <h2 class="title is-5">Primary Information</h2>
+            <h2 class="title is-5">{% trans "Primary Information" %}</h2>
             {% include "comicsdb/partials/form_errors.html" with form=form %}
             {% for field in form.hidden_fields %}{{ field }}{% endfor %}
 
             <div class="usab-group">
-                <h3 class="usab-group-label">Identity</h3>
+                <h3 class="usab-group-label">{% trans "Identity" %}</h3>
                 <div class="columns is-multiline">
                     <div class="column is-full">{% include "comicsdb/partials/form_field.html" with field=form.series %}</div>
                     <div class="column is-half">{% include "comicsdb/partials/form_field.html" with field=form.number %}</div>
@@ -57,7 +57,7 @@
             </div>
 
             <div class="usab-group">
-                <h3 class="usab-group-label">Publication</h3>
+                <h3 class="usab-group-label">{% trans "Publication" %}</h3>
                 <div class="columns is-multiline">
                     <div class="column is-half">{% include "comicsdb/partials/form_field.html" with field=form.cover_date %}</div>
                     <div class="column is-half">{% include "comicsdb/partials/form_field.html" with field=form.store_date %}</div>
@@ -68,7 +68,7 @@
             </div>
 
             <div class="usab-group">
-                <h3 class="usab-group-label">Codes &amp; IDs</h3>
+                <h3 class="usab-group-label">{% trans "Codes & IDs" %}</h3>
                 <div class="columns is-multiline">
                     <div class="column is-half">{% include "comicsdb/partials/form_field.html" with field=form.sku %}</div>
                     <div class="column is-half">{% include "comicsdb/partials/form_field.html" with field=form.isbn %}</div>
@@ -79,12 +79,12 @@
             </div>
 
             <div class="usab-group">
-                <h3 class="usab-group-label">Cover Image</h3>
+                <h3 class="usab-group-label">{% trans "Cover Image" %}</h3>
                 {% include "comicsdb/partials/form_field.html" with field=form.image %}
             </div>
 
             <div class="usab-group">
-                <h3 class="usab-group-label">Relationships</h3>
+                <h3 class="usab-group-label">{% trans "Relationships" %}</h3>
                 {% include "comicsdb/partials/form_field.html" with field=form.characters %}
                 {% include "comicsdb/partials/form_field.html" with field=form.teams %}
                 {% include "comicsdb/partials/form_field.html" with field=form.arcs %}
@@ -94,17 +94,17 @@
         </div>
         <!-- Credits Section -->
         <div class="box" id="section-credits">
-            <h2 class="title is-5">Credits</h2>
+            <h2 class="title is-5">{% trans "Credits" %}</h2>
             {% include "comicsdb/partials/credits_formset.html" with formset=credits %}
         </div>
         <!-- Variant Covers Section -->
         <div class="box" id="section-variants">
-            <h2 class="title is-5">Variant Covers</h2>
+            <h2 class="title is-5">{% trans "Variant Covers" %}</h2>
             {% include "comicsdb/partials/variants_formset.html" with formset=variants %}
         </div>
         <!-- Attribution Section -->
         <div class="box" id="section-attribution">
-            <h2 class="title is-5">Attribution</h2>
+            <h2 class="title is-5">{% trans "Attribution" %}</h2>
             {% include "comicsdb/partials/attribution_formset.html" with formset=attribution %}
         </div>
     </form>

--- a/comicsdb/templates/comicsdb/issue_list.html
+++ b/comicsdb/templates/comicsdb/issue_list.html
@@ -1,15 +1,15 @@
 {% extends parent_template|default:"base.html" %}
 {% load humanize %}
-{% load static %}
+{% load i18n static %}
 {% block title %}
     {% if title %}{{ title }}{% endif %}
-    Issues - Metron
+    {% trans "Issues - Metron" %}
 {% endblock %}
 {% block content %}
     <header class="block has-text-centered">
         <h1 class="title">
             {% if title %}{{ title }}{% endif %}
-            Issues
+            {% trans "Issues" %}
         </h1>
     </header>
     <section class="section">
@@ -24,14 +24,14 @@
         <section class="section pt-0">
             <div class="container">
                 {# Navigation Bar #}
-                <nav class="level" aria-label="Issue list navigation">
+                <nav class="level" aria-label="{% trans 'Issue list navigation' %}">
                     <div class="level-left">
                         <div class="level-item">
                             <p class="subtitle is-5">
                                 {% if page_obj.paginator %}
-                                    <strong>{{ page_obj.paginator.count|intcomma }}</strong> Issue{{ page_obj.paginator.count|pluralize }}
+                                    {% blocktrans count counter=page_obj.paginator.count with counter_fmt=page_obj.paginator.count|intcomma %}<strong>{{ counter_fmt }}</strong> Issue{% plural %}<strong>{{ counter_fmt }}</strong> Issues{% endblocktrans %}
                                 {% else %}
-                                    <strong>{{ issue_list.count|intcomma }}</strong> Issue{{ issue_list.count|pluralize }}
+                                    {% blocktrans count counter=issue_list.count with counter_fmt=issue_list.count|intcomma %}<strong>{{ counter_fmt }}</strong> Issue{% plural %}<strong>{{ counter_fmt }}</strong> Issues{% endblocktrans %}
                                 {% endif %}
                             </p>
                         </div>
@@ -44,12 +44,12 @@
                             <div class="level-item">
                                 <a class="button is-primary"
                                    href="{% url 'issue:create' %}"
-                                   title="Add a new issue"
-                                   aria-label="Add a new issue">
+                                   title="{% trans 'Add a new issue' %}"
+                                   aria-label="{% trans 'Add a new issue' %}">
                                     <span class="icon is-small" aria-hidden="true">
                                         <i class="fas fa-plus"></i>
                                     </span>
-                                    <span>New</span>
+                                    <span>{% trans "New" %}</span>
                                 </a>
                             </div>
                         {% endif %}
@@ -63,14 +63,17 @@
         <section class="section pt-0">
             <div class="container has-text-centered">
                 {% if has_active_filters %}
-                    <p class="title is-4">No results found</p>
-                    <p class="subtitle">Try adjusting your search filters</p>
+                    <p class="title is-4">{% trans "No results found" %}</p>
+                    <p class="subtitle">{% trans "Try adjusting your search filters" %}</p>
                     <a href="{% url 'issue:list' %}" class="button is-light is-medium">
                         <span class="icon"><i class="fas fa-times"></i></span>
-                        <span>Clear All Filters</span>
+                        <span>{% trans "Clear All Filters" %}</span>
                     </a>
                 {% else %}
-                    {% include "comicsdb/partials/empty_state.html" with item_type="Issue" create_url="issue:create" create_title="Add a new issue" %}
+                    {% trans "Issue" as issue_label %}
+                    {% trans "Issues" as issue_label_plural %}
+                    {% trans "Add a new issue" as issue_create_title %}
+                    {% include "comicsdb/partials/empty_state.html" with item_type=issue_label item_type_plural=issue_label_plural create_url="issue:create" create_title=issue_create_title %}
                 {% endif %}
             </div>
         </section>

--- a/comicsdb/templates/comicsdb/model_with_attribution_form.html
+++ b/comicsdb/templates/comicsdb/model_with_attribution_form.html
@@ -1,8 +1,9 @@
 {% extends parent_template|default:"base.html" %}
-{% load static %}
+{% load i18n static %}
 {% load bulma_tags %}
 {% block title %}
-    {{ title|default:"Form" }}
+    {% trans "Form" as default_title %}
+    {{ title|default:default_title }}
 {% endblock title %}
 {% block headcss %}
     {{ form.media.css }}
@@ -13,31 +14,32 @@
           href="{% static 'site/css/issue-form-usability.css' %}">
 {% endblock %}
 {% block content %}
+    {% trans "Form" as default_title %}
     <form method="post" enctype="multipart/form-data" id="mainForm" novalidate>
         {% csrf_token %}
         <!-- Sticky action bar — Save / Cancel always reachable + section nav -->
         <div class="usab-actionbar">
             <div class="usab-actionbar__top">
-                <h1 class="usab-actionbar__title">{{ title|default:"Form" }}</h1>
+                <h1 class="usab-actionbar__title">{{ title|default:default_title }}</h1>
                 <div class="usab-actionbar__actions">
                     <button type="button" class="button" onclick="history.back()">
                         <span class="icon"><i class="fas fa-times"></i></span>
-                        <span>Cancel</span>
+                        <span>{% trans "Cancel" %}</span>
                     </button>
                     <button class="button is-info" type="submit">
                         <span class="icon"><i class="fas fa-check"></i></span>
-                        <span>Save</span>
+                        <span>{% trans "Save" %}</span>
                     </button>
                 </div>
             </div>
-            <nav class="usab-nav" aria-label="Form sections">
-                <a href="#section-primary" class="is-active">Primary</a>
-                <a href="#section-attribution">Attribution</a>
+            <nav class="usab-nav" aria-label="{% trans 'Form sections' %}">
+                <a href="#section-primary" class="is-active">{% trans "Primary" %}</a>
+                <a href="#section-attribution">{% trans "Attribution" %}</a>
             </nav>
         </div>
         <!-- Primary Information Section -->
         <div class="box" id="section-primary">
-            <h2 class="title is-5">Primary Information</h2>
+            <h2 class="title is-5">{% trans "Primary Information" %}</h2>
             {% include "comicsdb/partials/form_errors.html" with form=form %}
             {% for field in form.hidden_fields %}{{ field }}{% endfor %}
             {% for field in form.visible_fields %}
@@ -46,7 +48,7 @@
         </div>
         <!-- Attribution Section -->
         <div class="box" id="section-attribution">
-            <h2 class="title is-5">Attribution</h2>
+            <h2 class="title is-5">{% trans "Attribution" %}</h2>
             {% include "comicsdb/partials/attribution_formset.html" with formset=attribution %}
         </div>
     </form>

--- a/comicsdb/templates/comicsdb/partials/active_filters.html
+++ b/comicsdb/templates/comicsdb/partials/active_filters.html
@@ -1,3 +1,4 @@
+{% load i18n %}
 {% comment %}
    active-filter chip bar.
    Renders only when `active_filters` is non-empty (the including template guards
@@ -9,7 +10,7 @@
 {% endcomment %}
 <div class="field is-grouped is-grouped-multiline is-align-items-center mb-0">
     <div class="control">
-        <span class="is-size-7 has-text-grey has-text-weight-semibold">Active filters:</span>
+        <span class="is-size-7 has-text-grey has-text-weight-semibold">{% trans "Active filters:" %}</span>
     </div>
     {% for chip in active_filters %}
         <div class="control">
@@ -19,12 +20,12 @@
                 </span>
                 <a class="tag is-delete"
                    href="{{ chip.remove_url }}"
-                   title="Remove {{ chip.label }} filter"
-                   aria-label="Remove {{ chip.label }} filter"></a>
+                   title="{% blocktrans with chip_label=chip.label %}Remove {{ chip_label }} filter{% endblocktrans %}"
+                   aria-label="{% blocktrans with chip_label=chip.label %}Remove {{ chip_label }} filter{% endblocktrans %}"></a>
             </div>
         </div>
     {% endfor %}
     <div class="control">
-        <a class="is-size-7" href="{{ request.path }}">Clear all</a>
+        <a class="is-size-7" href="{{ request.path }}">{% trans "Clear all" %}</a>
     </div>
 </div>

--- a/comicsdb/templates/comicsdb/partials/arc_issue_items.html
+++ b/comicsdb/templates/comicsdb/partials/arc_issue_items.html
@@ -1,3 +1,4 @@
+{% load i18n %}
 {% for issue in issues %}
     <li>
         <a href="{% url 'issue:detail' issue.slug %}">{{ issue }}</a>
@@ -13,7 +14,7 @@
                 hx-target="#issues-list"
                 hx-swap="beforeend"
                 hx-indicator="#issues-spinner">
-            <span>Load More Issues</span>
+            <span>{% trans "Load More Issues" %}</span>
         </button>
         <span id="issues-spinner" class="htmx-indicator ml-2">
             <i class="fas fa-spinner fa-spin"></i>

--- a/comicsdb/templates/comicsdb/partials/attribution_formset.html
+++ b/comicsdb/templates/comicsdb/partials/attribution_formset.html
@@ -1,4 +1,4 @@
-{% load bulma_tags %}
+{% load bulma_tags i18n %}
 {% comment %}
     Attribution formset table
     Usage: {% include "comicsdb/partials/attribution_formset.html" with formset=attribution %}
@@ -13,9 +13,9 @@
     {% endif %}
     <thead>
         <tr>
-            <th scope="col">Source</th>
-            <th scope="col">URL</th>
-            <th scope="col" class="has-text-centered" style="width: 80px;">Delete</th>
+            <th scope="col">{% trans "Source" %}</th>
+            <th scope="col">{% trans "URL" %}</th>
+            <th scope="col" class="has-text-centered" style="width: 80px;">{% trans "Delete" %}</th>
         </tr>
     </thead>
     <tbody id="attributionTableBody">
@@ -62,7 +62,7 @@
                         <button type="button"
                                 class="button is-small is-danger delete-row"
                                 onclick="const checkbox = this.parentElement.querySelector('input[type=checkbox]'); checkbox.checked = !checkbox.checked; const row = this.closest('tr'); row.style.opacity = checkbox.checked ? '0.5' : '1'; row.style.textDecoration = checkbox.checked ? 'line-through' : 'none';"
-                                title="Mark for deletion">
+                                title="{% trans 'Mark for deletion' %}">
                             <span class="icon is-small">
                                 <i class="fas fa-times"></i>
                             </span>
@@ -72,7 +72,7 @@
                         <button type="button"
                                 class="button is-small is-danger delete-row"
                                 onclick="this.closest('tr').remove(); updateFormsetManagement('attribution');"
-                                title="Remove this row">
+                                title="{% trans 'Remove this row' %}">
                             <span class="icon is-small">
                                 <i class="fas fa-times"></i>
                             </span>
@@ -93,5 +93,5 @@
     <span class="icon">
         <i class="fas fa-plus"></i>
     </span>
-    <span>Add another attribution</span>
+    <span>{% trans "Add another attribution" %}</span>
 </button>

--- a/comicsdb/templates/comicsdb/partials/attribution_formset_row.html
+++ b/comicsdb/templates/comicsdb/partials/attribution_formset_row.html
@@ -1,4 +1,4 @@
-{% load bulma_tags %}
+{% load bulma_tags i18n %}
 <tr class="formset-row">
     {% for field in form.visible_fields %}
         {% if field.name != 'DELETE' %}
@@ -38,7 +38,7 @@
         <button type="button"
                 class="button is-small is-danger delete-row"
                 onclick="this.closest('tr').remove(); updateFormsetManagement('attribution');"
-                title="Remove this row">
+                title="{% trans 'Remove this row' %}">
             <span class="icon is-small">
                 <i class="fas fa-times"></i>
             </span>

--- a/comicsdb/templates/comicsdb/partials/card_grid.html
+++ b/comicsdb/templates/comicsdb/partials/card_grid.html
@@ -1,20 +1,22 @@
 {% load thumbnail %}
 {% load static %}
 {% load humanize %}
+{% load i18n %}
 {% comment %}
     Reusable card grid for displaying items with images
     Usage: {% include "comicsdb/partials/card_grid.html" with items=character_list ... %}
-    
+
     Required parameters:
     - items: List of items to display
     - detail_url_name: URL name for detail view (e.g., "character:detail")
     - image_ratio: Image aspect ratio class (e.g., "is-2by3", "is-square")
     - default_image: Path to default image if item has no image
-    
+
     Optional parameters:
     - count_type: Which count to display - "issue" or "series" (default: "issue")
     - count_url_name: URL name for count/list view (e.g., "character:issue")
-    - count_label: Label for count (e.g., "Issue", "Series")
+    - count_label: Singular label for count (e.g., "Issue", "Series")
+    - count_label_plural: Plural label for count (e.g., "Issues", "Series")
     - show_count: Boolean to show/hide count footer (default: True)
 {% endcomment %}
 <div class="columns is-multiline">
@@ -29,7 +31,7 @@
                 <div class="card-image">
                     <figure class="image {{ image_ratio }}">
                         <a href="{% url detail_url_name item.slug %}"
-                           aria-label="View details for {{ item }}">
+                           aria-label="{% blocktrans %}View details for {{ item }}{% endblocktrans %}">
                             {% if item.image %}
                                 {# Use different thumbnail sizes and crop based on ratio #}
                                 {% if image_ratio == "is-square" %}
@@ -52,7 +54,7 @@
                                 {% endif %}
                             {% else %}
                                 <img src="{% static default_image %}"
-                                     alt="No image available for {{ item.name }}"
+                                     alt="{% blocktrans %}No image available for {{ item.name }}{% endblocktrans %}"
                                      loading="lazy">
                             {% endif %}
                         </a>
@@ -64,28 +66,12 @@
                         {# Determine which count to use based on count_type parameter #}
                         {% if count_type == "series" %}
                             {% with count=item.series_count %}
-                                {% if count and count_url_name %}
-                                    <a href="{% url count_url_name item.slug %}"
-                                       class="card-footer-item is-size-7 has-text-weight-semibold"
-                                       aria-label="{{ count }} {{ count_label }} for {{ item }}">
-                                        {{ count|intcomma }} {{ count_label }}
-                                    </a>
-                                {% else %}
-                                    <span class="card-footer-item is-size-7" aria-label="No {{ count_label|lower }}s">0 {{ count_label }}s</span>
-                                {% endif %}
+                                {% include "comicsdb/partials/card_grid_count.html" %}
                             {% endwith %}
                         {% else %}
                             {# Default to issue_count #}
                             {% with count=item.issue_count %}
-                                {% if count and count_url_name %}
-                                    <a href="{% url count_url_name item.slug %}"
-                                       class="card-footer-item is-size-7 has-text-weight-semibold"
-                                       aria-label="{{ count }} {{ count_label }}{{ count|pluralize }} for {{ item }}">
-                                        {{ count|intcomma }} {{ count_label }}{{ count|pluralize }}
-                                    </a>
-                                {% else %}
-                                    <span class="card-footer-item is-size-7" aria-label="No {{ count_label|lower }}s">0 {{ count_label }}s</span>
-                                {% endif %}
+                                {% include "comicsdb/partials/card_grid_count.html" %}
                             {% endwith %}
                         {% endif %}
                     {% endif %}

--- a/comicsdb/templates/comicsdb/partials/card_grid_count.html
+++ b/comicsdb/templates/comicsdb/partials/card_grid_count.html
@@ -1,0 +1,27 @@
+{% load i18n humanize %}
+{% comment %}
+    Renders the count footer link/span for card_grid.html.
+    Requires: count, count_url_name, item, count_label, count_label_plural
+    (all inherited from the including template's context).
+{% endcomment %}
+{% if count and count_url_name %}
+    {% if count == 1 %}
+        {% with label=count_label %}
+            <a href="{% url count_url_name item.slug %}"
+               class="card-footer-item is-size-7 has-text-weight-semibold"
+               aria-label="{% blocktrans with c=count|intcomma %}{{ c }} {{ label }} for {{ item }}{% endblocktrans %}">
+                {{ count|intcomma }} {{ label }}
+            </a>
+        {% endwith %}
+    {% else %}
+        {% with label=count_label_plural %}
+            <a href="{% url count_url_name item.slug %}"
+               class="card-footer-item is-size-7 has-text-weight-semibold"
+               aria-label="{% blocktrans with c=count|intcomma %}{{ c }} {{ label }} for {{ item }}{% endblocktrans %}">
+                {{ count|intcomma }} {{ label }}
+            </a>
+        {% endwith %}
+    {% endif %}
+{% else %}
+    <span class="card-footer-item is-size-7" aria-label="{% blocktrans %}No {{ count_label_plural }}{% endblocktrans %}">{% blocktrans %}0 {{ count_label_plural }}{% endblocktrans %}</span>
+{% endif %}

--- a/comicsdb/templates/comicsdb/partials/character_series_items.html
+++ b/comicsdb/templates/comicsdb/partials/character_series_items.html
@@ -1,3 +1,4 @@
+{% load i18n %}
 {% for series in appearances %}
     <li>
         <a href="{% url 'series:detail' slug=series.issues__series__slug %}">
@@ -9,12 +10,12 @@
             {% elif series.issues__series__series_type == 8 %}
                 HC
             {% elif series.issues__series__series_type == 12 %}
-                Digital
+                {% trans "Digital" %}
             {% endif %}
             ({{ series.issues__series__year_began }})
         </a>:
         <a href="{% url 'character:series' character=character_slug series=series.issues__series__slug %}">
-            {{ series.issues__count }} issue{{ series.issues__count|pluralize }}
+            {% blocktrans count counter=series.issues__count %}{{ counter }} issue{% plural %}{{ counter }} issues{% endblocktrans %}
         </a>
     </li>
 {% endfor %}
@@ -27,7 +28,7 @@
                 hx-target="#series-list"
                 hx-swap="beforeend"
                 hx-indicator="#series-spinner">
-            <span>Load More Series</span>
+            <span>{% trans "Load More Series" %}</span>
         </button>
         <span id="series-spinner" class="htmx-indicator ml-2">
             <i class="fas fa-spinner fa-spin"></i>

--- a/comicsdb/templates/comicsdb/partials/creator_series_items.html
+++ b/comicsdb/templates/comicsdb/partials/creator_series_items.html
@@ -1,3 +1,4 @@
+{% load i18n %}
 {% for series in credits %}
     <li>
         <a href="{% url 'series:detail' slug=series.issue__series__slug %}">
@@ -9,12 +10,12 @@
             {% elif series.issue__series__series_type == 8 %}
                 HC
             {% elif series.issue__series__series_type == 12 %}
-                Digital
+                {% trans "Digital" %}
             {% endif %}
             ({{ series.issue__series__year_began }})
         </a>:
         <a href="{% url 'creator:series' creator=creator_slug series=series.issue__series__slug %}">
-            {{ series.issue__count }} issue{{ series.issue__count|pluralize }}
+            {% blocktrans count counter=series.issue__count %}{{ counter }} issue{% plural %}{{ counter }} issues{% endblocktrans %}
         </a>
     </li>
 {% endfor %}
@@ -27,7 +28,7 @@
                 hx-target="#series-list"
                 hx-swap="beforeend"
                 hx-indicator="#series-spinner">
-            <span>Load More Series</span>
+            <span>{% trans "Load More Series" %}</span>
         </button>
         <span id="series-spinner" class="htmx-indicator ml-2">
             <i class="fas fa-spinner fa-spin"></i>

--- a/comicsdb/templates/comicsdb/partials/credits_formset.html
+++ b/comicsdb/templates/comicsdb/partials/credits_formset.html
@@ -1,4 +1,4 @@
-{% load bulma_tags %}
+{% load bulma_tags i18n %}
 {% comment %}
     Credits formset table
     Usage: {% include "comicsdb/partials/credits_formset.html" with formset=credits %}
@@ -13,9 +13,9 @@
     {% endif %}
     <thead>
         <tr>
-            <th scope="col">Creator</th>
-            <th scope="col">Role</th>
-            <th scope="col" class="has-text-centered" style="width: 80px;">Delete</th>
+            <th scope="col">{% trans "Creator" %}</th>
+            <th scope="col">{% trans "Role" %}</th>
+            <th scope="col" class="has-text-centered" style="width: 80px;">{% trans "Delete" %}</th>
         </tr>
     </thead>
     <tbody id="creditsTableBody">
@@ -60,7 +60,7 @@
                         <button type="button"
                                 class="button is-small is-danger delete-row"
                                 onclick="const checkbox = this.parentElement.querySelector('input[type=checkbox]'); checkbox.checked = !checkbox.checked; const row = this.closest('tr'); row.style.opacity = checkbox.checked ? '0.5' : '1'; row.style.textDecoration = checkbox.checked ? 'line-through' : 'none';"
-                                title="Mark for deletion">
+                                title="{% trans 'Mark for deletion' %}">
                             <span class="icon is-small">
                                 <i class="fas fa-times"></i>
                             </span>
@@ -70,7 +70,7 @@
                         <button type="button"
                                 class="button is-small is-danger delete-row"
                                 onclick="this.closest('tr').remove(); updateFormsetManagement('credits');"
-                                title="Remove this row">
+                                title="{% trans 'Remove this row' %}">
                             <span class="icon is-small">
                                 <i class="fas fa-times"></i>
                             </span>
@@ -91,5 +91,5 @@
     <span class="icon">
         <i class="fas fa-plus"></i>
     </span>
-    <span>Add another creator credit</span>
+    <span>{% trans "Add another creator credit" %}</span>
 </button>

--- a/comicsdb/templates/comicsdb/partials/credits_formset_row.html
+++ b/comicsdb/templates/comicsdb/partials/credits_formset_row.html
@@ -1,4 +1,4 @@
-{% load bulma_tags %}
+{% load bulma_tags i18n %}
 <tr class="formset-row">
     {% for field in form.visible_fields %}
         {% if field.name != 'DELETE' %}
@@ -36,7 +36,7 @@
         <button type="button"
                 class="button is-small is-danger delete-row"
                 onclick="this.closest('tr').remove(); updateFormsetManagement('credits');"
-                title="Remove this row">
+                title="{% trans 'Remove this row' %}">
             <span class="icon is-small">
                 <i class="fas fa-times"></i>
             </span>

--- a/comicsdb/templates/comicsdb/partials/empty_state.html
+++ b/comicsdb/templates/comicsdb/partials/empty_state.html
@@ -1,9 +1,11 @@
+{% load i18n %}
 {% comment %}
     Empty state message with optional create button
     Usage: {% include "comicsdb/partials/empty_state.html" with item_type="Character" ... %}
-    
+
     Parameters:
-    - item_type: Type of item (e.g., "Character", "Publisher")
+    - item_type: Type of item, singular (e.g., "Character", "Publisher")
+    - item_type_plural: Type of item, plural (e.g., "Characters", "Publishers")
     - create_url: URL name for create action (optional)
     - create_title: Title for create button
 {% endcomment %}
@@ -14,17 +16,12 @@
                 <span class="icon is-large has-text-grey-light" aria-hidden="true">
                     <i class="fas fa-inbox fa-3x"></i>
                 </span>
-                <h2 class="title is-4">
-                    No {{ item_type }}{% if item_type|lower != "series" %}s{% endif %}
-                    Available
-                </h2>
+                <h2 class="title is-4">{% blocktrans %}No {{ item_type_plural }} Available{% endblocktrans %}</h2>
                 <p class="subtitle is-6 has-text-grey">
                     {% if user.is_authenticated and create_url %}
-                        Get started by creating your first {{ item_type|lower }}.
+                        {% blocktrans with item_type_lower=item_type|lower %}Get started by creating your first {{ item_type_lower }}.{% endblocktrans %}
                     {% else %}
-                        No {{ item_type|lower }}
-                        {% if item_type|lower != "series" %}s{% endif %}
-                        have been added yet.
+                        {% blocktrans %}No {{ item_type_plural }} have been added yet.{% endblocktrans %}
                     {% endif %}
                 </p>
                 {% if user.is_authenticated and create_url %}
@@ -35,7 +32,7 @@
                         <span class="icon" aria-hidden="true">
                             <i class="fas fa-plus"></i>
                         </span>
-                        <span>Create {{ item_type }}</span>
+                        <span>{% blocktrans %}Create {{ item_type }}{% endblocktrans %}</span>
                     </a>
                 {% endif %}
             </div>

--- a/comicsdb/templates/comicsdb/partials/issue_card_grid.html
+++ b/comicsdb/templates/comicsdb/partials/issue_card_grid.html
@@ -1,6 +1,7 @@
 {% load thumbnail %}
 {% load static %}
 {% load is_new %}
+{% load i18n %}
 {% comment %}
     Issue-specific card grid with "New!" tags, publisher, and cover date.
     Usage: {% include "comicsdb/partials/issue_card_grid.html" with items=issue_list %}
@@ -20,7 +21,7 @@
                         <h2 id="card-title-{{ issue.slug }}"
                             class="card-header-title is-centered">
                             {{ issue }}
-                            {% if is_new %}&nbsp;<span class="tag is-primary is-rounded" aria-label="Recently added">New!</span>{% endif %}
+                            {% if is_new %}&nbsp;<span class="tag is-primary is-rounded" aria-label="{% trans 'Recently added' %}">{% trans "New!" %}</span>{% endif %}
                         </h2>
                     {% endwith %}
                 </header>
@@ -30,7 +31,7 @@
                         {% thumbnail issue.image "320x480" format="WEBP" as im %}
                             <figure class="image {% if im.width > im.height %}is-3by2{% else %}is-2by3{% endif %}">
                                 <a href="{% url 'issue:detail' issue.slug %}"
-                                   aria-label="View details for {{ issue }}">
+                                   aria-label="{% blocktrans %}View details for {{ issue }}{% endblocktrans %}">
                                     <img src="{{ im.url }}"
                                          width="{{ im.width }}"
                                          height="{{ im.height }}"
@@ -42,9 +43,9 @@
                     {% else %}
                         <figure class="image is-2by3">
                             <a href="{% url 'issue:detail' issue.slug %}"
-                               aria-label="View details for {{ issue }}">
+                               aria-label="{% blocktrans %}View details for {{ issue }}{% endblocktrans %}">
                                 <img src="{% static 'site/img/image-not-found.webp' %}"
-                                     alt="No image available for {{ issue }}"
+                                     alt="{% blocktrans %}No image available for {{ issue }}{% endblocktrans %}"
                                      loading="lazy">
                             </a>
                         </figure>

--- a/comicsdb/templates/comicsdb/partials/issue_character_items.html
+++ b/comicsdb/templates/comicsdb/partials/issue_character_items.html
@@ -1,5 +1,5 @@
 {% load thumbnail %}
-{% load static %}
+{% load i18n static %}
 {% for character in characters %}
     <div class="column is-4">
         <article class="media">
@@ -17,7 +17,7 @@
                     {% else %}
                         <img class="is-rounded"
                              src="{% static 'site/img/creator-not-found.webp' %}"
-                             alt="No image for {{ character }}"
+                             alt="{% blocktrans %}No image for {{ character }}{% endblocktrans %}"
                              loading="lazy">
                     {% endif %}
                 </div>
@@ -37,7 +37,7 @@
                 hx-target="#characters-container"
                 hx-swap="beforeend"
                 hx-indicator="#characters-spinner">
-            <span>Load More Characters</span>
+            <span>{% trans "Load More Characters" %}</span>
         </button>
         <span id="characters-spinner" class="htmx-indicator ml-2">
             <i class="fas fa-spinner fa-spin"></i>

--- a/comicsdb/templates/comicsdb/partials/issue_credit_items.html
+++ b/comicsdb/templates/comicsdb/partials/issue_credit_items.html
@@ -1,5 +1,5 @@
 {% load thumbnail %}
-{% load static %}
+{% load i18n static %}
 {% for credit in credits %}
     <div class="column is-4">
         <article class="media">
@@ -17,7 +17,7 @@
                     {% else %}
                         <img class="is-rounded"
                              src="{% static 'site/img/creator-not-found.webp' %}"
-                             alt="No image for {{ credit.creator }}"
+                             alt="{% blocktrans %}No image for {{ credit.creator }}{% endblocktrans %}"
                              loading="lazy">
                     {% endif %}
                 </div>
@@ -47,7 +47,7 @@
                 hx-target="#credits-container"
                 hx-swap="beforeend"
                 hx-indicator="#credits-spinner">
-            <span>Load More Credits</span>
+            <span>{% trans "Load More Credits" %}</span>
         </button>
         <span id="credits-spinner" class="htmx-indicator ml-2">
             <i class="fas fa-spinner fa-spin"></i>

--- a/comicsdb/templates/comicsdb/partials/issue_filter.html
+++ b/comicsdb/templates/comicsdb/partials/issue_filter.html
@@ -1,4 +1,4 @@
-{% load range_tags %}
+{% load i18n range_tags %}
 {% comment %}
     USABILITY CHANGE: the ~14 advanced filter fields are now organised
     under labelled sub-sections (Series / Issue Numbers / Dates / Codes & IDs)
@@ -13,7 +13,7 @@
                     <span class="icon has-text-link">
                         <i class="fas fa-search"></i>
                     </span>
-                    <span>Search Issues</span>
+                    <span>{% trans "Search Issues" %}</span>
                 </span>
             </h2>
             {% if has_active_filters %}
@@ -21,26 +21,26 @@
                     <span class="icon">
                         <i class="fas fa-filter"></i>
                     </span>
-                    <span>Filters Active</span>
+                    <span>{% trans "Filters Active" %}</span>
                 </span>
             {% endif %}
         </div>
         {# Quick Search Field #}
         <div class="field">
-            <label class="label" for="q">Quick Search</label>
+            <label class="label" for="q">{% trans "Quick Search" %}</label>
             <div class="control has-icons-left">
                 <input class="input"
                        type="text"
                        id="q"
                        name="q"
                        value="{{ request.GET.q }}"
-                       placeholder="Search by series name..."
-                       aria-label="Quick search">
+                       placeholder="{% trans 'Search by series name...' %}"
+                       aria-label="{% trans 'Quick search' %}">
                 <span class="icon is-small is-left">
                     <i class="fas fa-search"></i>
                 </span>
             </div>
-            <p class="help">Search series names (supports multi-word search)</p>
+            <p class="help">{% trans "Search series names (supports multi-word search)" %}</p>
         </div>
         {# Collapsible Advanced Filters #}
         <details>
@@ -49,25 +49,25 @@
                     <span class="icon">
                         <i class="fas fa-sliders-h"></i>
                     </span>
-                    <span>Advanced Filters</span>
+                    <span>{% trans "Advanced Filters" %}</span>
                 </span>
             </summary>
 
             {# ── Group: Series ───────────────────────────────────────────── #}
-            <h4 class="title is-6 has-text-grey mt-4 mb-3">Series</h4>
+            <h4 class="title is-6 has-text-grey mt-4 mb-3">{% trans "Series" %}</h4>
             <div class="columns is-multiline">
                 {# Series Name Filter #}
                 <div class="column is-half">
                     <div class="field">
-                        <label class="label" for="series_name">Series Name</label>
+                        <label class="label" for="series_name">{% trans "Series Name" %}</label>
                         <div class="control has-icons-left">
                             <input class="input"
                                    type="text"
                                    id="series_name"
                                    name="series_name"
                                    value="{{ request.GET.series_name }}"
-                                   placeholder="e.g., Amazing Spider-Man"
-                                   aria-label="Filter by series name">
+                                   placeholder="{% trans 'e.g., Amazing Spider-Man' %}"
+                                   aria-label="{% trans 'Filter by series name' %}">
                             <span class="icon is-small is-left">
                                 <i class="fas fa-archive"></i>
                             </span>
@@ -77,13 +77,13 @@
                 {# Series Type Filter #}
                 <div class="column is-half">
                     <div class="field">
-                        <label class="label" for="series_type">Series Type</label>
+                        <label class="label" for="series_type">{% trans "Series Type" %}</label>
                         <div class="control has-icons-left">
                             <div class="select is-fullwidth">
                                 <select id="series_type"
                                         name="series_type"
-                                        aria-label="Filter by series type">
-                                    <option value="">All Types</option>
+                                        aria-label="{% trans 'Filter by series type' %}">
+                                    <option value="">{% trans "All Types" %}</option>
                                     {% for type in series_type %}
                                         <option value="{{ type.id }}"
                                                 {% if request.GET.series_type == type.id|stringformat:"s" %}selected{% endif %}>
@@ -101,15 +101,15 @@
                 {# Series Volume Filter #}
                 <div class="column is-half">
                     <div class="field">
-                        <label class="label" for="series_volume">Series Volume</label>
+                        <label class="label" for="series_volume">{% trans "Series Volume" %}</label>
                         <div class="control has-icons-left">
                             <input class="input"
                                    type="number"
                                    id="series_volume"
                                    name="series_volume"
                                    value="{{ request.GET.series_volume }}"
-                                   placeholder="e.g., 1"
-                                   aria-label="Filter by series volume">
+                                   placeholder="{% trans 'e.g., 1' %}"
+                                   aria-label="{% trans 'Filter by series volume' %}">
                             <span class="icon is-small is-left">
                                 <i class="fas fa-layer-group"></i>
                             </span>
@@ -119,15 +119,15 @@
                 {# Publisher Filter #}
                 <div class="column is-half">
                     <div class="field">
-                        <label class="label" for="publisher_name">Publisher</label>
+                        <label class="label" for="publisher_name">{% trans "Publisher" %}</label>
                         <div class="control has-icons-left">
                             <input class="input"
                                    type="text"
                                    id="publisher_name"
                                    name="publisher_name"
                                    value="{{ request.GET.publisher_name }}"
-                                   placeholder="e.g., Marvel"
-                                   aria-label="Filter by publisher">
+                                   placeholder="{% trans 'e.g., Marvel' %}"
+                                   aria-label="{% trans 'Filter by publisher' %}">
                             <span class="icon is-small is-left">
                                 <i class="fas fa-building"></i>
                             </span>
@@ -137,20 +137,20 @@
             </div>
 
             {# ── Group: Issue Numbers ────────────────────────────────────── #}
-            <h4 class="title is-6 has-text-grey mt-4 mb-3">Issue Numbers</h4>
+            <h4 class="title is-6 has-text-grey mt-4 mb-3">{% trans "Issue Numbers" %}</h4>
             <div class="columns is-multiline">
                 {# Issue Number Filter #}
                 <div class="column is-half">
                     <div class="field">
-                        <label class="label" for="number">Issue Number</label>
+                        <label class="label" for="number">{% trans "Issue Number" %}</label>
                         <div class="control has-icons-left">
                             <input class="input"
                                    type="text"
                                    id="number"
                                    name="number"
                                    value="{{ request.GET.number }}"
-                                   placeholder="e.g., 1"
-                                   aria-label="Filter by issue number">
+                                   placeholder="{% trans 'e.g., 1' %}"
+                                   aria-label="{% trans 'Filter by issue number' %}">
                             <span class="icon is-small is-left">
                                 <i class="fas fa-hashtag"></i>
                             </span>
@@ -160,15 +160,15 @@
                 {# Alternative Number Filter #}
                 <div class="column is-half">
                     <div class="field">
-                        <label class="label" for="alt_number">Alternative Number</label>
+                        <label class="label" for="alt_number">{% trans "Alternative Number" %}</label>
                         <div class="control has-icons-left">
                             <input class="input"
                                    type="text"
                                    id="alt_number"
                                    name="alt_number"
                                    value="{{ request.GET.alt_number }}"
-                                   placeholder="e.g., 616"
-                                   aria-label="Filter by alternative number">
+                                   placeholder="{% trans 'e.g., 616' %}"
+                                   aria-label="{% trans 'Filter by alternative number' %}">
                             <span class="icon is-small is-left">
                                 <i class="fas fa-sort-numeric-down"></i>
                             </span>
@@ -178,16 +178,16 @@
             </div>
 
             {# ── Group: Dates ────────────────────────────────────────────── #}
-            <h4 class="title is-6 has-text-grey mt-4 mb-3">Dates</h4>
+            <h4 class="title is-6 has-text-grey mt-4 mb-3">{% trans "Dates" %}</h4>
             <div class="columns is-multiline">
                 {# Cover Year Filter #}
                 <div class="column is-half">
                     <div class="field">
-                        <label class="label" for="cover_year">Cover Year</label>
+                        <label class="label" for="cover_year">{% trans "Cover Year" %}</label>
                         <div class="control has-icons-left">
                             <div class="select is-fullwidth">
-                                <select id="cover_year" name="cover_year" aria-label="Filter by cover year">
-                                    <option value="">All Years</option>
+                                <select id="cover_year" name="cover_year" aria-label="{% trans 'Filter by cover year' %}">
+                                    <option value="">{% trans "All Years" %}</option>
                                     {% now "m" as current_month %}
                                     {% now "Y" as current_year %}
                                     {% if current_month >= '10' %}
@@ -215,33 +215,33 @@
                 {# Cover Month Filter #}
                 <div class="column is-half">
                     <div class="field">
-                        <label class="label" for="cover_month">Cover Month</label>
+                        <label class="label" for="cover_month">{% trans "Cover Month" %}</label>
                         <div class="control has-icons-left">
                             <div class="select is-fullwidth">
                                 <select id="cover_month"
                                         name="cover_month"
-                                        aria-label="Filter by cover month">
-                                    <option value="">All Months</option>
-                                    <option value="1" {% if request.GET.cover_month == "1" %}selected{% endif %}>January</option>
-                                    <option value="2" {% if request.GET.cover_month == "2" %}selected{% endif %}>February</option>
-                                    <option value="3" {% if request.GET.cover_month == "3" %}selected{% endif %}>March</option>
-                                    <option value="4" {% if request.GET.cover_month == "4" %}selected{% endif %}>April</option>
-                                    <option value="5" {% if request.GET.cover_month == "5" %}selected{% endif %}>May</option>
-                                    <option value="6" {% if request.GET.cover_month == "6" %}selected{% endif %}>June</option>
-                                    <option value="7" {% if request.GET.cover_month == "7" %}selected{% endif %}>July</option>
-                                    <option value="8" {% if request.GET.cover_month == "8" %}selected{% endif %}>August</option>
-                                    <option value="9" {% if request.GET.cover_month == "9" %}selected{% endif %}>September</option>
+                                        aria-label="{% trans 'Filter by cover month' %}">
+                                    <option value="">{% trans "All Months" %}</option>
+                                    <option value="1" {% if request.GET.cover_month == "1" %}selected{% endif %}>{% trans "January" %}</option>
+                                    <option value="2" {% if request.GET.cover_month == "2" %}selected{% endif %}>{% trans "February" %}</option>
+                                    <option value="3" {% if request.GET.cover_month == "3" %}selected{% endif %}>{% trans "March" %}</option>
+                                    <option value="4" {% if request.GET.cover_month == "4" %}selected{% endif %}>{% trans "April" %}</option>
+                                    <option value="5" {% if request.GET.cover_month == "5" %}selected{% endif %}>{% trans "May" %}</option>
+                                    <option value="6" {% if request.GET.cover_month == "6" %}selected{% endif %}>{% trans "June" %}</option>
+                                    <option value="7" {% if request.GET.cover_month == "7" %}selected{% endif %}>{% trans "July" %}</option>
+                                    <option value="8" {% if request.GET.cover_month == "8" %}selected{% endif %}>{% trans "August" %}</option>
+                                    <option value="9" {% if request.GET.cover_month == "9" %}selected{% endif %}>{% trans "September" %}</option>
                                     <option value="10"
                                             {% if request.GET.cover_month == "10" %}selected{% endif %}>
-                                        October
+                                        {% trans "October" %}
                                     </option>
                                     <option value="11"
                                             {% if request.GET.cover_month == "11" %}selected{% endif %}>
-                                        November
+                                        {% trans "November" %}
                                     </option>
                                     <option value="12"
                                             {% if request.GET.cover_month == "12" %}selected{% endif %}>
-                                        December
+                                        {% trans "December" %}
                                     </option>
                                 </select>
                             </div>
@@ -254,14 +254,14 @@
                 {# Store Date From Filter #}
                 <div class="column is-half">
                     <div class="field">
-                        <label class="label" for="store_date_after">Store Date From</label>
+                        <label class="label" for="store_date_after">{% trans "Store Date From" %}</label>
                         <div class="control has-icons-left">
                             <input class="input"
                                    type="date"
                                    id="store_date_after"
                                    name="store_date_after"
                                    value="{{ request.GET.store_date_after }}"
-                                   aria-label="Filter by store date from">
+                                   aria-label="{% trans 'Filter by store date from' %}">
                             <span class="icon is-small is-left">
                                 <i class="fas fa-calendar"></i>
                             </span>
@@ -271,14 +271,14 @@
                 {# Store Date To Filter #}
                 <div class="column is-half">
                     <div class="field">
-                        <label class="label" for="store_date_before">Store Date To</label>
+                        <label class="label" for="store_date_before">{% trans "Store Date To" %}</label>
                         <div class="control has-icons-left">
                             <input class="input"
                                    type="date"
                                    id="store_date_before"
                                    name="store_date_before"
                                    value="{{ request.GET.store_date_before }}"
-                                   aria-label="Filter by store date to">
+                                   aria-label="{% trans 'Filter by store date to' %}">
                             <span class="icon is-small is-left">
                                 <i class="fas fa-calendar"></i>
                             </span>
@@ -288,14 +288,14 @@
                 {# FOC Date From Filter #}
                 <div class="column is-half">
                     <div class="field">
-                        <label class="label" for="foc_date_after">FOC Date From</label>
+                        <label class="label" for="foc_date_after">{% trans "FOC Date From" %}</label>
                         <div class="control has-icons-left">
                             <input class="input"
                                    type="date"
                                    id="foc_date_after"
                                    name="foc_date_after"
                                    value="{{ request.GET.foc_date_after }}"
-                                   aria-label="Filter by FOC date from">
+                                   aria-label="{% trans 'Filter by FOC date from' %}">
                             <span class="icon is-small is-left">
                                 <i class="fas fa-calendar"></i>
                             </span>
@@ -305,14 +305,14 @@
                 {# FOC Date To Filter #}
                 <div class="column is-half">
                     <div class="field">
-                        <label class="label" for="foc_date_before">FOC Date To</label>
+                        <label class="label" for="foc_date_before">{% trans "FOC Date To" %}</label>
                         <div class="control has-icons-left">
                             <input class="input"
                                    type="date"
                                    id="foc_date_before"
                                    name="foc_date_before"
                                    value="{{ request.GET.foc_date_before }}"
-                                   aria-label="Filter by FOC date to">
+                                   aria-label="{% trans 'Filter by FOC date to' %}">
                             <span class="icon is-small is-left">
                                 <i class="fas fa-calendar"></i>
                             </span>
@@ -322,20 +322,20 @@
             </div>
 
             {# ── Group: Codes & IDs ──────────────────────────────────────── #}
-            <h4 class="title is-6 has-text-grey mt-4 mb-3">Codes &amp; IDs</h4>
+            <h4 class="title is-6 has-text-grey mt-4 mb-3">{% trans "Codes & IDs" %}</h4>
             <div class="columns is-multiline">
                 {# UPC Code Filter #}
                 <div class="column is-half">
                     <div class="field">
-                        <label class="label" for="upc">UPC Code</label>
+                        <label class="label" for="upc">{% trans "UPC Code" %}</label>
                         <div class="control has-icons-left">
                             <input class="input"
                                    type="text"
                                    id="upc"
                                    name="upc"
                                    value="{{ request.GET.upc }}"
-                                   placeholder="e.g., 76194134186700111"
-                                   aria-label="Filter by UPC code">
+                                   placeholder="{% trans 'e.g., 76194134186700111' %}"
+                                   aria-label="{% trans 'Filter by UPC code' %}">
                             <span class="icon is-small is-left">
                                 <i class="fas fa-barcode"></i>
                             </span>
@@ -345,15 +345,15 @@
                 {# SKU Filter #}
                 <div class="column is-half">
                     <div class="field">
-                        <label class="label" for="sku">Distributor SKU</label>
+                        <label class="label" for="sku">{% trans "Distributor SKU" %}</label>
                         <div class="control has-icons-left">
                             <input class="input"
                                    type="text"
                                    id="sku"
                                    name="sku"
                                    value="{{ request.GET.sku }}"
-                                   placeholder="e.g., JUN240001"
-                                   aria-label="Filter by distributor SKU">
+                                   placeholder="{% trans 'e.g., JUN240001' %}"
+                                   aria-label="{% trans 'Filter by distributor SKU' %}">
                             <span class="icon is-small is-left">
                                 <i class="fas fa-tag"></i>
                             </span>
@@ -363,15 +363,15 @@
                 {# Comic Vine ID Filter #}
                 <div class="column is-half">
                     <div class="field">
-                        <label class="label" for="cv_id">Comic Vine ID</label>
+                        <label class="label" for="cv_id">{% trans "Comic Vine ID" %}</label>
                         <div class="control has-icons-left">
                             <input class="input"
                                    type="number"
                                    id="cv_id"
                                    name="cv_id"
                                    value="{{ request.GET.cv_id }}"
-                                   placeholder="e.g., 12345"
-                                   aria-label="Filter by Comic Vine ID">
+                                   placeholder="{% trans 'e.g., 12345' %}"
+                                   aria-label="{% trans 'Filter by Comic Vine ID' %}">
                             <span class="icon is-small is-left">
                                 <i class="fas fa-fingerprint"></i>
                             </span>
@@ -382,7 +382,7 @@
                 <div class="column is-half">
                     <div class="field">
                         <label class="label" for="gcd_id">
-                            <abbr title="Grand Comics Database">GCD</abbr> ID
+                            <abbr title="{% trans 'Grand Comics Database' %}">GCD</abbr> {% trans "ID" %}
                         </label>
                         <div class="control has-icons-left">
                             <input class="input"
@@ -390,8 +390,8 @@
                                    id="gcd_id"
                                    name="gcd_id"
                                    value="{{ request.GET.gcd_id }}"
-                                   placeholder="e.g., 67890"
-                                   aria-label="Filter by GCD ID">
+                                   placeholder="{% trans 'e.g., 67890' %}"
+                                   aria-label="{% trans 'Filter by GCD ID' %}">
                             <span class="icon is-small is-left">
                                 <i class="fas fa-fingerprint"></i>
                             </span>
@@ -407,17 +407,17 @@
                     <span class="icon">
                         <i class="fas fa-search"></i>
                     </span>
-                    <span>Apply Filters</span>
+                    <span>{% trans "Apply Filters" %}</span>
                 </button>
             </div>
             <div class="control">
                 <a class="button is-light"
                    href="{% url 'issue:list' %}"
-                   title="Clear all filters">
+                   title="{% trans 'Clear all filters' %}">
                     <span class="icon">
                         <i class="fas fa-times"></i>
                     </span>
-                    <span>Clear Filters</span>
+                    <span>{% trans "Clear Filters" %}</span>
                 </a>
             </div>
         </div>

--- a/comicsdb/templates/comicsdb/partials/issue_sort.html
+++ b/comicsdb/templates/comicsdb/partials/issue_sort.html
@@ -1,3 +1,4 @@
+{% load i18n %}
 {% comment %}
    result sort control.
    Submits on change (method="get", no action -> posts back to the current page).
@@ -8,7 +9,7 @@
 {% endcomment %}
 <form method="get"
       class="field is-grouped is-align-items-center mb-0"
-      aria-label="Sort issues">
+      aria-label="{% trans 'Sort issues' %}">
     {% for key, values in request.GET.lists %}
         {% if key != "sort" and key != "page" %}
             {% for value in values %}
@@ -16,13 +17,13 @@
             {% endfor %}
         {% endif %}
     {% endfor %}
-    <label class="label mb-0 mr-2" for="issue-sort-select">Sort</label>
+    <label class="label mb-0 mr-2" for="issue-sort-select">{% trans "Sort" %}</label>
     <div class="control">
         <div class="select">
             <select id="issue-sort-select"
                     name="sort"
                     onchange="this.form.submit()"
-                    aria-label="Sort order">
+                    aria-label="{% trans 'Sort order' %}">
                 {% for key, opt in sort_options.items %}
                     <option value="{{ key }}"
                             {% if key == current_sort %}selected{% endif %}>{{ opt.label }}</option>
@@ -32,7 +33,7 @@
     </div>
     <noscript>
         <div class="control">
-            <button type="submit" class="button">Sort</button>
+            <button type="submit" class="button">{% trans "Sort" %}</button>
         </div>
     </noscript>
 </form>

--- a/comicsdb/templates/comicsdb/partials/issue_team_items.html
+++ b/comicsdb/templates/comicsdb/partials/issue_team_items.html
@@ -1,5 +1,5 @@
 {% load thumbnail %}
-{% load static %}
+{% load i18n static %}
 {% for team in teams %}
     <div class="column is-4">
         <article class="media">
@@ -17,7 +17,7 @@
                     {% else %}
                         <img class="is-rounded"
                              src="{% static 'site/img/creator-not-found.webp' %}"
-                             alt="No image for {{ team }}"
+                             alt="{% blocktrans %}No image for {{ team }}{% endblocktrans %}"
                              loading="lazy">
                     {% endif %}
                 </div>
@@ -37,7 +37,7 @@
                 hx-target="#teams-container"
                 hx-swap="beforeend"
                 hx-indicator="#teams-spinner">
-            <span>Load More Teams</span>
+            <span>{% trans "Load More Teams" %}</span>
         </button>
         <span id="teams-spinner" class="htmx-indicator ml-2">
             <i class="fas fa-spinner fa-spin"></i>

--- a/comicsdb/templates/comicsdb/partials/issue_universe_items.html
+++ b/comicsdb/templates/comicsdb/partials/issue_universe_items.html
@@ -1,5 +1,5 @@
 {% load thumbnail %}
-{% load static %}
+{% load i18n static %}
 {% for universe in universes %}
     <div class="column is-4">
         <article class="media">
@@ -17,7 +17,7 @@
                     {% else %}
                         <img class="is-rounded"
                              src="{% static 'site/img/creator-not-found.webp' %}"
-                             alt="No image for {{ universe }}"
+                             alt="{% blocktrans %}No image for {{ universe }}{% endblocktrans %}"
                              loading="lazy">
                     {% endif %}
                 </div>
@@ -37,7 +37,7 @@
                 hx-target="#universes-container"
                 hx-swap="beforeend"
                 hx-indicator="#universes-spinner">
-            <span>Load More Universes</span>
+            <span>{% trans "Load More Universes" %}</span>
         </button>
         <span id="universes-spinner" class="htmx-indicator ml-2">
             <i class="fas fa-spinner fa-spin"></i>

--- a/comicsdb/templates/comicsdb/partials/list_header.html
+++ b/comicsdb/templates/comicsdb/partials/list_header.html
@@ -1,23 +1,24 @@
-{% load humanize %}
+{% load humanize i18n %}
 {% comment %}
     Reusable list header with count, search, and add button
     Usage: {% include "comicsdb/partials/list_header.html" with title="Characters" ... %}
-    
+
     Required parameters:
-    - title: Display title (e.g., "Character", "Publisher")
+    - title: Display title, singular (e.g., "Character", "Publisher")
+    - title_plural: Display title, plural (e.g., "Characters", "Publishers")
     - count: Total item count from paginator
     - search_url: URL name for search action
     - search_placeholder: Placeholder text for search input
     - create_url: URL name for create action (optional)
     - create_title: Title attribute for create button
 {% endcomment %}
-<nav class="level" aria-label="List navigation and actions">
+<nav class="level" aria-label="{% trans 'List navigation and actions' %}">
     <div class="level-left">
         {# Item Count #}
         <div class="level-item">
             <p class="subtitle is-5">
                 <strong>{{ count|intcomma }}</strong>
-                {{ title }}{% if title != "Series" %}{{ count|pluralize }}{% endif %}
+                {% if count == 1 %}{{ title }}{% else %}{{ title_plural }}{% endif %}
             </p>
         </div>
         {# Search Form #}
@@ -26,10 +27,10 @@
                   method="get"
                   accept-charset="utf-8"
                   role="search"
-                  aria-label="Search {{ title|lower }}s">
+                  aria-label="{% blocktrans %}Search {{ title_plural }}{% endblocktrans %}">
                 <div class="field has-addons">
                     <div class="control">
-                        <label for="search-input-{{ title|lower }}" class="is-sr-only">Search {{ title }}s</label>
+                        <label for="search-input-{{ title|lower }}" class="is-sr-only">{% blocktrans %}Search {{ title_plural }}{% endblocktrans %}</label>
                         <input id="search-input-{{ title|lower }}"
                                class="input"
                                name="q"
@@ -38,11 +39,11 @@
                                aria-label="{{ search_placeholder }}">
                     </div>
                     <div class="control">
-                        <button class="button" type="submit" aria-label="Search">
+                        <button class="button" type="submit" aria-label="{% trans 'Search' %}">
                             <span class="icon" aria-hidden="true">
                                 <i class="fas fa-search"></i>
                             </span>
-                            <span>Search</span>
+                            <span>{% trans "Search" %}</span>
                         </button>
                     </div>
                 </div>
@@ -60,7 +61,7 @@
                     <span class="icon is-small" aria-hidden="true">
                         <i class="fas fa-plus"></i>
                     </span>
-                    <span>New</span>
+                    <span>{% trans "New" %}</span>
                 </a>
             </div>
         </div>

--- a/comicsdb/templates/comicsdb/partials/pagination.html
+++ b/comicsdb/templates/comicsdb/partials/pagination.html
@@ -1,4 +1,4 @@
-{% load pagination_tags %}
+{% load i18n pagination_tags %}
 {% comment %}
     Generic pagination component that preserves all query parameters.
     Works with any list view that uses Django's pagination.
@@ -17,23 +17,23 @@
         {% if page_obj.has_previous %}
             <a class="pagination-previous"
                href="?{% url_replace page=page_obj.previous_page_number %}"
-               aria-label="Go to previous page">Previous</a>
+               aria-label="{% trans 'Go to previous page' %}">{% trans "Previous" %}</a>
         {% else %}
             <span class="pagination-previous"
-                  title="This is the first page"
+                  title="{% trans 'This is the first page' %}"
                   disabled
-                  aria-disabled="true">Previous</span>
+                  aria-disabled="true">{% trans "Previous" %}</span>
         {% endif %}
         {# Next Page Button #}
         {% if page_obj.has_next %}
             <a class="pagination-next"
                href="?{% url_replace page=page_obj.next_page_number %}"
-               aria-label="Go to next page">Next page</a>
+               aria-label="{% trans 'Go to next page' %}">{% trans "Next page" %}</a>
         {% else %}
             <span class="pagination-next"
-                  title="This is the last page"
+                  title="{% trans 'This is the last page' %}"
                   disabled
-                  aria-disabled="true">Next page</span>
+                  aria-disabled="true">{% trans "Next page" %}</span>
         {% endif %}
         {# Page Numbers #}
         <ul class="pagination-list">
@@ -47,14 +47,14 @@
                     <li>
                         <a class="pagination-link is-current"
                            href="?{% url_replace page=page_num %}"
-                           aria-label="Page {{ page_num }}"
+                           aria-label="{% blocktrans %}Page {{ page_num }}{% endblocktrans %}"
                            aria-current="page">{{ page_num }}</a>
                     </li>
                 {% else %}
                     <li>
                         <a class="pagination-link"
                            href="?{% url_replace page=page_num %}"
-                           aria-label="Go to page {{ page_num }}">{{ page_num }}</a>
+                           aria-label="{% blocktrans %}Go to page {{ page_num }}{% endblocktrans %}">{{ page_num }}</a>
                     </li>
                 {% endif %}
             {% endfor %}

--- a/comicsdb/templates/comicsdb/partials/publisher_imprint_items.html
+++ b/comicsdb/templates/comicsdb/partials/publisher_imprint_items.html
@@ -1,5 +1,5 @@
 {% load thumbnail %}
-{% load static %}
+{% load i18n static %}
 {% load humanize %}
 {% for imprint in imprints %}
     <div class="column is-4">
@@ -18,7 +18,7 @@
                     {% else %}
                         <img class="is-rounded"
                              src="{% static 'site/img/creator-not-found.webp' %}"
-                             alt="No image for {{ imprint.name }}"
+                             alt="{% blocktrans %}No image for {{ imprint.name }}{% endblocktrans %}"
                              loading="lazy">
                     {% endif %}
                 </div>
@@ -28,7 +28,7 @@
                     <p>
                         <a href="{% url 'imprint:detail' imprint.slug %}">{{ imprint.name }}</a>
                         <br>
-                        <small class="has-text-grey-dark">{{ imprint.series_count|intcomma }} series</small>
+                        <small class="has-text-grey-dark">{% blocktrans count counter=imprint.series_count with counter_fmt=imprint.series_count|intcomma %}{{ counter_fmt }} series{% plural %}{{ counter_fmt }} series{% endblocktrans %}</small>
                     </p>
                 </div>
             </div>
@@ -44,7 +44,7 @@
                 hx-target="#imprints-container"
                 hx-swap="beforeend"
                 hx-indicator="#imprints-spinner">
-            <span>Load More Imprints</span>
+            <span>{% trans "Load More Imprints" %}</span>
         </button>
         <span id="imprints-spinner" class="htmx-indicator ml-2">
             <i class="fas fa-spinner fa-spin"></i>

--- a/comicsdb/templates/comicsdb/partials/publisher_universe_items.html
+++ b/comicsdb/templates/comicsdb/partials/publisher_universe_items.html
@@ -1,5 +1,5 @@
 {% load thumbnail %}
-{% load static %}
+{% load i18n static %}
 {% load humanize %}
 {% for universe in universes %}
     <div class="column is-4">
@@ -18,7 +18,7 @@
                     {% else %}
                         <img class="is-rounded"
                              src="{% static 'site/img/creator-not-found.webp' %}"
-                             alt="No image for {{ universe.name }}"
+                             alt="{% blocktrans %}No image for {{ universe.name }}{% endblocktrans %}"
                              loading="lazy">
                     {% endif %}
                 </div>
@@ -28,7 +28,7 @@
                     <p>
                         <a href="{% url 'universe:detail' universe.slug %}">{{ universe.name }}</a>
                         <br>
-                        <small class="has-text-grey-dark">{{ universe.issue_count|intcomma }} issue{{ universe.issue_count|pluralize }}</small>
+                        <small class="has-text-grey-dark">{% blocktrans count counter=universe.issue_count with counter_fmt=universe.issue_count|intcomma %}{{ counter_fmt }} issue{% plural %}{{ counter_fmt }} issues{% endblocktrans %}</small>
                     </p>
                 </div>
             </div>
@@ -44,7 +44,7 @@
                 hx-target="#universes-container"
                 hx-swap="beforeend"
                 hx-indicator="#universes-spinner">
-            <span>Load More Universes</span>
+            <span>{% trans "Load More Universes" %}</span>
         </button>
         <span id="universes-spinner" class="htmx-indicator ml-2">
             <i class="fas fa-spinner fa-spin"></i>

--- a/comicsdb/templates/comicsdb/partials/series_card_grid.html
+++ b/comicsdb/templates/comicsdb/partials/series_card_grid.html
@@ -1,6 +1,7 @@
 {% load thumbnail %}
 {% load static %}
 {% load humanize %}
+{% load i18n %}
 {% comment %}
     Series-specific card grid (uses first_issue_cover instead of series.image)
     Usage: {% include "comicsdb/partials/series_card_grid.html" with items=series_list %}
@@ -18,7 +19,7 @@
                 <div class="card-image">
                     <figure class="image is-2by3">
                         <a href="{% url 'series:detail' series.slug %}"
-                           aria-label="View details for {{ series }}">
+                           aria-label="{% blocktrans %}View details for {{ series }}{% endblocktrans %}">
                             {% with cover=series.first_issue_cover %}
                                 {% if cover %}
                                     {% thumbnail cover "320x480" crop="center" format="WEBP" as im %}
@@ -30,7 +31,7 @@
                                     {% endthumbnail %}
                                 {% else %}
                                     <img src="{% static 'site/img/image-not-found.webp' %}"
-                                         alt="No image available for {{ series }}"
+                                         alt="{% blocktrans %}No image available for {{ series }}{% endblocktrans %}"
                                          loading="lazy">
                                 {% endif %}
                             {% endwith %}
@@ -44,17 +45,17 @@
                            class="card-footer-item is-size-7"
                            title="{{ series.publisher }}"
                            style="overflow: hidden; text-overflow: ellipsis; white-space: nowrap; display: block; text-align: center;"
-                           aria-label="View publisher {{ series.publisher }}">{{ series.publisher }}</a>
+                           aria-label="{% blocktrans with publisher=series.publisher %}View publisher {{ publisher }}{% endblocktrans %}">{{ series.publisher }}</a>
                     {% endif %}
                     {% with count=series.issue_count %}
                         {% if count %}
                             <a href="{% url 'series:issue' series.slug %}"
                                class="card-footer-item is-size-7 has-text-weight-semibold"
-                               aria-label="{{ count }} issue{{ count|pluralize }} for {{ series }}">
-                                {{ count|intcomma }} issue{{ count|pluralize }}
+                               aria-label="{% blocktrans count counter=count with counter_fmt=count|intcomma %}{{ counter_fmt }} issue for {{ series }}{% plural %}{{ counter_fmt }} issues for {{ series }}{% endblocktrans %}">
+                                {% blocktrans count counter=count with counter_fmt=count|intcomma %}{{ counter_fmt }} issue{% plural %}{{ counter_fmt }} issues{% endblocktrans %}
                             </a>
                         {% else %}
-                            <span class="card-footer-item is-size-7" aria-label="No issues">0 issues</span>
+                            <span class="card-footer-item is-size-7" aria-label="{% trans 'No issues' %}">{% trans "0 issues" %}</span>
                         {% endif %}
                     {% endwith %}
                 </footer>

--- a/comicsdb/templates/comicsdb/partials/series_filter.html
+++ b/comicsdb/templates/comicsdb/partials/series_filter.html
@@ -1,3 +1,4 @@
+{% load i18n %}
 <div class="box mb-5" id="filter-panel">
     <form method="get" accept-charset="utf-8">
         <div class="is-flex is-justify-content-space-between is-align-items-center mb-4">
@@ -6,7 +7,7 @@
                     <span class="icon has-text-link">
                         <i class="fas fa-search"></i>
                     </span>
-                    <span>Search Series</span>
+                    <span>{% trans "Search Series" %}</span>
                 </span>
             </h2>
             {% if has_active_filters %}
@@ -14,26 +15,26 @@
                     <span class="icon">
                         <i class="fas fa-filter"></i>
                     </span>
-                    <span>Filters Active</span>
+                    <span>{% trans "Filters Active" %}</span>
                 </span>
             {% endif %}
         </div>
         {# Quick Search Field #}
         <div class="field">
-            <label class="label" for="q">Quick Search</label>
+            <label class="label" for="q">{% trans "Quick Search" %}</label>
             <div class="control has-icons-left">
                 <input class="input"
                        type="text"
                        id="q"
                        name="q"
                        value="{{ request.GET.q }}"
-                       placeholder="Search series names..."
-                       aria-label="Quick search">
+                       placeholder="{% trans 'Search series names...' %}"
+                       aria-label="{% trans 'Quick search' %}">
                 <span class="icon is-small is-left">
                     <i class="fas fa-search"></i>
                 </span>
             </div>
-            <p class="help">Search series names and alternative names (supports multi-word search)</p>
+            <p class="help">{% trans "Search series names and alternative names (supports multi-word search)" %}</p>
         </div>
         {# Collapsible Advanced Filters #}
         <details>
@@ -42,22 +43,22 @@
                     <span class="icon">
                         <i class="fas fa-sliders-h"></i>
                     </span>
-                    <span>Advanced Filters</span>
+                    <span>{% trans "Advanced Filters" %}</span>
                 </span>
             </summary>
             <div class="columns is-multiline">
                 {# Series Name Filter #}
                 <div class="column is-half">
                     <div class="field">
-                        <label class="label" for="name">Series Name</label>
+                        <label class="label" for="name">{% trans "Series Name" %}</label>
                         <div class="control has-icons-left">
                             <input class="input"
                                    type="text"
                                    id="name"
                                    name="name"
                                    value="{{ request.GET.name }}"
-                                   placeholder="e.g., Amazing Spider-Man"
-                                   aria-label="Filter by series name">
+                                   placeholder="{% trans 'e.g., Amazing Spider-Man' %}"
+                                   aria-label="{% trans 'Filter by series name' %}">
                             <span class="icon is-small is-left">
                                 <i class="fas fa-book-open"></i>
                             </span>
@@ -67,15 +68,15 @@
                 {# Alternative Name Filter #}
                 <div class="column is-half">
                     <div class="field">
-                        <label class="label" for="alt_names">Alternative Name</label>
+                        <label class="label" for="alt_names">{% trans "Alternative Name" %}</label>
                         <div class="control has-icons-left">
                             <input class="input"
                                    type="text"
                                    id="alt_names"
                                    name="alt_names"
                                    value="{{ request.GET.alt_names }}"
-                                   placeholder="e.g., Betty & Veronica Spectacular"
-                                   aria-label="Filter by alternative series name">
+                                   placeholder="{% trans 'e.g., Betty & Veronica Spectacular' %}"
+                                   aria-label="{% trans 'Filter by alternative series name' %}">
                             <span class="icon is-small is-left">
                                 <i class="fas fa-book-open"></i>
                             </span>
@@ -85,13 +86,13 @@
                 {# Series Type Filter #}
                 <div class="column is-half">
                     <div class="field">
-                        <label class="label" for="series_type">Series Type</label>
+                        <label class="label" for="series_type">{% trans "Series Type" %}</label>
                         <div class="control has-icons-left">
                             <div class="select is-fullwidth">
                                 <select id="series_type"
                                         name="series_type"
-                                        aria-label="Filter by series type">
-                                    <option value="">All Types</option>
+                                        aria-label="{% trans 'Filter by series type' %}">
+                                    <option value="">{% trans "All Types" %}</option>
                                     {% for type in series_types %}
                                         <option value="{{ type.id }}"
                                                 {% if request.GET.series_type == type.id|stringformat:"s" %}selected{% endif %}>
@@ -109,15 +110,15 @@
                 {# Publisher Filter #}
                 <div class="column is-half">
                     <div class="field">
-                        <label class="label" for="publisher_name">Publisher</label>
+                        <label class="label" for="publisher_name">{% trans "Publisher" %}</label>
                         <div class="control has-icons-left">
                             <input class="input"
                                    type="text"
                                    id="publisher_name"
                                    name="publisher_name"
                                    value="{{ request.GET.publisher_name }}"
-                                   placeholder="e.g., Marvel"
-                                   aria-label="Filter by publisher">
+                                   placeholder="{% trans 'e.g., Marvel' %}"
+                                   aria-label="{% trans 'Filter by publisher' %}">
                             <span class="icon is-small is-left">
                                 <i class="fas fa-building"></i>
                             </span>
@@ -127,15 +128,15 @@
                 {# Imprint Filter #}
                 <div class="column is-half">
                     <div class="field">
-                        <label class="label" for="imprint_name">Imprint</label>
+                        <label class="label" for="imprint_name">{% trans "Imprint" %}</label>
                         <div class="control has-icons-left">
                             <input class="input"
                                    type="text"
                                    id="imprint_name"
                                    name="imprint_name"
                                    value="{{ request.GET.imprint_name }}"
-                                   placeholder="e.g., Vertigo"
-                                   aria-label="Filter by imprint">
+                                   placeholder="{% trans 'e.g., Vertigo' %}"
+                                   aria-label="{% trans 'Filter by imprint' %}">
                             <span class="icon is-small is-left">
                                 <i class="fas fa-bookmark"></i>
                             </span>
@@ -145,15 +146,15 @@
                 {# Year Began Range #}
                 <div class="column is-half">
                     <div class="field">
-                        <label class="label" for="year_began_gte">Year Began (From)</label>
+                        <label class="label" for="year_began_gte">{% trans "Year Began (From)" %}</label>
                         <div class="control has-icons-left">
                             <input class="input"
                                    type="number"
                                    id="year_began_gte"
                                    name="year_began_gte"
                                    value="{{ request.GET.year_began_gte }}"
-                                   placeholder="e.g., 1960"
-                                   aria-label="Filter by year began (from)">
+                                   placeholder="{% trans 'e.g., 1960' %}"
+                                   aria-label="{% trans 'Filter by year began (from)' %}">
                             <span class="icon is-small is-left">
                                 <i class="fas fa-calendar-alt"></i>
                             </span>
@@ -162,15 +163,15 @@
                 </div>
                 <div class="column is-half">
                     <div class="field">
-                        <label class="label" for="year_began_lte">Year Began (To)</label>
+                        <label class="label" for="year_began_lte">{% trans "Year Began (To)" %}</label>
                         <div class="control has-icons-left">
                             <input class="input"
                                    type="number"
                                    id="year_began_lte"
                                    name="year_began_lte"
                                    value="{{ request.GET.year_began_lte }}"
-                                   placeholder="e.g., 2020"
-                                   aria-label="Filter by year began (to)">
+                                   placeholder="{% trans 'e.g., 2020' %}"
+                                   aria-label="{% trans 'Filter by year began (to)' %}">
                             <span class="icon is-small is-left">
                                 <i class="fas fa-calendar-alt"></i>
                             </span>
@@ -180,15 +181,15 @@
                 {# Volume Filter #}
                 <div class="column is-half">
                     <div class="field">
-                        <label class="label" for="volume">Volume</label>
+                        <label class="label" for="volume">{% trans "Volume" %}</label>
                         <div class="control has-icons-left">
                             <input class="input"
                                    type="number"
                                    id="volume"
                                    name="volume"
                                    value="{{ request.GET.volume }}"
-                                   placeholder="e.g., 1"
-                                   aria-label="Filter by volume">
+                                   placeholder="{% trans 'e.g., 1' %}"
+                                   aria-label="{% trans 'Filter by volume' %}">
                             <span class="icon is-small is-left">
                                 <i class="fas fa-layer-group"></i>
                             </span>
@@ -198,11 +199,11 @@
                 {# Status Filter #}
                 <div class="column is-half">
                     <div class="field">
-                        <label class="label" for="status">Status</label>
+                        <label class="label" for="status">{% trans "Status" %}</label>
                         <div class="control has-icons-left">
                             <div class="select is-fullwidth">
-                                <select id="status" name="status" aria-label="Filter by status">
-                                    <option value="">All Statuses</option>
+                                <select id="status" name="status" aria-label="{% trans 'Filter by status' %}">
+                                    <option value="">{% trans "All Statuses" %}</option>
                                     {% for value, label in status_choices %}
                                         <option value="{{ value }}"
                                                 {% if request.GET.status == value %}selected{% endif %}>
@@ -226,17 +227,17 @@
                     <span class="icon">
                         <i class="fas fa-search"></i>
                     </span>
-                    <span>Apply Filters</span>
+                    <span>{% trans "Apply Filters" %}</span>
                 </button>
             </div>
             <div class="control">
                 <a class="button is-light"
                    href="{% url 'series:list' %}"
-                   title="Clear all filters">
+                   title="{% trans 'Clear all filters' %}">
                     <span class="icon">
                         <i class="fas fa-times"></i>
                     </span>
-                    <span>Clear Filters</span>
+                    <span>{% trans "Clear Filters" %}</span>
                 </a>
             </div>
         </div>

--- a/comicsdb/templates/comicsdb/partials/team_member_items.html
+++ b/comicsdb/templates/comicsdb/partials/team_member_items.html
@@ -1,5 +1,5 @@
 {% load thumbnail %}
-{% load static %}
+{% load i18n static %}
 {% for character in members %}
     <div class="column is-4">
         <article class="media">
@@ -17,7 +17,7 @@
                     {% else %}
                         <img class="is-rounded"
                              src="{% static 'site/img/creator-not-found.webp' %}"
-                             alt="No image for {{ character }}"
+                             alt="{% blocktrans %}No image for {{ character }}{% endblocktrans %}"
                              loading="lazy">
                     {% endif %}
                 </div>
@@ -37,7 +37,7 @@
                 hx-target="#members-container"
                 hx-swap="beforeend"
                 hx-indicator="#members-spinner">
-            <span>Load More Members</span>
+            <span>{% trans "Load More Members" %}</span>
         </button>
         <span id="members-spinner" class="htmx-indicator ml-2">
             <i class="fas fa-spinner fa-spin"></i>

--- a/comicsdb/templates/comicsdb/partials/universe_character_items.html
+++ b/comicsdb/templates/comicsdb/partials/universe_character_items.html
@@ -1,5 +1,5 @@
 {% load thumbnail %}
-{% load static %}
+{% load i18n static %}
 {% for character in characters %}
     <div class="column is-4">
         <article class="media">
@@ -17,7 +17,7 @@
                     {% else %}
                         <img class="is-rounded"
                              src="{% static 'site/img/creator-not-found.webp' %}"
-                             alt="No image for {{ character }}"
+                             alt="{% blocktrans %}No image for {{ character }}{% endblocktrans %}"
                              loading="lazy">
                     {% endif %}
                 </div>
@@ -37,7 +37,7 @@
                 hx-target="#characters-container"
                 hx-swap="beforeend"
                 hx-indicator="#characters-spinner">
-            <span>Load More Characters</span>
+            <span>{% trans "Load More Characters" %}</span>
         </button>
         <span id="characters-spinner" class="htmx-indicator ml-2">
             <i class="fas fa-spinner fa-spin"></i>

--- a/comicsdb/templates/comicsdb/partials/universe_series_items.html
+++ b/comicsdb/templates/comicsdb/partials/universe_series_items.html
@@ -1,3 +1,4 @@
+{% load i18n %}
 {% for series in appearances %}
     <li>
         <a href="{% url 'series:detail' slug=series.issues__series__slug %}">
@@ -9,12 +10,12 @@
             {% elif series.issues__series__series_type == 8 %}
                 HC
             {% elif series.issues__series__series_type == 12 %}
-                Digital
+                {% trans "Digital" %}
             {% endif %}
             ({{ series.issues__series__year_began }})
         </a>:
         <a href="{% url 'universe:series' universe=universe_slug series=series.issues__series__slug %}">
-            {{ series.issues__count }} issue{{ series.issues__count|pluralize }}
+            {% blocktrans count counter=series.issues__count %}{{ counter }} issue{% plural %}{{ counter }} issues{% endblocktrans %}
         </a>
     </li>
 {% endfor %}
@@ -27,7 +28,7 @@
                 hx-target="#series-list"
                 hx-swap="beforeend"
                 hx-indicator="#series-spinner">
-            <span>Load More Series</span>
+            <span>{% trans "Load More Series" %}</span>
         </button>
         <span id="series-spinner" class="htmx-indicator ml-2">
             <i class="fas fa-spinner fa-spin"></i>

--- a/comicsdb/templates/comicsdb/partials/universe_team_items.html
+++ b/comicsdb/templates/comicsdb/partials/universe_team_items.html
@@ -1,5 +1,5 @@
 {% load thumbnail %}
-{% load static %}
+{% load i18n static %}
 {% for team in teams %}
     <div class="column is-4">
         <article class="media">
@@ -17,7 +17,7 @@
                     {% else %}
                         <img class="is-rounded"
                              src="{% static 'site/img/creator-not-found.webp' %}"
-                             alt="No image for {{ team }}"
+                             alt="{% blocktrans %}No image for {{ team }}{% endblocktrans %}"
                              loading="lazy">
                     {% endif %}
                 </div>
@@ -37,7 +37,7 @@
                 hx-target="#teams-container"
                 hx-swap="beforeend"
                 hx-indicator="#teams-spinner">
-            <span>Load More Teams</span>
+            <span>{% trans "Load More Teams" %}</span>
         </button>
         <span id="teams-spinner" class="htmx-indicator ml-2">
             <i class="fas fa-spinner fa-spin"></i>

--- a/comicsdb/templates/comicsdb/partials/variants_formset.html
+++ b/comicsdb/templates/comicsdb/partials/variants_formset.html
@@ -1,4 +1,4 @@
-{% load bulma_tags %}
+{% load bulma_tags i18n %}
 {% comment %}
     Variants formset table
     Usage: {% include "comicsdb/partials/variants_formset.html" with formset=variants %}
@@ -22,12 +22,12 @@
     </colgroup>
     <thead>
         <tr>
-            <th scope="col">Image</th>
-            <th scope="col">Name</th>
-            <th scope="col">Price</th>
-            <th scope="col">SKU</th>
-            <th scope="col">UPC</th>
-            <th scope="col" class="has-text-centered">Delete</th>
+            <th scope="col">{% trans "Image" %}</th>
+            <th scope="col">{% trans "Name" %}</th>
+            <th scope="col">{% trans "Price" %}</th>
+            <th scope="col">{% trans "SKU" %}</th>
+            <th scope="col">{% trans "UPC" %}</th>
+            <th scope="col" class="has-text-centered">{% trans "Delete" %}</th>
         </tr>
     </thead>
     <tbody id="variantsTableBody">
@@ -74,7 +74,7 @@
                         <button type="button"
                                 class="button is-small is-danger delete-row"
                                 onclick="const checkbox = this.parentElement.querySelector('input[type=checkbox]'); checkbox.checked = !checkbox.checked; const row = this.closest('tr'); row.style.opacity = checkbox.checked ? '0.5' : '1'; row.style.textDecoration = checkbox.checked ? 'line-through' : 'none';"
-                                title="Mark for deletion">
+                                title="{% trans 'Mark for deletion' %}">
                             <span class="icon is-small">
                                 <i class="fas fa-times"></i>
                             </span>
@@ -84,7 +84,7 @@
                         <button type="button"
                                 class="button is-small is-danger delete-row"
                                 onclick="this.closest('tr').remove(); updateFormsetManagement('variants');"
-                                title="Remove this row">
+                                title="{% trans 'Remove this row' %}">
                             <span class="icon is-small">
                                 <i class="fas fa-times"></i>
                             </span>
@@ -105,5 +105,5 @@
     <span class="icon">
         <i class="fas fa-plus"></i>
     </span>
-    <span>Add another variant cover</span>
+    <span>{% trans "Add another variant cover" %}</span>
 </button>

--- a/comicsdb/templates/comicsdb/partials/variants_formset_row.html
+++ b/comicsdb/templates/comicsdb/partials/variants_formset_row.html
@@ -1,4 +1,4 @@
-{% load bulma_tags %}
+{% load bulma_tags i18n %}
 <tr class="formset-row">
     {% for field in form.visible_fields %}
         {% if field.name != 'DELETE' %}
@@ -38,7 +38,7 @@
         <button type="button"
                 class="button is-small is-danger delete-row"
                 onclick="this.closest('tr').remove(); updateFormsetManagement('variants');"
-                title="Remove this row">
+                title="{% trans 'Remove this row' %}">
             <span class="icon is-small">
                 <i class="fas fa-times"></i>
             </span>

--- a/comicsdb/templates/comicsdb/publisher_detail.html
+++ b/comicsdb/templates/comicsdb/publisher_detail.html
@@ -1,7 +1,7 @@
 {% extends parent_template|default:"base.html" %}
 {% load humanize %}
 {% load thumbnail %}
-{% load static %}
+{% load i18n static %}
 {% block title %}
     {{ publisher.name }}
 {% endblock title %}
@@ -11,31 +11,31 @@
         <h1 class="title">{{ publisher }}</h1>
     </header>
     {# Navigation Bar #}
-    <nav class="level mb-5" aria-label="Publisher navigation">
+    <nav class="level mb-5" aria-label="{% trans 'Publisher navigation' %}">
         <div class="level-left">
             {% if navigation.previous_publisher %}
                 <a class="button is-link"
                    href="{% url 'publisher:detail' navigation.previous_publisher.slug %}"
-                   aria-label="Go to {{ navigation.previous_publisher }}">
+                   aria-label="{% blocktrans with previous_publisher=navigation.previous_publisher %}Go to {{ previous_publisher }}{% endblocktrans %}">
                     <span class="icon is-small"><i class="fas fa-arrow-left" aria-hidden="true"></i></span>
-                    <span>Previous Publisher</span>
+                    <span>{% trans "Previous Publisher" %}</span>
                 </a>
             {% else %}
                 <button class="button" disabled aria-disabled="true">
                     <span class="icon is-small"><i class="fas fa-arrow-left" aria-hidden="true"></i></span>
-                    <span>Previous Publisher</span>
+                    <span>{% trans "Previous Publisher" %}</span>
                 </button>
             {% endif %}
             {% if navigation.next_publisher %}
                 <a class="button is-link ml-2"
                    href="{% url 'publisher:detail' navigation.next_publisher.slug %}"
-                   aria-label="Go to {{ navigation.next_publisher }}">
-                    <span>Next Publisher</span>
+                   aria-label="{% blocktrans with next_publisher=navigation.next_publisher %}Go to {{ next_publisher }}{% endblocktrans %}">
+                    <span>{% trans "Next Publisher" %}</span>
                     <span class="icon is-small"><i class="fas fa-arrow-right" aria-hidden="true"></i></span>
                 </a>
             {% else %}
                 <button class="button ml-2" disabled aria-disabled="true">
-                    <span>Next Publisher</span>
+                    <span>{% trans "Next Publisher" %}</span>
                     <span class="icon is-small"><i class="fas fa-arrow-right" aria-hidden="true"></i></span>
                 </button>
             {% endif %}
@@ -44,16 +44,16 @@
             <div class="buttons">
                 <a class="button is-link"
                    href="{% url 'publisher:series' publisher.slug %}"
-                   title="View series list for this publisher">
+                   title="{% trans 'View series list for this publisher' %}">
                     <span class="icon is-small"><i class="fas fa-list" aria-hidden="true"></i></span>
-                    <span>Series List</span>
+                    <span>{% trans "Series List" %}</span>
                 </a>
                 {% if user.is_authenticated %}
                     <a class="button is-primary"
                        href="{% url 'publisher:create' %}"
-                       title="Add a new publisher">
+                       title="{% trans 'Add a new publisher' %}">
                         <span class="icon is-small"><i class="fas fa-plus" aria-hidden="true"></i></span>
-                        <span>New</span>
+                        <span>{% trans "New" %}</span>
                     </a>
                     <div class="dropdown is-right" id="publisher-actions-dropdown">
                         <div class="dropdown-trigger">
@@ -61,7 +61,7 @@
                                     aria-haspopup="true"
                                     aria-controls="publisher-actions-menu"
                                     hx-on:click="document.getElementById('publisher-actions-dropdown').classList.toggle('is-active')">
-                                <span>Actions</span>
+                                <span>{% trans "Actions" %}</span>
                                 <span class="icon is-small"><i class="fas fa-angle-down" aria-hidden="true"></i></span>
                             </button>
                         </div>
@@ -70,19 +70,19 @@
                                 <a class="dropdown-item"
                                    href="{% url 'publisher:update' publisher.slug %}">
                                     <span class="icon is-small"><i class="fas fa-edit" aria-hidden="true"></i></span>
-                                    <span>Edit</span>
+                                    <span>{% trans "Edit" %}</span>
                                 </a>
                                 <a class="dropdown-item"
                                    href="{% url 'publisher:history' publisher.slug %}">
                                     <span class="icon is-small"><i class="fas fa-history" aria-hidden="true"></i></span>
-                                    <span>History</span>
+                                    <span>{% trans "History" %}</span>
                                 </a>
                                 {% if perms.comicsdb.delete_publisher %}
                                     <hr class="dropdown-divider">
                                     <a class="dropdown-item has-text-danger"
                                        href="{% url 'publisher:delete' publisher.slug %}">
                                         <span class="icon is-small"><i class="fas fa-trash" aria-hidden="true"></i></span>
-                                        <span>Delete</span>
+                                        <span>{% trans "Delete" %}</span>
                                     </a>
                                 {% endif %}
                             </div>
@@ -116,7 +116,7 @@
                         {% endthumbnail %}
                     {% else %}
                         <img src="{% static 'site/img/image-not-found.webp' %}"
-                             alt="No image for {{ publisher.name }}"
+                             alt="{% blocktrans %}No image for {{ publisher.name }}{% endblocktrans %}"
                              loading="lazy">
                     {% endif %}
                 </figure>
@@ -126,21 +126,21 @@
         <div class="column">
             {# Summary #}
             <div class="box">
-                <h2 class="title is-5">Summary</h2>
+                <h2 class="title is-5">{% trans "Summary" %}</h2>
                 {% if publisher.desc %}
                     <div class="content">{{ publisher.desc|linebreaksbr }}</div>
                 {% else %}
-                    <p class="has-text-grey">No information available.</p>
+                    <p class="has-text-grey">{% trans "No information available." %}</p>
                 {% endif %}
                 <footer class="content is-small is-italic mt-4">
-                    Last edited on <time datetime="{{ publisher.modified|date:'c' }}">{{ publisher.modified }}</time> by
+                    {% blocktrans with modified_time=publisher.modified %}Last edited on <time datetime="{{ modified_time|date:'c' }}">{{ modified_time }}</time> by{% endblocktrans %}
                     <a href="{% url 'user-detail' username=publisher.edited_by.username %}">{{ publisher.edited_by.username }}</a>
                 </footer>
             </div>
             {# Imprints #}
             {% if imprint_count > 0 %}
                 <div class="box">
-                    <h2 class="title is-5">Imprint{{ imprint_count|pluralize }} ({{ imprint_count }})</h2>
+                    <h2 class="title is-5">{% blocktrans count counter=imprint_count %}Imprint ({{ counter }}){% plural %}Imprints ({{ counter }}){% endblocktrans %}</h2>
                     <div class="columns is-multiline" id="imprints-container">
                         {% for imprint in imprints %}
                             <div class="column is-4">
@@ -159,7 +159,7 @@
                                             {% else %}
                                                 <img class="is-rounded"
                                                      src="{% static 'site/img/creator-not-found.webp' %}"
-                                                     alt="No image for {{ imprint.name }}"
+                                                     alt="{% blocktrans %}No image for {{ imprint.name }}{% endblocktrans %}"
                                                      loading="lazy">
                                             {% endif %}
                                         </div>
@@ -169,7 +169,7 @@
                                             <p>
                                                 <a href="{% url 'imprint:detail' imprint.slug %}">{{ imprint.name }}</a>
                                                 <br>
-                                                <small class="has-text-grey-dark">{{ imprint.series_count|intcomma }} series</small>
+                                                <small class="has-text-grey-dark">{% blocktrans count counter=imprint.series_count with counter_fmt=imprint.series_count|intcomma %}{{ counter_fmt }} series{% plural %}{{ counter_fmt }} series{% endblocktrans %}</small>
                                             </p>
                                         </div>
                                     </div>
@@ -185,7 +185,7 @@
                                     hx-target="#imprints-container"
                                     hx-swap="beforeend"
                                     hx-indicator="#imprints-spinner">
-                                <span>Load More Imprints</span>
+                                <span>{% trans "Load More Imprints" %}</span>
                             </button>
                             <span id="imprints-spinner" class="htmx-indicator ml-2">
                                 <i class="fas fa-spinner fa-spin"></i>
@@ -197,7 +197,7 @@
             {# Universes #}
             {% if universe_count > 0 %}
                 <div class="box">
-                    <h2 class="title is-5">Universe{{ universe_count|pluralize }} ({{ universe_count }})</h2>
+                    <h2 class="title is-5">{% blocktrans count counter=universe_count %}Universe ({{ counter }}){% plural %}Universes ({{ counter }}){% endblocktrans %}</h2>
                     <div class="columns is-multiline" id="universes-container">
                         {% for universe in universes %}
                             <div class="column is-4">
@@ -216,7 +216,7 @@
                                             {% else %}
                                                 <img class="is-rounded"
                                                      src="{% static 'site/img/creator-not-found.webp' %}"
-                                                     alt="No image for {{ universe.name }}"
+                                                     alt="{% blocktrans %}No image for {{ universe.name }}{% endblocktrans %}"
                                                      loading="lazy">
                                             {% endif %}
                                         </div>
@@ -226,7 +226,7 @@
                                             <p>
                                                 <a href="{% url 'universe:detail' universe.slug %}">{{ universe.name }}</a>
                                                 <br>
-                                                <small class="has-text-grey-dark">{{ universe.issue_count|intcomma }} issue{{ universe.issue_count|pluralize }}</small>
+                                                <small class="has-text-grey-dark">{% blocktrans count counter=universe.issue_count with counter_fmt=universe.issue_count|intcomma %}{{ counter_fmt }} issue{% plural %}{{ counter_fmt }} issues{% endblocktrans %}</small>
                                             </p>
                                         </div>
                                     </div>
@@ -242,7 +242,7 @@
                                     hx-target="#universes-container"
                                     hx-swap="beforeend"
                                     hx-indicator="#universes-spinner">
-                                <span>Load More Universes</span>
+                                <span>{% trans "Load More Universes" %}</span>
                             </button>
                             <span id="universes-spinner" class="htmx-indicator ml-2">
                                 <i class="fas fa-spinner fa-spin"></i>
@@ -261,20 +261,20 @@
         {# Metadata Sidebar #}
         <div class="column is-one-fifth">
             <div class="box">
-                <h2 class="title is-6">Publisher Details</h2>
+                <h2 class="title is-6">{% trans "Publisher Details" %}</h2>
                 <dl>
                     {% if publisher.founded %}
-                        <dt class="has-text-weight-bold">Founded:</dt>
+                        <dt class="has-text-weight-bold">{% trans "Founded:" %}</dt>
                         <dd class="mb-3">
                             {{ publisher.founded }}
                         </dd>
                     {% endif %}
-                    <dt class="has-text-weight-bold">Country:</dt>
+                    <dt class="has-text-weight-bold">{% trans "Country:" %}</dt>
                     <dd class="mb-3">
                         {{ publisher.country.name }}
                     </dd>
                     {% if publisher.series_count > 0 %}
-                        <dt class="has-text-weight-bold">Number of Series:</dt>
+                        <dt class="has-text-weight-bold">{% trans "Number of Series:" %}</dt>
                         <dd class="mb-3">
                             {{ publisher.series_count|intcomma }}
                         </dd>
@@ -283,21 +283,21 @@
             </div>
             {# Identification Numbers #}
             <div class="box">
-                <h2 class="title is-6">Identification Numbers</h2>
+                <h2 class="title is-6">{% trans "Identification Numbers" %}</h2>
                 <dl>
-                    <dt class="has-text-weight-bold">Metron:</dt>
+                    <dt class="has-text-weight-bold">{% trans "Metron:" %}</dt>
                     <dd class="mb-2 is-flex is-align-items-center is-justify-content-space-between">
                         <span class="is-family-monospace">{{ publisher.id }}</span>
                         <button type="button"
                                 class="button is-small is-light copy-id"
                                 data-copy="{{ publisher.id }}"
-                                title="Copy Metron ID"
-                                aria-label="Copy Metron ID">
+                                title="{% trans 'Copy Metron ID' %}"
+                                aria-label="{% trans 'Copy Metron ID' %}">
                             <span class="icon is-small"><i class="fas fa-copy"></i></span>
                         </button>
                     </dd>
                     {% if publisher.cv_id %}
-                        <dt class="has-text-weight-bold">Comic Vine:</dt>
+                        <dt class="has-text-weight-bold">{% trans "Comic Vine:" %}</dt>
                         <dd class="mb-2 is-flex is-align-items-center is-justify-content-space-between">
                             <a class="is-family-monospace"
                                href="https://comicvine.gamespot.com/publisher/4010-{{ publisher.cv_id }}/"
@@ -309,15 +309,15 @@
                             <button type="button"
                                     class="button is-small is-light copy-id"
                                     data-copy="{{ publisher.cv_id }}"
-                                    title="Copy Comic Vine ID"
-                                    aria-label="Copy Comic Vine ID">
+                                    title="{% trans 'Copy Comic Vine ID' %}"
+                                    aria-label="{% trans 'Copy Comic Vine ID' %}">
                                 <span class="icon is-small"><i class="fas fa-copy"></i></span>
                             </button>
                         </dd>
                     {% endif %}
                     {% if publisher.gcd_id %}
                         <dt class="has-text-weight-bold">
-                            <abbr title="Grand Comics Database">GCD</abbr>:
+                            <abbr title="{% trans 'Grand Comics Database' %}">GCD</abbr>:
                         </dt>
                         <dd class="is-flex is-align-items-center is-justify-content-space-between">
                             <a class="is-family-monospace"
@@ -330,8 +330,8 @@
                             <button type="button"
                                     class="button is-small is-light copy-id"
                                     data-copy="{{ publisher.gcd_id }}"
-                                    title="Copy GCD ID"
-                                    aria-label="Copy GCD ID">
+                                    title="{% trans 'Copy GCD ID' %}"
+                                    aria-label="{% trans 'Copy GCD ID' %}">
                                 <span class="icon is-small"><i class="fas fa-copy"></i></span>
                             </button>
                         </dd>

--- a/comicsdb/templates/comicsdb/publisher_list.html
+++ b/comicsdb/templates/comicsdb/publisher_list.html
@@ -1,17 +1,22 @@
 {% extends parent_template|default:"base.html" %}
-{% load static %}
-{% block title %}Publishers - Metron{% endblock %}
+{% load i18n static %}
+{% block title %}{% trans "Publishers - Metron" %}{% endblock %}
 {% block content %}
     <header class="block has-text-centered">
-        <h1 class="title">Publishers List</h1>
+        <h1 class="title">{% trans "Publishers List" %}</h1>
     </header>
+    {% trans "Publisher" as list_title %}
+    {% trans "Publishers" as list_title_plural %}
+    {% trans "Find a publisher" as list_search_placeholder %}
+    {% trans "Series" as series_label %}
+    {% trans "Add a new publisher" as list_create_title %}
     {% if publisher_list %}
         <section>
-            {% include "comicsdb/partials/list_header.html" with title="Publisher" count=page_obj.paginator.count search_url="publisher:search" search_placeholder="Find a publisher" create_url="publisher:create" create_title="Add a new publisher" %}
-            {% include "comicsdb/partials/card_grid.html" with items=publisher_list detail_url_name="publisher:detail" image_ratio="is-2by3" default_image="site/img/image-not-found.webp" count_type="series" count_url_name="publisher:series" count_label="Series" %}
+            {% include "comicsdb/partials/list_header.html" with title=list_title title_plural=list_title_plural count=page_obj.paginator.count search_url="publisher:search" search_placeholder=list_search_placeholder create_url="publisher:create" create_title=list_create_title %}
+            {% include "comicsdb/partials/card_grid.html" with items=publisher_list detail_url_name="publisher:detail" image_ratio="is-2by3" default_image="site/img/image-not-found.webp" count_type="series" count_url_name="publisher:series" count_label=series_label count_label_plural=series_label %}
         </section>
     {% else %}
-        {% include "comicsdb/partials/empty_state.html" with item_type="Publisher" create_url="publisher:create" create_title="Add a new publisher" %}
+        {% include "comicsdb/partials/empty_state.html" with item_type=list_title item_type_plural=list_title_plural create_url="publisher:create" create_title=list_create_title %}
     {% endif %}
 {% endblock %}
 {% block pagination %}

--- a/comicsdb/templates/comicsdb/series_detail.html
+++ b/comicsdb/templates/comicsdb/series_detail.html
@@ -1,6 +1,6 @@
 {% extends parent_template|default:"base.html" %}
 {% load thumbnail %}
-{% load static %}
+{% load i18n static %}
 {% load humanize %}
 {% block title %}
     {{ series.name }}
@@ -29,31 +29,31 @@
         </p>
     </header>
     {# Navigation Bar #}
-    <nav class="level mb-5" aria-label="Series navigation">
+    <nav class="level mb-5" aria-label="{% trans 'Series navigation' %}">
         <div class="level-left">
             {% if navigation.previous_series %}
                 <a class="button is-link"
                    href="{% url 'series:detail' navigation.previous_series.slug %}"
-                   aria-label="Go to {{ navigation.previous_series }}">
+                   aria-label="{% blocktrans with previous_series=navigation.previous_series %}Go to {{ previous_series }}{% endblocktrans %}">
                     <span class="icon is-small"><i class="fas fa-arrow-left" aria-hidden="true"></i></span>
-                    <span>Previous Series</span>
+                    <span>{% trans "Previous Series" %}</span>
                 </a>
             {% else %}
                 <button class="button" disabled aria-disabled="true">
                     <span class="icon is-small"><i class="fas fa-arrow-left" aria-hidden="true"></i></span>
-                    <span>Previous Series</span>
+                    <span>{% trans "Previous Series" %}</span>
                 </button>
             {% endif %}
             {% if navigation.next_series %}
                 <a class="button is-link ml-2"
                    href="{% url 'series:detail' navigation.next_series.slug %}"
-                   aria-label="Go to {{ navigation.next_series }}">
-                    <span>Next Series</span>
+                   aria-label="{% blocktrans with next_series=navigation.next_series %}Go to {{ next_series }}{% endblocktrans %}">
+                    <span>{% trans "Next Series" %}</span>
                     <span class="icon is-small"><i class="fas fa-arrow-right" aria-hidden="true"></i></span>
                 </a>
             {% else %}
                 <button class="button ml-2" disabled aria-disabled="true">
-                    <span>Next Series</span>
+                    <span>{% trans "Next Series" %}</span>
                     <span class="icon is-small"><i class="fas fa-arrow-right" aria-hidden="true"></i></span>
                 </button>
             {% endif %}
@@ -62,17 +62,17 @@
             <div class="buttons">
                 <a class="button is-link"
                    href="{% url 'series:issue' series.slug %}"
-                   title="View issue list for this series">
+                   title="{% trans 'View issue list for this series' %}">
                     <span class="icon is-small"><i class="fas fa-list" aria-hidden="true"></i></span>
-                    <span>Issue List</span>
+                    <span>{% trans "Issue List" %}</span>
                 </a>
                 {% if user.is_authenticated %}
                     {% include "pull_list/partials/pull_list_button.html" with series=series on_pull_list=on_pull_list %}
                     <a class="button is-primary"
                        href="{% url 'series:create' %}"
-                       title="Add a new series">
+                       title="{% trans 'Add a new series' %}">
                         <span class="icon is-small"><i class="fas fa-plus" aria-hidden="true"></i></span>
-                        <span>New</span>
+                        <span>{% trans "New" %}</span>
                     </a>
                     <div class="dropdown is-right" id="series-actions-dropdown">
                         <div class="dropdown-trigger">
@@ -80,7 +80,7 @@
                                     aria-haspopup="true"
                                     aria-controls="series-actions-menu"
                                     hx-on:click="document.getElementById('series-actions-dropdown').classList.toggle('is-active')">
-                                <span>Actions</span>
+                                <span>{% trans "Actions" %}</span>
                                 <span class="icon is-small"><i class="fas fa-angle-down" aria-hidden="true"></i></span>
                             </button>
                         </div>
@@ -89,19 +89,19 @@
                                 <a class="dropdown-item"
                                    href="{% url 'series:update' series.slug %}">
                                     <span class="icon is-small"><i class="fas fa-edit" aria-hidden="true"></i></span>
-                                    <span>Edit</span>
+                                    <span>{% trans "Edit" %}</span>
                                 </a>
                                 <a class="dropdown-item"
                                    href="{% url 'series:history' series.slug %}">
                                     <span class="icon is-small"><i class="fas fa-history" aria-hidden="true"></i></span>
-                                    <span>History</span>
+                                    <span>{% trans "History" %}</span>
                                 </a>
                                 {% if perms.comicsdb.delete_series %}
                                     <hr class="dropdown-divider">
                                     <a class="dropdown-item has-text-danger"
                                        href="{% url 'series:delete' series.slug %}">
                                         <span class="icon is-small"><i class="fas fa-trash" aria-hidden="true"></i></span>
-                                        <span>Delete</span>
+                                        <span>{% trans "Delete" %}</span>
                                     </a>
                                 {% endif %}
                             </div>
@@ -136,7 +136,7 @@
                             {% endthumbnail %}
                         {% else %}
                             <img src="{% static 'site/img/image-not-found.webp' %}"
-                                 alt="No image for {{ series }}"
+                                 alt="{% blocktrans %}No image for {{ series }}{% endblocktrans %}"
                                  loading="lazy">
                         {% endif %}
                     {% endwith %}
@@ -147,21 +147,21 @@
         <div class="column">
             {# Summary #}
             <div class="box">
-                <h2 class="title is-5">Summary</h2>
+                <h2 class="title is-5">{% trans "Summary" %}</h2>
                 {% if series.desc %}
                     <div class="content">{{ series.desc|linebreaksbr }}</div>
                 {% else %}
-                    <p class="has-text-grey">No information available.</p>
+                    <p class="has-text-grey">{% trans "No information available." %}</p>
                 {% endif %}
                 <footer class="content is-small is-italic mt-4">
-                    Last edited on <time datetime="{{ series.modified|date:'c' }}">{{ series.modified }}</time> by
+                    {% blocktrans with modified_time=series.modified %}Last edited on <time datetime="{{ modified_time|date:'c' }}">{{ modified_time }}</time> by{% endblocktrans %}
                     <a href="{% url 'user-detail' username=series.edited_by.username %}">{{ series.edited_by.username }}</a>
                 </footer>
             </div>
             {# Top Creators #}
             {% if creators %}
                 <div class="box">
-                    <h2 class="title is-5">Most Issue Credits ({{ creators|length }})</h2>
+                    <h2 class="title is-5">{% blocktrans with count=creators|length %}Most Issue Credits ({{ count }}){% endblocktrans %}</h2>
                     <div class="columns is-multiline">
                         {% for creator in creators %}
                             <div class="column is-4">
@@ -180,7 +180,7 @@
                                             {% else %}
                                                 <img class="is-rounded"
                                                      src="{% static 'site/img/creator-not-found.webp' %}"
-                                                     alt="No image for {{ creator.creators__name }}"
+                                                     alt="{% blocktrans %}No image for {{ creator.creators__name }}{% endblocktrans %}"
                                                      loading="lazy">
                                             {% endif %}
                                         </div>
@@ -190,7 +190,7 @@
                                             <p>
                                                 <a href="{% url 'creator:detail' creator.creators__slug %}">{{ creator.creators__name }}</a>
                                                 <br>
-                                                <small class="has-text-grey-dark">{{ creator.count }} issue{{ creator.count|pluralize }}</small>
+                                                <small class="has-text-grey-dark">{% blocktrans count counter=creator.count %}{{ counter }} issue{% plural %}{{ counter }} issues{% endblocktrans %}</small>
                                             </p>
                                         </div>
                                     </div>
@@ -203,7 +203,7 @@
             {# Top Characters #}
             {% if characters %}
                 <div class="box">
-                    <h2 class="title is-5">Top Character Appearances ({{ characters|length }})</h2>
+                    <h2 class="title is-5">{% blocktrans with count=characters|length %}Top Character Appearances ({{ count }}){% endblocktrans %}</h2>
                     <div class="columns is-multiline">
                         {% for character in characters %}
                             <div class="column is-4">
@@ -222,7 +222,7 @@
                                             {% else %}
                                                 <img class="is-rounded"
                                                      src="{% static 'site/img/creator-not-found.webp' %}"
-                                                     alt="No image for {{ character.characters__name }}"
+                                                     alt="{% blocktrans %}No image for {{ character.characters__name }}{% endblocktrans %}"
                                                      loading="lazy">
                                             {% endif %}
                                         </div>
@@ -232,7 +232,7 @@
                                             <p>
                                                 <a href="{% url 'character:detail' character.characters__slug %}">{{ character.characters__name }}</a>
                                                 <br>
-                                                <small class="has-text-grey-dark">{{ character.count }} issue{{ character.count|pluralize }}</small>
+                                                <small class="has-text-grey-dark">{% blocktrans count counter=character.count %}{{ counter }} issue{% plural %}{{ counter }} issues{% endblocktrans %}</small>
                                             </p>
                                         </div>
                                     </div>
@@ -252,50 +252,56 @@
         {# Metadata Sidebar #}
         <div class="column is-one-fifth">
             <div class="box">
-                <h2 class="title is-6">Series Details</h2>
+                <h2 class="title is-6">{% trans "Series Details" %}</h2>
                 <dl>
-                    <dt class="has-text-weight-bold">Publisher:</dt>
+                    <dt class="has-text-weight-bold">{% trans "Publisher:" %}</dt>
                     <dd class="mb-3">
                         <a href="{% url 'publisher:detail' series.publisher.slug %}">{{ series.publisher }}</a>
                     </dd>
                     {% if series.imprint %}
-                        <dt class="has-text-weight-bold">Imprint:</dt>
+                        <dt class="has-text-weight-bold">{% trans "Imprint:" %}</dt>
                         <dd class="mb-3">
                             <a href="{% url 'imprint:detail' series.imprint.slug %}">{{ series.imprint }}</a>
                         </dd>
                     {% endif %}
-                    <dt class="has-text-weight-bold">Type:</dt>
+                    <dt class="has-text-weight-bold">{% trans "Type:" %}</dt>
                     <dd class="mb-3">
                         {{ series.series_type }}
                     </dd>
-                    <dt class="has-text-weight-bold">Status:</dt>
+                    <dt class="has-text-weight-bold">{% trans "Status:" %}</dt>
                     <dd class="mb-3">
                         {{ series.get_status_display }}
                     </dd>
                     {% if series.volume %}
-                        <dt class="has-text-weight-bold">Volume:</dt>
+                        <dt class="has-text-weight-bold">{% trans "Volume:" %}</dt>
                         <dd class="mb-3">
                             {{ series.volume }}
                         </dd>
                     {% endif %}
-                    <dt class="has-text-weight-bold">Started:</dt>
+                    <dt class="has-text-weight-bold">{% trans "Started:" %}</dt>
                     <dd class="mb-3">
                         {{ series.year_began }}
                     </dd>
                     {% if series.year_end %}
-                        <dt class="has-text-weight-bold">Ended:</dt>
+                        <dt class="has-text-weight-bold">{% trans "Ended:" %}</dt>
                         <dd class="mb-3">
                             {{ series.year_end }}
                         </dd>
                     {% endif %}
                     {% if series.issue_count > 0 %}
-                        <dt class="has-text-weight-bold">Number of Issues:</dt>
+                        <dt class="has-text-weight-bold">{% trans "Number of Issues:" %}</dt>
                         <dd class="mb-3">
                             {{ series.issue_count|intcomma }}
                         </dd>
                     {% endif %}
                     {% if series.alt_names %}
-                        <dt class="has-text-weight-bold">Alternative Name{{ series.alt_names|pluralize }}:</dt>
+                        <dt class="has-text-weight-bold">
+                            {% if series.alt_names|length > 1 %}
+                                {% trans "Alternative Names:" %}
+                            {% else %}
+                                {% trans "Alternative Name:" %}
+                            {% endif %}
+                        </dt>
                         <dd class="mb-3">
                             {{ series.alt_names|join:", " }}
                         </dd>
@@ -304,7 +310,13 @@
                 {# Genres #}
                 {% with genres=series.genres.all %}
                     {% if genres %}
-                        <h3 class="title is-6 mt-4">Genre{{ genres|pluralize }}</h3>
+                        <h3 class="title is-6 mt-4">
+                            {% if genres|length > 1 %}
+                                {% trans "Genres" %}
+                            {% else %}
+                                {% trans "Genre" %}
+                            {% endif %}
+                        </h3>
                         <ul class="menu-list">
                             {% for genre in genres %}<li>{{ genre.name }}</li>{% endfor %}
                         </ul>
@@ -313,21 +325,21 @@
             </div>
             {# Identification Numbers #}
             <div class="box">
-                <h2 class="title is-6">Identification Numbers</h2>
+                <h2 class="title is-6">{% trans "Identification Numbers" %}</h2>
                 <dl>
-                    <dt class="has-text-weight-bold">Metron:</dt>
+                    <dt class="has-text-weight-bold">{% trans "Metron:" %}</dt>
                     <dd class="mb-2 is-flex is-align-items-center is-justify-content-space-between">
                         <span class="is-family-monospace">{{ series.id }}</span>
                         <button type="button"
                                 class="button is-small is-light copy-id"
                                 data-copy="{{ series.id }}"
-                                title="Copy Metron ID"
-                                aria-label="Copy Metron ID">
+                                title="{% trans 'Copy Metron ID' %}"
+                                aria-label="{% trans 'Copy Metron ID' %}">
                             <span class="icon is-small"><i class="fas fa-copy"></i></span>
                         </button>
                     </dd>
                     {% if series.cv_id %}
-                        <dt class="has-text-weight-bold">Comic Vine:</dt>
+                        <dt class="has-text-weight-bold">{% trans "Comic Vine:" %}</dt>
                         <dd class="mb-2 is-flex is-align-items-center is-justify-content-space-between">
                             <a class="is-family-monospace"
                                href="https://comicvine.gamespot.com/volume/4050-{{ series.cv_id }}/"
@@ -339,15 +351,15 @@
                             <button type="button"
                                     class="button is-small is-light copy-id"
                                     data-copy="{{ series.cv_id }}"
-                                    title="Copy Comic Vine ID"
-                                    aria-label="Copy Comic Vine ID">
+                                    title="{% trans 'Copy Comic Vine ID' %}"
+                                    aria-label="{% trans 'Copy Comic Vine ID' %}">
                                 <span class="icon is-small"><i class="fas fa-copy"></i></span>
                             </button>
                         </dd>
                     {% endif %}
                     {% if series.gcd_id %}
                         <dt class="has-text-weight-bold">
-                            <abbr title="Grand Comics Database">GCD</abbr>:
+                            <abbr title="{% trans 'Grand Comics Database' %}">GCD</abbr>:
                         </dt>
                         <dd class="is-flex is-align-items-center is-justify-content-space-between">
                             <a class="is-family-monospace"
@@ -360,8 +372,8 @@
                             <button type="button"
                                     class="button is-small is-light copy-id"
                                     data-copy="{{ series.gcd_id }}"
-                                    title="Copy GCD ID"
-                                    aria-label="Copy GCD ID">
+                                    title="{% trans 'Copy GCD ID' %}"
+                                    aria-label="{% trans 'Copy GCD ID' %}">
                                 <span class="icon is-small"><i class="fas fa-copy"></i></span>
                             </button>
                         </dd>
@@ -373,7 +385,7 @@
             {% with assoc=series.associated.all %}
                 {% if assoc %}
                     <div class="box">
-                        <h2 class="title is-6">Associated Series</h2>
+                        <h2 class="title is-6">{% trans "Associated Series" %}</h2>
                         <ul class="menu-list">
                             {% for associated in assoc %}
                                 <li>

--- a/comicsdb/templates/comicsdb/series_list.html
+++ b/comicsdb/templates/comicsdb/series_list.html
@@ -1,14 +1,14 @@
 {% extends parent_template|default:"base.html" %}
-{% load static %}
+{% load i18n static %}
 {% block title %}
     {% if title %}{{ title }}{% endif %}
-    Series - Metron
+    {% trans "Series - Metron" %}
 {% endblock %}
 {% block content %}
     <header class="block has-text-centered">
         <h1 class="title">
             {% if title %}{{ title }}{% endif %}
-            Series
+            {% trans "Series" %}
         </h1>
     </header>
     <section class="section">
@@ -22,12 +22,12 @@
     {% if series_list %}
         <section class="section pt-0">
             <div class="container">
-                <nav class="level" aria-label="List navigation and actions">
+                <nav class="level" aria-label="{% trans 'List navigation and actions' %}">
                     <div class="level-left">
                         {# Item Count #}
                         <div class="level-item">
                             <p class="subtitle is-5">
-                                <strong>{{ page_obj.paginator.count|default:series_list.count }}</strong> Series
+                                <strong>{{ page_obj.paginator.count|default:series_list.count }}</strong> {% trans "Series" %}
                             </p>
                         </div>
                     </div>
@@ -37,12 +37,12 @@
                             <div class="level-item">
                                 <a class="button is-primary"
                                    href="{% url 'series:create' %}"
-                                   title="Add a new series"
-                                   aria-label="Add a new series">
+                                   title="{% trans 'Add a new series' %}"
+                                   aria-label="{% trans 'Add a new series' %}">
                                     <span class="icon is-small" aria-hidden="true">
                                         <i class="fas fa-plus"></i>
                                     </span>
-                                    <span>New</span>
+                                    <span>{% trans "New" %}</span>
                                 </a>
                             </div>
                         </div>
@@ -56,14 +56,16 @@
         <section class="section pt-0">
             <div class="container has-text-centered">
                 {% if has_active_filters %}
-                    <p class="title is-4">No results found</p>
-                    <p class="subtitle">Try adjusting your search filters</p>
+                    <p class="title is-4">{% trans "No results found" %}</p>
+                    <p class="subtitle">{% trans "Try adjusting your search filters" %}</p>
                     <a href="{% url 'series:list' %}" class="button is-light is-medium">
                         <span class="icon"><i class="fas fa-times"></i></span>
-                        <span>Clear All Filters</span>
+                        <span>{% trans "Clear All Filters" %}</span>
                     </a>
                 {% else %}
-                    {% include "comicsdb/partials/empty_state.html" with item_type="Series" create_url="series:create" create_title="Add a new series" %}
+                    {% trans "Series" as series_label %}
+                    {% trans "Add a new series" as series_create_title %}
+                    {% include "comicsdb/partials/empty_state.html" with item_type=series_label item_type_plural=series_label create_url="series:create" create_title=series_create_title %}
                 {% endif %}
             </div>
         </section>

--- a/comicsdb/templates/comicsdb/statistics.html
+++ b/comicsdb/templates/comicsdb/statistics.html
@@ -1,65 +1,65 @@
 {% extends parent_template|default:"base.html" %}
-{% load static %}
+{% load i18n static %}
 {% load humanize %}
 {% block headscripts %}
     <script src="{% static 'chartkick/Chart.bundle.js' %}"></script>
     <script src="{% static 'chartkick/chartkick.js' %}"></script>
 {% endblock %}
 {% block title %}
-    Statistics - Metron
+    {% trans "Statistics - Metron" %}
 {% endblock title %}
 {% block content %}
     {# Page Header #}
     <header class="block has-text-centered">
-        <h1 class="title is-3">Metron Database Statistics</h1>
+        <h1 class="title is-3">{% trans "Metron Database Statistics" %}</h1>
         <p class="subtitle is-6 has-text-grey">
-            Last Updated: <time datetime="{{ update_time|date:'c' }}">{{ update_time }}</time>
+            {% blocktrans with update_time_value=update_time %}Last Updated: <time datetime="{{ update_time_value|date:'c' }}">{{ update_time_value }}</time>{% endblocktrans %}
         </p>
     </header>
     {# Summary Totals #}
     <section class="section">
         <div class="box has-background-light">
-            <h2 class="title is-4 has-text-centered has-text-dark mb-5">Database Totals</h2>
+            <h2 class="title is-4 has-text-centered has-text-dark mb-5">{% trans "Database Totals" %}</h2>
             <div class="columns is-multiline">
                 <div class="column is-3">
                     <div class="box has-text-centered">
-                        <p class="heading">Publishers</p>
+                        <p class="heading">{% trans "Publishers" %}</p>
                         <p class="title is-3 has-text-primary">{{ publishers_total|intcomma }}</p>
                     </div>
                 </div>
                 <div class="column is-3">
                     <div class="box has-text-centered">
-                        <p class="heading">Series</p>
+                        <p class="heading">{% trans "Series" %}</p>
                         <p class="title is-3 has-text-info">{{ series_total|intcomma }}</p>
                     </div>
                 </div>
                 <div class="column is-3">
                     <div class="box has-text-centered">
-                        <p class="heading">Issues</p>
+                        <p class="heading">{% trans "Issues" %}</p>
                         <p class="title is-3 has-text-link">{{ issues_total|intcomma }}</p>
                     </div>
                 </div>
                 <div class="column is-3">
                     <div class="box has-text-centered">
-                        <p class="heading">Characters</p>
+                        <p class="heading">{% trans "Characters" %}</p>
                         <p class="title is-3 has-text-success">{{ characters_total|intcomma }}</p>
                     </div>
                 </div>
                 <div class="column is-3">
                     <div class="box has-text-centered">
-                        <p class="heading">Creators</p>
+                        <p class="heading">{% trans "Creators" %}</p>
                         <p class="title is-3 has-text-warning">{{ creators_total|intcomma }}</p>
                     </div>
                 </div>
                 <div class="column is-3">
                     <div class="box has-text-centered">
-                        <p class="heading">Teams</p>
+                        <p class="heading">{% trans "Teams" %}</p>
                         <p class="title is-3 has-text-danger">{{ teams_total|intcomma }}</p>
                     </div>
                 </div>
                 <div class="column is-3">
                     <div class="box has-text-centered">
-                        <p class="heading">Story Arcs</p>
+                        <p class="heading">{% trans "Story Arcs" %}</p>
                         <p class="title is-3 has-text-grey-dark">{{ arcs_total|intcomma }}</p>
                     </div>
                 </div>
@@ -68,7 +68,7 @@
     </section>
     {# Charts Section #}
     <section class="section">
-        <h2 class="title is-4 has-text-centered mb-5">Statistical Analysis</h2>
+        <h2 class="title is-4 has-text-centered mb-5">{% trans "Statistical Analysis" %}</h2>
         {# Issues by Year #}
         <div class="box mb-5">
             <div class="content">{{ year_count }}</div>
@@ -108,10 +108,9 @@
     <section class="section">
         <div class="notification is-info is-light">
             <div class="content">
-                <p class="has-text-weight-bold">About These Statistics</p>
+                <p class="has-text-weight-bold">{% trans "About These Statistics" %}</p>
                 <p>
-                    These statistics are automatically generated from the Metron database and are updated every 30 minutes.
-                    They represent the collective efforts of our community in building a comprehensive comic book database.
+                    {% blocktrans %}These statistics are automatically generated from the Metron database and are updated every 30 minutes. They represent the collective efforts of our community in building a comprehensive comic book database.{% endblocktrans %}
                 </p>
             </div>
         </div>

--- a/comicsdb/templates/comicsdb/team_detail.html
+++ b/comicsdb/templates/comicsdb/team_detail.html
@@ -1,6 +1,6 @@
 {% extends parent_template|default:"base.html" %}
 {% load thumbnail %}
-{% load static %}
+{% load i18n static %}
 {% load humanize %}
 {% block title %}
     {{ team.name }}
@@ -11,31 +11,31 @@
         <h1 class="title">{{ team }}</h1>
     </header>
     {# Navigation Bar #}
-    <nav class="level mb-5" aria-label="Team navigation">
+    <nav class="level mb-5" aria-label="{% trans 'Team navigation' %}">
         <div class="level-left">
             {% if navigation.previous_team %}
                 <a class="button is-link"
                    href="{% url 'team:detail' navigation.previous_team.slug %}"
-                   aria-label="Go to {{ navigation.previous_team }}">
+                   aria-label="{% blocktrans with previous_team=navigation.previous_team %}Go to {{ previous_team }}{% endblocktrans %}">
                     <span class="icon is-small"><i class="fas fa-arrow-left" aria-hidden="true"></i></span>
-                    <span>Previous Team</span>
+                    <span>{% trans "Previous Team" %}</span>
                 </a>
             {% else %}
                 <button class="button" disabled aria-disabled="true">
                     <span class="icon is-small"><i class="fas fa-arrow-left" aria-hidden="true"></i></span>
-                    <span>Previous Team</span>
+                    <span>{% trans "Previous Team" %}</span>
                 </button>
             {% endif %}
             {% if navigation.next_team %}
                 <a class="button is-link ml-2"
                    href="{% url 'team:detail' navigation.next_team.slug %}"
-                   aria-label="Go to {{ navigation.next_team }}">
-                    <span>Next Team</span>
+                   aria-label="{% blocktrans with next_team=navigation.next_team %}Go to {{ next_team }}{% endblocktrans %}">
+                    <span>{% trans "Next Team" %}</span>
                     <span class="icon is-small"><i class="fas fa-arrow-right" aria-hidden="true"></i></span>
                 </a>
             {% else %}
                 <button class="button ml-2" disabled aria-disabled="true">
-                    <span>Next Team</span>
+                    <span>{% trans "Next Team" %}</span>
                     <span class="icon is-small"><i class="fas fa-arrow-right" aria-hidden="true"></i></span>
                 </button>
             {% endif %}
@@ -45,9 +45,9 @@
                 <div class="buttons">
                     <a class="button is-primary"
                        href="{% url 'team:create' %}"
-                       title="Add a new team">
+                       title="{% trans 'Add a new team' %}">
                         <span class="icon is-small"><i class="fas fa-plus" aria-hidden="true"></i></span>
-                        <span>New</span>
+                        <span>{% trans "New" %}</span>
                     </a>
                     <div class="dropdown is-right" id="team-actions-dropdown">
                         <div class="dropdown-trigger">
@@ -55,7 +55,7 @@
                                     aria-haspopup="true"
                                     aria-controls="team-actions-menu"
                                     hx-on:click="document.getElementById('team-actions-dropdown').classList.toggle('is-active')">
-                                <span>Actions</span>
+                                <span>{% trans "Actions" %}</span>
                                 <span class="icon is-small"><i class="fas fa-angle-down" aria-hidden="true"></i></span>
                             </button>
                         </div>
@@ -64,19 +64,19 @@
                                 <a class="dropdown-item"
                                    href="{% url 'team:update' team.slug %}">
                                     <span class="icon is-small"><i class="fas fa-edit" aria-hidden="true"></i></span>
-                                    <span>Edit</span>
+                                    <span>{% trans "Edit" %}</span>
                                 </a>
                                 <a class="dropdown-item"
                                    href="{% url 'team:history' team.slug %}">
                                     <span class="icon is-small"><i class="fas fa-history" aria-hidden="true"></i></span>
-                                    <span>History</span>
+                                    <span>{% trans "History" %}</span>
                                 </a>
                                 {% if perms.comicsdb.delete_team %}
                                     <hr class="dropdown-divider">
                                     <a class="dropdown-item has-text-danger"
                                        href="{% url 'team:delete' team.slug %}">
                                         <span class="icon is-small"><i class="fas fa-trash" aria-hidden="true"></i></span>
-                                        <span>Delete</span>
+                                        <span>{% trans "Delete" %}</span>
                                     </a>
                                 {% endif %}
                             </div>
@@ -110,7 +110,7 @@
                         {% endthumbnail %}
                     {% else %}
                         <img src="{% static 'site/img/image-not-found.webp' %}"
-                             alt="No image for {{ team.name }}"
+                             alt="{% blocktrans %}No image for {{ team.name }}{% endblocktrans %}"
                              loading="lazy">
                     {% endif %}
                 </figure>
@@ -120,21 +120,21 @@
         <div class="column">
             {# Summary #}
             <div class="box">
-                <h2 class="title is-5">Summary</h2>
+                <h2 class="title is-5">{% trans "Summary" %}</h2>
                 {% if team.desc %}
                     <div class="content">{{ team.desc|linebreaksbr }}</div>
                 {% else %}
-                    <p class="has-text-grey">No information available.</p>
+                    <p class="has-text-grey">{% trans "No information available." %}</p>
                 {% endif %}
                 <footer class="content is-small is-italic mt-4">
-                    Last edited on <time datetime="{{ team.modified|date:'c' }}">{{ team.modified }}</time> by
+                    {% blocktrans with modified_time=team.modified %}Last edited on <time datetime="{{ modified_time|date:'c' }}">{{ modified_time }}</time> by{% endblocktrans %}
                     <a href="{% url 'user-detail' username=team.edited_by.username %}">{{ team.edited_by.username }}</a>
                 </footer>
             </div>
             {# Members #}
             {% if member_count > 0 %}
                 <div class="box">
-                    <h2 class="title is-5">Member{{ member_count|pluralize }} ({{ member_count }})</h2>
+                    <h2 class="title is-5">{% blocktrans count counter=member_count %}Member ({{ counter }}){% plural %}Members ({{ counter }}){% endblocktrans %}</h2>
                     <div id="members-container" class="columns is-multiline">
                         {% for character in members %}
                             <div class="column is-4">
@@ -153,7 +153,7 @@
                                             {% else %}
                                                 <img class="is-rounded"
                                                      src="{% static 'site/img/creator-not-found.webp' %}"
-                                                     alt="No image for {{ character }}"
+                                                     alt="{% blocktrans %}No image for {{ character }}{% endblocktrans %}"
                                                      loading="lazy">
                                             {% endif %}
                                         </div>
@@ -172,7 +172,7 @@
                                     hx-target="#members-container"
                                     hx-swap="beforeend"
                                     hx-indicator="#members-spinner">
-                                <span>Load More Members</span>
+                                <span>{% trans "Load More Members" %}</span>
                             </button>
                             <span id="members-spinner" class="htmx-indicator ml-2">
                                 <i class="fas fa-spinner fa-spin"></i>
@@ -191,9 +191,9 @@
         {# Metadata Sidebar #}
         <div class="column is-one-fifth">
             <div class="box">
-                <h2 class="title is-6">Team Details</h2>
+                <h2 class="title is-6">{% trans "Team Details" %}</h2>
                 <dl>
-                    <dt class="has-text-weight-bold">Number of Issues:</dt>
+                    <dt class="has-text-weight-bold">{% trans "Number of Issues:" %}</dt>
                     <dd class="mb-3">
                         {{ team.issue_count|intcomma }}
                     </dd>
@@ -201,7 +201,13 @@
                 {# Creators #}
                 {% with creators=team.creators.all %}
                     {% if creators %}
-                        <h3 class="title is-6 mt-4">Creator{{ creators|pluralize }}</h3>
+                        <h3 class="title is-6 mt-4">
+                            {% if creators|length > 1 %}
+                                {% trans "Creators" %}
+                            {% else %}
+                                {% trans "Creator" %}
+                            {% endif %}
+                        </h3>
                         <ul class="menu-list">
                             {% for creator in creators %}
                                 <li>
@@ -214,7 +220,13 @@
                 {# Universes #}
                 {% with universes=team.universes.all %}
                     {% if universes %}
-                        <h3 class="title is-6 mt-4">Universe{{ universes|pluralize }}</h3>
+                        <h3 class="title is-6 mt-4">
+                            {% if universes|length > 1 %}
+                                {% trans "Universes" %}
+                            {% else %}
+                                {% trans "Universe" %}
+                            {% endif %}
+                        </h3>
                         <ul class="menu-list">
                             {% for universe in universes %}
                                 <li>
@@ -227,21 +239,21 @@
             </div>
             {# Identification Numbers #}
             <div class="box">
-                <h2 class="title is-6">Identification Numbers</h2>
+                <h2 class="title is-6">{% trans "Identification Numbers" %}</h2>
                 <dl>
-                    <dt class="has-text-weight-bold">Metron:</dt>
+                    <dt class="has-text-weight-bold">{% trans "Metron:" %}</dt>
                     <dd class="mb-2 is-flex is-align-items-center is-justify-content-space-between">
                         <span class="is-family-monospace">{{ team.id }}</span>
                         <button type="button"
                                 class="button is-small is-light copy-id"
                                 data-copy="{{ team.id }}"
-                                title="Copy Metron ID"
-                                aria-label="Copy Metron ID">
+                                title="{% trans 'Copy Metron ID' %}"
+                                aria-label="{% trans 'Copy Metron ID' %}">
                             <span class="icon is-small"><i class="fas fa-copy"></i></span>
                         </button>
                     </dd>
                     {% if team.cv_id %}
-                        <dt class="has-text-weight-bold">Comic Vine:</dt>
+                        <dt class="has-text-weight-bold">{% trans "Comic Vine:" %}</dt>
                         <dd class="mb-2 is-flex is-align-items-center is-justify-content-space-between">
                             <a class="is-family-monospace"
                                href="https://comicvine.gamespot.com/team/4060-{{ team.cv_id }}/"
@@ -253,15 +265,15 @@
                             <button type="button"
                                     class="button is-small is-light copy-id"
                                     data-copy="{{ team.cv_id }}"
-                                    title="Copy Comic Vine ID"
-                                    aria-label="Copy Comic Vine ID">
+                                    title="{% trans 'Copy Comic Vine ID' %}"
+                                    aria-label="{% trans 'Copy Comic Vine ID' %}">
                                 <span class="icon is-small"><i class="fas fa-copy"></i></span>
                             </button>
                         </dd>
                     {% endif %}
                     {% if team.gcd_id %}
                         <dt class="has-text-weight-bold">
-                            <abbr title="Grand Comics Database">GCD</abbr>:
+                            <abbr title="{% trans 'Grand Comics Database' %}">GCD</abbr>:
                         </dt>
                         <dd class="is-flex is-align-items-center is-justify-content-space-between">
                             <a class="is-family-monospace"
@@ -274,8 +286,8 @@
                             <button type="button"
                                     class="button is-small is-light copy-id"
                                     data-copy="{{ team.gcd_id }}"
-                                    title="Copy GCD ID"
-                                    aria-label="Copy GCD ID">
+                                    title="{% trans 'Copy GCD ID' %}"
+                                    aria-label="{% trans 'Copy GCD ID' %}">
                                 <span class="icon is-small"><i class="fas fa-copy"></i></span>
                             </button>
                         </dd>

--- a/comicsdb/templates/comicsdb/team_list.html
+++ b/comicsdb/templates/comicsdb/team_list.html
@@ -1,17 +1,23 @@
 {% extends parent_template|default:"base.html" %}
-{% load static %}
-{% block title %}Teams - Metron{% endblock %}
+{% load i18n static %}
+{% block title %}{% trans "Teams - Metron" %}{% endblock %}
 {% block content %}
     <header class="block has-text-centered">
-        <h1 class="title">Teams List</h1>
+        <h1 class="title">{% trans "Teams List" %}</h1>
     </header>
+    {% trans "Team" as list_title %}
+    {% trans "Teams" as list_title_plural %}
+    {% trans "Find a team" as list_search_placeholder %}
+    {% trans "Issue" as issue_label %}
+    {% trans "Issues" as issue_label_plural %}
+    {% trans "Add a new team" as list_create_title %}
     {% if team_list %}
         <section>
-            {% include "comicsdb/partials/list_header.html" with title="Team" count=page_obj.paginator.count search_url="team:search" search_placeholder="Find a team" create_url="team:create" create_title="Add a new team" %}
-            {% include "comicsdb/partials/card_grid.html" with items=team_list detail_url_name="team:detail" image_ratio="is-2by3" default_image="site/img/image-not-found.webp" count_url_name="team:issue" count_label="issue" %}
+            {% include "comicsdb/partials/list_header.html" with title=list_title title_plural=list_title_plural count=page_obj.paginator.count search_url="team:search" search_placeholder=list_search_placeholder create_url="team:create" create_title=list_create_title %}
+            {% include "comicsdb/partials/card_grid.html" with items=team_list detail_url_name="team:detail" image_ratio="is-2by3" default_image="site/img/image-not-found.webp" count_url_name="team:issue" count_label=issue_label count_label_plural=issue_label_plural %}
         </section>
     {% else %}
-        {% include "comicsdb/partials/empty_state.html" with item_type="Team" create_url="team:create" create_title="Add a new team" %}
+        {% include "comicsdb/partials/empty_state.html" with item_type=list_title item_type_plural=list_title_plural create_url="team:create" create_title=list_create_title %}
     {% endif %}
 {% endblock %}
 {% block pagination %}

--- a/comicsdb/templates/comicsdb/universe_detail.html
+++ b/comicsdb/templates/comicsdb/universe_detail.html
@@ -1,6 +1,6 @@
 {% extends parent_template|default:"base.html" %}
 {% load thumbnail %}
-{% load static %}
+{% load i18n static %}
 {% load humanize %}
 {% block title %}
     {{ universe.name }}
@@ -11,31 +11,31 @@
         <h1 class="title">{{ universe }}</h1>
     </header>
     {# Navigation Bar #}
-    <nav class="level mb-5" aria-label="Universe navigation">
+    <nav class="level mb-5" aria-label="{% trans 'Universe navigation' %}">
         <div class="level-left">
             {% if navigation.previous_universe %}
                 <a class="button is-link"
                    href="{% url 'universe:detail' navigation.previous_universe.slug %}"
-                   aria-label="Go to {{ navigation.previous_universe }}">
+                   aria-label="{% blocktrans with previous_universe=navigation.previous_universe %}Go to {{ previous_universe }}{% endblocktrans %}">
                     <span class="icon is-small"><i class="fas fa-arrow-left" aria-hidden="true"></i></span>
-                    <span>Previous Universe</span>
+                    <span>{% trans "Previous Universe" %}</span>
                 </a>
             {% else %}
                 <button class="button" disabled aria-disabled="true">
                     <span class="icon is-small"><i class="fas fa-arrow-left" aria-hidden="true"></i></span>
-                    <span>Previous Universe</span>
+                    <span>{% trans "Previous Universe" %}</span>
                 </button>
             {% endif %}
             {% if navigation.next_universe %}
                 <a class="button is-link ml-2"
                    href="{% url 'universe:detail' navigation.next_universe.slug %}"
-                   aria-label="Go to {{ navigation.next_universe }}">
-                    <span>Next Universe</span>
+                   aria-label="{% blocktrans with next_universe=navigation.next_universe %}Go to {{ next_universe }}{% endblocktrans %}">
+                    <span>{% trans "Next Universe" %}</span>
                     <span class="icon is-small"><i class="fas fa-arrow-right" aria-hidden="true"></i></span>
                 </a>
             {% else %}
                 <button class="button ml-2" disabled aria-disabled="true">
-                    <span>Next Universe</span>
+                    <span>{% trans "Next Universe" %}</span>
                     <span class="icon is-small"><i class="fas fa-arrow-right" aria-hidden="true"></i></span>
                 </button>
             {% endif %}
@@ -45,9 +45,9 @@
                 <div class="buttons">
                     <a class="button is-primary"
                        href="{% url 'universe:create' %}"
-                       title="Add a new universe">
+                       title="{% trans 'Add a new universe' %}">
                         <span class="icon is-small"><i class="fas fa-plus" aria-hidden="true"></i></span>
-                        <span>New</span>
+                        <span>{% trans "New" %}</span>
                     </a>
                     <div class="dropdown is-right" id="universe-actions-dropdown">
                         <div class="dropdown-trigger">
@@ -55,7 +55,7 @@
                                     aria-haspopup="true"
                                     aria-controls="universe-actions-menu"
                                     hx-on:click="document.getElementById('universe-actions-dropdown').classList.toggle('is-active')">
-                                <span>Actions</span>
+                                <span>{% trans "Actions" %}</span>
                                 <span class="icon is-small"><i class="fas fa-angle-down" aria-hidden="true"></i></span>
                             </button>
                         </div>
@@ -64,19 +64,19 @@
                                 <a class="dropdown-item"
                                    href="{% url 'universe:update' universe.slug %}">
                                     <span class="icon is-small"><i class="fas fa-edit" aria-hidden="true"></i></span>
-                                    <span>Edit</span>
+                                    <span>{% trans "Edit" %}</span>
                                 </a>
                                 <a class="dropdown-item"
                                    href="{% url 'universe:history' universe.slug %}">
                                     <span class="icon is-small"><i class="fas fa-history" aria-hidden="true"></i></span>
-                                    <span>History</span>
+                                    <span>{% trans "History" %}</span>
                                 </a>
                                 {% if perms.comicsdb.delete_universe %}
                                     <hr class="dropdown-divider">
                                     <a class="dropdown-item has-text-danger"
                                        href="{% url 'universe:delete' universe.slug %}">
                                         <span class="icon is-small"><i class="fas fa-trash" aria-hidden="true"></i></span>
-                                        <span>Delete</span>
+                                        <span>{% trans "Delete" %}</span>
                                     </a>
                                 {% endif %}
                             </div>
@@ -110,7 +110,7 @@
                         {% endthumbnail %}
                     {% else %}
                         <img src="{% static 'site/img/image-not-found.webp' %}"
-                             alt="No image for {{ universe.name }}"
+                             alt="{% blocktrans %}No image for {{ universe.name }}{% endblocktrans %}"
                              loading="lazy">
                     {% endif %}
                 </figure>
@@ -120,21 +120,21 @@
         <div class="column">
             {# Summary #}
             <div class="box">
-                <h2 class="title is-5">Summary</h2>
+                <h2 class="title is-5">{% trans "Summary" %}</h2>
                 {% if universe.desc %}
                     <div class="content">{{ universe.desc|linebreaksbr }}</div>
                 {% else %}
-                    <p class="has-text-grey">No information available.</p>
+                    <p class="has-text-grey">{% trans "No information available." %}</p>
                 {% endif %}
                 <footer class="content is-small is-italic mt-4">
-                    Last edited on <time datetime="{{ universe.modified|date:'c' }}">{{ universe.modified }}</time> by
+                    {% blocktrans with modified_time=universe.modified %}Last edited on <time datetime="{{ modified_time|date:'c' }}">{{ modified_time }}</time> by{% endblocktrans %}
                     <a href="{% url 'user-detail' username=universe.edited_by.username %}">{{ universe.edited_by.username }}</a>
                 </footer>
             </div>
             {# Characters #}
             {% if universe.character_count > 0 %}
                 <div class="box">
-                    <h2 class="title is-5">Character{{ universe.character_count|pluralize }} ({{ universe.character_count }})</h2>
+                    <h2 class="title is-5">{% blocktrans count counter=universe.character_count %}Character ({{ counter }}){% plural %}Characters ({{ counter }}){% endblocktrans %}</h2>
                     <div class="columns is-multiline" id="characters-container">
                         {% for character in universe.characters.all|slice:":30" %}
                             <div class="column is-4">
@@ -153,7 +153,7 @@
                                             {% else %}
                                                 <img class="is-rounded"
                                                      src="{% static 'site/img/creator-not-found.webp' %}"
-                                                     alt="No image for {{ character }}"
+                                                     alt="{% blocktrans %}No image for {{ character }}{% endblocktrans %}"
                                                      loading="lazy">
                                             {% endif %}
                                         </div>
@@ -173,7 +173,7 @@
                                     hx-target="#characters-container"
                                     hx-swap="beforeend"
                                     hx-indicator="#characters-spinner">
-                                <span>Load More Characters</span>
+                                <span>{% trans "Load More Characters" %}</span>
                             </button>
                             <span id="characters-spinner" class="htmx-indicator ml-2">
                                 <i class="fas fa-spinner fa-spin"></i>
@@ -185,7 +185,7 @@
             {# Teams #}
             {% if universe.team_count > 0 %}
                 <div class="box">
-                    <h2 class="title is-5">Team{{ universe.team_count|pluralize }} ({{ universe.team_count }})</h2>
+                    <h2 class="title is-5">{% blocktrans count counter=universe.team_count %}Team ({{ counter }}){% plural %}Teams ({{ counter }}){% endblocktrans %}</h2>
                     <div class="columns is-multiline" id="teams-container">
                         {% for team in universe.teams.all|slice:":30" %}
                             <div class="column is-4">
@@ -204,7 +204,7 @@
                                             {% else %}
                                                 <img class="is-rounded"
                                                      src="{% static 'site/img/creator-not-found.webp' %}"
-                                                     alt="No image for {{ team }}"
+                                                     alt="{% blocktrans %}No image for {{ team }}{% endblocktrans %}"
                                                      loading="lazy">
                                             {% endif %}
                                         </div>
@@ -224,7 +224,7 @@
                                     hx-target="#teams-container"
                                     hx-swap="beforeend"
                                     hx-indicator="#teams-spinner">
-                                <span>Load More Teams</span>
+                                <span>{% trans "Load More Teams" %}</span>
                             </button>
                             <span id="teams-spinner" class="htmx-indicator ml-2">
                                 <i class="fas fa-spinner fa-spin"></i>
@@ -236,7 +236,7 @@
             {# Series Appearances #}
             {% if appearances %}
                 <div class="box">
-                    <h2 class="title is-5">Series Appearances ({{ series_count }})</h2>
+                    <h2 class="title is-5">{% blocktrans %}Series Appearances ({{ series_count }}){% endblocktrans %}</h2>
                     <div class="content">
                         <ul id="series-list">
                             {% for series in appearances %}
@@ -250,12 +250,12 @@
                                         {% elif series.issues__series__series_type == 8 %}
                                             HC
                                         {% elif series.issues__series__series_type == 12 %}
-                                            Digital
+                                            {% trans "Digital" %}
                                         {% endif %}
                                         ({{ series.issues__series__year_began }})
                                     </a>:
                                     <a href="{% url 'universe:series' universe=universe.slug series=series.issues__series__slug %}">
-                                        {{ series.issues__count }} issue{{ series.issues__count|pluralize }}
+                                        {% blocktrans count counter=series.issues__count %}{{ counter }} issue{% plural %}{{ counter }} issues{% endblocktrans %}
                                     </a>
                                 </li>
                             {% endfor %}
@@ -267,7 +267,7 @@
                                         hx-target="#series-list"
                                         hx-swap="beforeend"
                                         hx-indicator="#series-spinner">
-                                    <span>Load More Series</span>
+                                    <span>{% trans "Load More Series" %}</span>
                                 </button>
                                 <span id="series-spinner" class="htmx-indicator ml-2">
                                     <i class="fas fa-spinner fa-spin"></i>
@@ -287,19 +287,19 @@
         {# Metadata Sidebar #}
         <div class="column is-one-fifth">
             <div class="box">
-                <h2 class="title is-6">Universe Details</h2>
+                <h2 class="title is-6">{% trans "Universe Details" %}</h2>
                 <dl>
-                    <dt class="has-text-weight-bold">Publisher:</dt>
+                    <dt class="has-text-weight-bold">{% trans "Publisher:" %}</dt>
                     <dd class="mb-3">
                         <a href="{% url 'publisher:detail' universe.publisher.slug %}">{{ universe.publisher }}</a>
                     </dd>
                     {% if universe.total_issue_count > 0 %}
-                        <dt class="has-text-weight-bold">Number of Issues:</dt>
+                        <dt class="has-text-weight-bold">{% trans "Number of Issues:" %}</dt>
                         <dd class="mb-3">
                             {{ universe.total_issue_count|intcomma }}
                         </dd>
                         {% with first=universe.first_appearance %}
-                            <dt class="has-text-weight-bold">First Appearance:</dt>
+                            <dt class="has-text-weight-bold">{% trans "First Appearance:" %}</dt>
                             <dd class="mb-3">
                                 <a href="{% url 'issue:detail' first.slug %}">{{ first }}</a>
                             </dd>
@@ -309,22 +309,22 @@
             </div>
             {# Identification Numbers #}
             <div class="box">
-                <h2 class="title is-6">Identification Numbers</h2>
+                <h2 class="title is-6">{% trans "Identification Numbers" %}</h2>
                 <dl>
-                    <dt class="has-text-weight-bold">Metron:</dt>
+                    <dt class="has-text-weight-bold">{% trans "Metron:" %}</dt>
                     <dd class="mb-2 is-flex is-align-items-center is-justify-content-space-between">
                         <span class="is-family-monospace">{{ universe.id }}</span>
                         <button type="button"
                                 class="button is-small is-light copy-id"
                                 data-copy="{{ universe.id }}"
-                                title="Copy Metron ID"
-                                aria-label="Copy Metron ID">
+                                title="{% trans 'Copy Metron ID' %}"
+                                aria-label="{% trans 'Copy Metron ID' %}">
                             <span class="icon is-small"><i class="fas fa-copy"></i></span>
                         </button>
                     </dd>
                     {% if universe.gcd_id %}
                         <dt class="has-text-weight-bold">
-                            <abbr title="Grand Comics Database">GCD</abbr>:
+                            <abbr title="{% trans 'Grand Comics Database' %}">GCD</abbr>:
                         </dt>
                         <dd class="is-flex is-align-items-center is-justify-content-space-between">
                             <a class="is-family-monospace"
@@ -337,8 +337,8 @@
                             <button type="button"
                                     class="button is-small is-light copy-id"
                                     data-copy="{{ universe.gcd_id }}"
-                                    title="Copy GCD ID"
-                                    aria-label="Copy GCD ID">
+                                    title="{% trans 'Copy GCD ID' %}"
+                                    aria-label="{% trans 'Copy GCD ID' %}">
                                 <span class="icon is-small"><i class="fas fa-copy"></i></span>
                             </button>
                         </dd>

--- a/comicsdb/templates/comicsdb/universe_list.html
+++ b/comicsdb/templates/comicsdb/universe_list.html
@@ -1,17 +1,23 @@
 {% extends parent_template|default:"base.html" %}
-{% load static %}
-{% block title %}Universes - Metron{% endblock %}
+{% load i18n static %}
+{% block title %}{% trans "Universes - Metron" %}{% endblock %}
 {% block content %}
     <header class="block has-text-centered">
-        <h1 class="title">Universes List</h1>
+        <h1 class="title">{% trans "Universes List" %}</h1>
     </header>
+    {% trans "Universe" as list_title %}
+    {% trans "Universes" as list_title_plural %}
+    {% trans "Find a universe" as list_search_placeholder %}
+    {% trans "Issue" as issue_label %}
+    {% trans "Issues" as issue_label_plural %}
+    {% trans "Add a new universe" as list_create_title %}
     {% if universe_list %}
         <section>
-            {% include "comicsdb/partials/list_header.html" with title="Universe" count=page_obj.paginator.count search_url="universe:search" search_placeholder="Find a universe" create_url="universe:create" create_title="Add a new universe" %}
-            {% include "comicsdb/partials/card_grid.html" with items=universe_list detail_url_name="universe:detail" image_ratio="is-2by3" default_image="site/img/image-not-found.webp" count_url_name="universe:issue" count_label="Issue" %}
+            {% include "comicsdb/partials/list_header.html" with title=list_title title_plural=list_title_plural count=page_obj.paginator.count search_url="universe:search" search_placeholder=list_search_placeholder create_url="universe:create" create_title=list_create_title %}
+            {% include "comicsdb/partials/card_grid.html" with items=universe_list detail_url_name="universe:detail" image_ratio="is-2by3" default_image="site/img/image-not-found.webp" count_url_name="universe:issue" count_label=issue_label count_label_plural=issue_label_plural %}
         </section>
     {% else %}
-        {% include "comicsdb/partials/empty_state.html" with item_type="Universe" create_url="universe:create" create_title="Add a new universe" %}
+        {% include "comicsdb/partials/empty_state.html" with item_type=list_title item_type_plural=list_title_plural create_url="universe:create" create_title=list_create_title %}
     {% endif %}
 {% endblock %}
 {% block pagination %}

--- a/comicsdb/templates/comicsdb/week_list.html
+++ b/comicsdb/templates/comicsdb/week_list.html
@@ -1,19 +1,19 @@
 {% extends parent_template|default:"base.html" %}
-{% load static %}
+{% load i18n static %}
 {% block title %}
     {% if future %}
-        Future Releases - Metron
+        {% trans "Future Releases - Metron" %}
     {% else %}
-        New Comics - {{ release_day|date:'F d, Y' }} - Metron
+        {% blocktrans with release_date=release_day|date:'F d, Y' %}New Comics - {{ release_date }} - Metron{% endblocktrans %}
     {% endif %}
 {% endblock %}
 {% block content %}
     <header class="block has-text-centered">
         <h1 class="title">
             {% if not future %}
-                Comics Released the Week of {{ release_day|date:'F d, Y' }}
+                {% blocktrans with release_date=release_day|date:'F d, Y' %}Comics Released the Week of {{ release_date }}{% endblocktrans %}
             {% else %}
-                Future Releases
+                {% trans "Future Releases" %}
             {% endif %}
         </h1>
     </header>
@@ -29,14 +29,14 @@
         <section class="section pt-0">
             <div class="container">
                 {# Navigation Bar #}
-                <nav class="level" aria-label="Weekly releases navigation">
+                <nav class="level" aria-label="{% trans 'Weekly releases navigation' %}">
                     <div class="level-left">
                         <div class="level-item">
                             <p class="subtitle is-5">
                                 {% if page_obj.paginator %}
-                                    <strong>{{ page_obj.paginator.count }}</strong> Issue{{ page_obj.paginator.count|pluralize }}
+                                    {% blocktrans count counter=page_obj.paginator.count %}<strong>{{ counter }}</strong> Issue{% plural %}<strong>{{ counter }}</strong> Issues{% endblocktrans %}
                                 {% else %}
-                                    <strong>{{ issue_list.count }}</strong> Issue{{ issue_list.count|pluralize }}
+                                    {% blocktrans count counter=issue_list.count %}<strong>{{ counter }}</strong> Issue{% plural %}<strong>{{ counter }}</strong> Issues{% endblocktrans %}
                                 {% endif %}
                             </p>
                         </div>
@@ -49,12 +49,12 @@
                             <div class="level-item">
                                 <a class="button is-primary"
                                    href="{% url 'issue:create' %}"
-                                   title="Add a new issue"
-                                   aria-label="Add a new issue">
+                                   title="{% trans 'Add a new issue' %}"
+                                   aria-label="{% trans 'Add a new issue' %}">
                                     <span class="icon is-small" aria-hidden="true">
                                         <i class="fas fa-plus"></i>
                                     </span>
-                                    <span>New</span>
+                                    <span>{% trans "New" %}</span>
                                 </a>
                             </div>
                         {% endif %}
@@ -68,34 +68,34 @@
         <section class="section pt-0">
             <div class="container has-text-centered">
                 {% if has_active_filters %}
-                    <p class="title is-4">No results found</p>
-                    <p class="subtitle">Try adjusting your search filters</p>
+                    <p class="title is-4">{% trans "No results found" %}</p>
+                    <p class="subtitle">{% trans "Try adjusting your search filters" %}</p>
                     <a href="{{ request.path }}" class="button is-light is-medium">
                         <span class="icon"><i class="fas fa-times"></i></span>
-                        <span>Clear All Filters</span>
+                        <span>{% trans "Clear All Filters" %}</span>
                     </a>
                 {% else %}
                     <div class="content">
                         <span class="icon is-large has-text-grey-light" aria-hidden="true">
                             <i class="fas fa-calendar-times fa-3x"></i>
                         </span>
-                        <h2 class="title is-4">No Releases Found</h2>
+                        <h2 class="title is-4">{% trans "No Releases Found" %}</h2>
                         <p class="subtitle is-6 has-text-grey">
                             {% if future %}
-                                No future releases have been scheduled yet.
+                                {% trans "No future releases have been scheduled yet." %}
                             {% else %}
-                                No issues were released this week.
+                                {% trans "No issues were released this week." %}
                             {% endif %}
                         </p>
                         {% if user.is_authenticated %}
                             <a class="button is-primary is-medium"
                                href="{% url 'issue:create' %}"
-                               title="Add a new issue"
-                               aria-label="Add a new issue">
+                               title="{% trans 'Add a new issue' %}"
+                               aria-label="{% trans 'Add a new issue' %}">
                                 <span class="icon" aria-hidden="true">
                                     <i class="fas fa-plus"></i>
                                 </span>
-                                <span>Add Issue</span>
+                                <span>{% trans "Add Issue" %}</span>
                             </a>
                         {% endif %}
                     </div>

--- a/comicsdb/views/issue_list_helpers.py
+++ b/comicsdb/views/issue_list_helpers.py
@@ -7,6 +7,8 @@ diff to ``views/issue.py`` stays small. No new dependencies.
 
 from urllib.parse import urlencode
 
+from django.utils.translation import gettext_lazy as _
+
 from comicsdb.models.series import SeriesType
 
 # ---------------------------------------------------------------------------
@@ -18,19 +20,19 @@ from comicsdb.models.series import SeriesType
 # ordering) and renders first / selected when no sort is chosen.
 SORT_OPTIONS = {
     "": {
-        "label": "Series A\u2013Z",
+        "label": _("Series A\u2013Z"),
         "order": ["series__sort_name", "cover_date", "store_date", "number"],
     },
     "cover_new": {
-        "label": "Cover date (newest)",
+        "label": _("Cover date (newest)"),
         "order": ["-cover_date", "series__sort_name", "number"],
     },
     "cover_old": {
-        "label": "Cover date (oldest)",
+        "label": _("Cover date (oldest)"),
         "order": ["cover_date", "series__sort_name", "number"],
     },
     "added": {
-        "label": "Recently added",
+        "label": _("Recently added"),
         "order": ["-created_on", "series__sort_name", "number"],
     },
 }
@@ -53,38 +55,38 @@ _NON_FILTER_PARAMS = {"page", "sort"}
 
 # Human-readable labels for each filter param the issue browse exposes.
 FILTER_LABELS = {
-    "q": "Search",
-    "series_name": "Series",
-    "series_type": "Type",
-    "series_volume": "Volume",
-    "publisher_name": "Publisher",
-    "number": "Number",
-    "alt_number": "Alt number",
-    "cover_year": "Cover year",
-    "cover_month": "Cover month",
-    "store_date_after": "Store date from",
-    "store_date_before": "Store date to",
-    "foc_date_after": "FOC date from",
-    "foc_date_before": "FOC date to",
-    "upc": "UPC",
-    "sku": "SKU",
-    "cv_id": "Comic Vine ID",
-    "gcd_id": "GCD ID",
+    "q": _("Search"),
+    "series_name": _("Series"),
+    "series_type": _("Type"),
+    "series_volume": _("Volume"),
+    "publisher_name": _("Publisher"),
+    "number": _("Number"),
+    "alt_number": _("Alt number"),
+    "cover_year": _("Cover year"),
+    "cover_month": _("Cover month"),
+    "store_date_after": _("Store date from"),
+    "store_date_before": _("Store date to"),
+    "foc_date_after": _("FOC date from"),
+    "foc_date_before": _("FOC date to"),
+    "upc": _("UPC"),
+    "sku": _("SKU"),
+    "cv_id": _("Comic Vine ID"),
+    "gcd_id": _("GCD ID"),
 }
 
 _MONTHS = {
-    "1": "January",
-    "2": "February",
-    "3": "March",
-    "4": "April",
-    "5": "May",
-    "6": "June",
-    "7": "July",
-    "8": "August",
-    "9": "September",
-    "10": "October",
-    "11": "November",
-    "12": "December",
+    "1": _("January"),
+    "2": _("February"),
+    "3": _("March"),
+    "4": _("April"),
+    "5": _("May"),
+    "6": _("June"),
+    "7": _("July"),
+    "8": _("August"),
+    "9": _("September"),
+    "10": _("October"),
+    "11": _("November"),
+    "12": _("December"),
 }
 
 

--- a/comicsdb/views/series_list_helpers.py
+++ b/comicsdb/views/series_list_helpers.py
@@ -6,25 +6,27 @@ params exposed by SeriesViewFilter.
 
 from urllib.parse import urlencode
 
+from django.utils.translation import gettext_lazy as _
+
 from comicsdb.models import Series, SeriesType
 
 _NON_FILTER_PARAMS = {"page"}
 
 FILTER_LABELS = {
-    "q": "Search",
-    "name": "Name",
-    "alt_names": "Alternative Name",
-    "series_type": "Type",
-    "publisher_name": "Publisher",
-    "publisher_id": "Publisher ID",
-    "imprint_name": "Imprint",
-    "imprint_id": "Imprint ID",
-    "year_began": "Year Began",
-    "year_began_gte": "Year Began (from)",
-    "year_began_lte": "Year Began (to)",
-    "year_end": "Year Ended",
-    "status": "Status",
-    "volume": "Volume",
+    "q": _("Search"),
+    "name": _("Name"),
+    "alt_names": _("Alternative Name"),
+    "series_type": _("Type"),
+    "publisher_name": _("Publisher"),
+    "publisher_id": _("Publisher ID"),
+    "imprint_name": _("Imprint"),
+    "imprint_id": _("Imprint ID"),
+    "year_began": _("Year Began"),
+    "year_began_gte": _("Year Began (from)"),
+    "year_began_lte": _("Year Began (to)"),
+    "year_end": _("Year Ended"),
+    "status": _("Status"),
+    "volume": _("Volume"),
 }
 
 _STATUS_LABELS = {str(k): v for k, v in Series.Status.choices}

--- a/comicsdb/views/statistics.py
+++ b/comicsdb/views/statistics.py
@@ -5,6 +5,8 @@ from django.core.cache import cache
 from django.db.models import Count
 from django.db.models.functions import TruncDate, TruncMonth, TruncYear
 from django.shortcuts import render
+from django.utils.dateformat import format as date_format
+from django.utils.translation import gettext as _
 
 from comicsdb.models import Arc, Character, Creator, Issue, Publisher, Series, Team
 
@@ -47,7 +49,7 @@ def _create_monthly_issue_dict() -> dict[str, int]:
         )
         cache.set("monthly_issues", monthly_issues, CACHE_TTL)
 
-    return {issue["month"].strftime("%b"): issue["c"] for issue in monthly_issues[::-1]}
+    return {date_format(issue["month"], "M"): issue["c"] for issue in monthly_issues[::-1]}
 
 
 def _create_daily_issue_dict() -> dict[str, int]:
@@ -75,7 +77,7 @@ def _create_creator_dict() -> dict[str, int]:
         )
         cache.set("creators", creators, CACHE_TTL)
 
-    return {creator["month"].strftime("%b"): creator["c"] for creator in creators[::-1]}
+    return {date_format(creator["month"], "M"): creator["c"] for creator in creators[::-1]}
 
 
 def _create_character_dict() -> dict[str, int]:
@@ -89,7 +91,7 @@ def _create_character_dict() -> dict[str, int]:
         )
         cache.set("characters", characters, CACHE_TTL)
 
-    return {character["month"].strftime("%b"): character["c"] for character in characters[::-1]}
+    return {date_format(character["month"], "M"): character["c"] for character in characters[::-1]}
 
 
 def statistics(request):
@@ -131,29 +133,29 @@ def statistics(request):
     # Time based statistics
     pub_chart = PieChart(
         _create_pub_dict(),
-        title="Percentage of Issues by Publisher",
+        title=_("Percentage of Issues by Publisher"),
         thousands=",",
         legend=False,
     )
     year_chart = PieChart(
-        _create_year_count_dict(), title="Number of Issues Added per Year", thousands=","
+        _create_year_count_dict(), title=_("Number of Issues Added per Year"), thousands=","
     )
     daily_chart = ColumnChart(
         _create_daily_issue_dict(),
-        title="Number of Issues for the last 30 days",
+        title=_("Number of Issues for the last 30 days"),
         thousands=",",
     )
     monthly_chart = ColumnChart(
-        _create_monthly_issue_dict(), title="Number of Issues Added by Month", thousands=","
+        _create_monthly_issue_dict(), title=_("Number of Issues Added by Month"), thousands=","
     )
     creator_chart = ColumnChart(
         _create_creator_dict(),
-        title="Number of Creators Added by Month",
+        title=_("Number of Creators Added by Month"),
         thousands=",",
     )
     character_chart = ColumnChart(
         _create_character_dict(),
-        title="Number of Characters Added by Month",
+        title=_("Number of Characters Added by Month"),
         thousands=",",
     )
 

--- a/locale/it/LC_MESSAGES/django.po
+++ b/locale/it/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: metron\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-13 12:29-0400\n"
+"POT-Creation-Date: 2026-08-13 12:53-0400\n"
 "PO-Revision-Date: 2026-08-13 11:23-0400\n"
 "Last-Translator: Metron Project\n"
 "Language-Team: Italian\n"
@@ -266,6 +266,290 @@ msgstr "%(first)s e %(last)s"
 msgid "Successfully added %(parts)s from reprinted issues."
 msgstr "Aggiunti con successo %(parts)s dagli albi ristampati."
 
+#: polls/templates/polls/partials/poll_results.html:3
+msgid "Results"
+msgstr "Risultati"
+
+#: polls/templates/polls/partials/poll_results.html:21
+#: polls/templates/polls/poll_list.html:45
+#, python-format
+msgid "%(counter)s vote"
+msgid_plural "%(counter)s votes"
+msgstr[0] "%(counter)s voto"
+msgstr[1] "%(counter)s voti"
+
+#: polls/templates/polls/partials/poll_results.html:36
+#, python-format
+msgid "<strong>%(counter)s</strong> total vote"
+msgid_plural "<strong>%(counter)s</strong> total votes"
+msgstr[0] "<strong>%(counter)s</strong> voto totale"
+msgstr[1] "<strong>%(counter)s</strong> voti totali"
+
+#: polls/templates/polls/partials/poll_results.html:39
+msgid "No votes have been cast yet."
+msgstr "Non è stato ancora espresso alcun voto."
+
+#: polls/templates/polls/poll_confirm_delete.html:3
+msgid "Delete Poll - Metron"
+msgstr "Elimina Sondaggio - Metron"
+
+#: polls/templates/polls/poll_confirm_delete.html:10
+msgid "Delete Poll"
+msgstr "Elimina Sondaggio"
+
+#: polls/templates/polls/poll_confirm_delete.html:12
+#, python-format
+msgid ""
+"Are you sure you want to delete <strong>%(title)s</strong>? This will also "
+"delete all votes cast in this poll and cannot be undone."
+msgstr ""
+"Sei sicuro di voler eliminare <strong>%(title)s</strong>? Questo eliminerà "
+"anche tutti i voti espressi in questo sondaggio e non può essere annullato."
+
+#: polls/templates/polls/poll_confirm_delete.html:20
+#: polls/templates/polls/poll_detail.html:38
+msgid "Delete"
+msgstr "Elimina"
+
+#: polls/templates/polls/poll_confirm_delete.html:25
+#: pull_list/templates/pull_list/remove_series_confirm.html:27
+msgid "Cancel"
+msgstr "Annulla"
+
+#: polls/templates/polls/poll_detail.html:3
+#, python-format
+msgid "%(title)s - Metron"
+msgstr "%(title)s - Metron"
+
+#: polls/templates/polls/poll_detail.html:10 templates/partials/navbar.html:177
+msgid "Polls"
+msgstr "Sondaggi"
+
+#: polls/templates/polls/poll_detail.html:22
+#: polls/templates/polls/poll_detail.html:104
+#: polls/templates/polls/poll_list.html:25
+msgid "Active"
+msgstr "Attivo"
+
+#: polls/templates/polls/poll_detail.html:24
+#: polls/templates/polls/poll_detail.html:104
+#: polls/templates/polls/poll_list.html:27
+msgid "Upcoming"
+msgstr "In Arrivo"
+
+#: polls/templates/polls/poll_detail.html:26
+#: polls/templates/polls/poll_detail.html:104
+#: polls/templates/polls/poll_list.html:29
+msgid "Closed"
+msgstr "Chiuso"
+
+#: polls/templates/polls/poll_detail.html:48
+msgid "Proposal"
+msgstr "Proposta"
+
+#: polls/templates/polls/poll_detail.html:55
+msgid "Cast Your Vote"
+msgstr "Esprimi il Tuo Voto"
+
+#: polls/templates/polls/poll_detail.html:77
+msgid "Cast Vote"
+msgstr "Vota"
+
+#: polls/templates/polls/poll_detail.html:86
+#, python-format
+msgid "Voting opens on %(start_date)s."
+msgstr "Le votazioni si aprono il %(start_date)s."
+
+#: polls/templates/polls/poll_detail.html:90 templates/partials/navbar.html:273
+msgid "Log in"
+msgstr "Accedi"
+
+#: polls/templates/polls/poll_detail.html:91
+msgid "to cast your vote."
+msgstr "per esprimere il tuo voto."
+
+#: polls/templates/polls/poll_detail.html:100
+msgid "Poll Details"
+msgstr "Dettagli Sondaggio"
+
+#: polls/templates/polls/poll_detail.html:102
+msgid "Status:"
+msgstr "Stato:"
+
+#: polls/templates/polls/poll_detail.html:106
+msgid "Voting Opens:"
+msgstr "Apertura Votazioni:"
+
+#: polls/templates/polls/poll_detail.html:108
+msgid "Voting Closes:"
+msgstr "Chiusura Votazioni:"
+
+#: polls/templates/polls/poll_detail.html:110
+msgid "Total Votes:"
+msgstr "Voti Totali:"
+
+#: polls/templates/polls/poll_detail.html:113
+msgid "Created By:"
+msgstr "Creato Da:"
+
+#: polls/templates/polls/poll_list.html:3
+msgid "Community Polls - Metron"
+msgstr "Sondaggi della Community - Metron"
+
+#: polls/templates/polls/poll_list.html:6
+msgid "Community Polls"
+msgstr "Sondaggi della Community"
+
+#: polls/templates/polls/poll_list.html:7
+msgid "Vote on governance and policy proposals for the Metron project"
+msgstr "Vota le proposte di governance e policy per il progetto Metron"
+
+#: polls/templates/polls/poll_list.html:57
+msgid "No polls yet"
+msgstr "Nessun sondaggio ancora"
+
+#: polls/templates/polls/poll_list.html:58
+msgid "Check back later for community governance polls."
+msgstr "Torna più tardi per i sondaggi di governance della community."
+
+#: polls/views.py:79
+#, python-format
+msgid "Poll '%(title)s' deleted."
+msgstr "Sondaggio '%(title)s' eliminato."
+
+#: polls/views.py:91
+msgid "Voting is not currently open for this poll."
+msgstr "Le votazioni non sono attualmente aperte per questo sondaggio."
+
+#: polls/views.py:94
+msgid "You have already voted in this poll."
+msgstr "Hai già votato in questo sondaggio."
+
+#: polls/views.py:98
+msgid "No choice selected."
+msgstr "Nessuna scelta selezionata."
+
+#: pull_list/forms.py:16
+msgid "Search for a series..."
+msgstr "Cerca una serie..."
+
+#: pull_list/forms.py:20 pull_list/templates/pull_list/pulllist_detail.html:47
+#: templates/partials/navbar.html:74
+msgid "Series"
+msgstr "Serie"
+
+#: pull_list/forms.py:21
+msgid "Select a series to add to your pull list"
+msgstr "Seleziona una serie da aggiungere alla tua pull list"
+
+#: pull_list/models.py:27
+#: pull_list/templates/pull_list/partials/pull_list_button.html:11
+msgid "Pull List"
+msgstr "Pull List"
+
+#: pull_list/models.py:28
+msgid "Pull Lists"
+msgstr "Pull List"
+
+#: pull_list/models.py:56 pull_list/models.py:57
+msgid "Pull List Series"
+msgstr "Serie della Pull List"
+
+#: pull_list/templates/pull_list/partials/pull_list_button.html:7
+msgid "Remove from pull list"
+msgstr "Rimuovi dalla pull list"
+
+#: pull_list/templates/pull_list/partials/pull_list_button.html:7
+msgid "Add to pull list"
+msgstr "Aggiungi alla pull list"
+
+#: pull_list/templates/pull_list/pulllist_detail.html:3
+#, python-format
+msgid "%(name)s - Metron"
+msgstr "%(name)s - Metron"
+
+#: pull_list/templates/pull_list/pulllist_detail.html:10
+msgid "Add a Series"
+msgstr "Aggiungi una Serie"
+
+#: pull_list/templates/pull_list/pulllist_detail.html:28
+msgid "Add"
+msgstr "Aggiungi"
+
+#: pull_list/templates/pull_list/pulllist_detail.html:40
+#, python-format
+msgid "Series on Pull List (%(count)s)"
+msgstr "Serie nella Pull List (%(count)s)"
+
+#: pull_list/templates/pull_list/pulllist_detail.html:48
+msgid "Publisher"
+msgstr "Editore"
+
+#: pull_list/templates/pull_list/pulllist_detail.html:49
+msgid "Type"
+msgstr "Tipo"
+
+#: pull_list/templates/pull_list/pulllist_detail.html:68
+#: pull_list/templates/pull_list/remove_series_confirm.html:30
+msgid "Remove"
+msgstr "Rimuovi"
+
+#: pull_list/templates/pull_list/pulllist_detail.html:78
+msgid "No series on this pull list yet."
+msgstr "Nessuna serie ancora in questa pull list."
+
+#: pull_list/templates/pull_list/pulllist_detail.html:85
+msgid "Upcoming Issues"
+msgstr "Prossimi Albi"
+
+#: pull_list/templates/pull_list/pulllist_detail.html:91
+msgid "Issue"
+msgstr "Albo"
+
+#: pull_list/templates/pull_list/pulllist_detail.html:92
+msgid "Store Date"
+msgstr "Data di Uscita"
+
+#: pull_list/templates/pull_list/pulllist_detail.html:108
+msgid "No upcoming issues found for series on this pull list."
+msgstr "Nessun albo in arrivo trovato per le serie in questa pull list."
+
+#: pull_list/templates/pull_list/remove_series_confirm.html:3
+msgid "Remove Series from Pull List - Metron"
+msgstr "Rimuovi Serie dalla Pull List - Metron"
+
+#: pull_list/templates/pull_list/remove_series_confirm.html:6
+msgid "Remove Series"
+msgstr "Rimuovi Serie"
+
+#: pull_list/templates/pull_list/remove_series_confirm.html:15
+msgid "Confirm Removal"
+msgstr "Conferma Rimozione"
+
+#: pull_list/templates/pull_list/remove_series_confirm.html:19
+#, python-format
+msgid ""
+"Are you sure you want to remove <strong>%(series)s</strong> from your pull "
+"list?"
+msgstr ""
+"Sei sicuro di voler rimuovere <strong>%(series)s</strong> dalla tua pull "
+"list?"
+
+#: pull_list/views.py:37
+#, python-format
+msgid "Added %(series)s to your pull list."
+msgstr "Aggiunto %(series)s alla tua pull list."
+
+#: pull_list/views.py:42
+#, python-format
+msgid "%(series)s is already on your pull list."
+msgstr "%(series)s è già nella tua pull list."
+
+#: pull_list/views.py:89
+#, python-format
+msgid "Removed %(series)s from your pull list."
+msgstr "Rimosso %(series)s dalla tua pull list."
+
 #: templates/base.html:9
 msgid "Metron Comic Book Database"
 msgstr "Database Fumetti Metron"
@@ -393,10 +677,6 @@ msgstr "Editori"
 msgid "Imprints"
 msgstr "Etichette"
 
-#: templates/partials/navbar.html:74
-msgid "Series"
-msgstr "Serie"
-
 #: templates/partials/navbar.html:80
 msgid "Issues"
 msgstr "Albi"
@@ -457,10 +737,6 @@ msgstr "Wiki"
 msgid "API Docs"
 msgstr "Documentazione API"
 
-#: templates/partials/navbar.html:177
-msgid "Polls"
-msgstr "Sondaggi"
-
 #: templates/partials/navbar.html:183
 msgid "Statistics"
 msgstr "Statistiche"
@@ -512,10 +788,6 @@ msgstr "Registrati"
 #: templates/partials/navbar.html:273
 msgid "Log in to your account"
 msgstr "Accedi al tuo account"
-
-#: templates/partials/navbar.html:273
-msgid "Log in"
-msgstr "Accedi"
 
 #: timeline/templates/timeline.html:4
 msgid "Timeline"

--- a/locale/it/LC_MESSAGES/django.po
+++ b/locale/it/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: metron\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-13 12:53-0400\n"
+"POT-Creation-Date: 2026-08-13 13:54-0400\n"
 "PO-Revision-Date: 2026-08-13 11:23-0400\n"
 "Last-Translator: Metron Project\n"
 "Language-Team: Italian\n"
@@ -32,8 +32,8 @@ msgstr "Valuta '%(currency)s' non valida. Supportate: %(valid)s"
 msgid "Invalid price format: %(error)s"
 msgstr "Formato del prezzo non valido: %(error)s"
 
-#: comicsdb/admin/issue.py:119 comicsdb/admin/issue.py:148
-#: comicsdb/admin/issue.py:170 comicsdb/admin/series.py:61
+#: comicsdb/admin/issue.py:119 comicsdb/admin/issue.py:148 comicsdb/admin/issue.py:170
+#: comicsdb/admin/series.py:61
 #, python-format
 msgid "%d issue was updated."
 msgid_plural "%d issues were updated."
@@ -60,8 +60,7 @@ msgstr "Completamento automatico..."
 
 #: comicsdb/forms/issue.py:98
 msgid "Primarily used for legacy numbering for DC and Marvel comics."
-msgstr ""
-"Utilizzato principalmente per la numerazione storica dei fumetti DC e Marvel."
+msgstr "Utilizzato principalmente per la numerazione storica dei fumetti DC e Marvel."
 
 #: comicsdb/forms/issue.py:99
 msgid "Separate multiple story titles by a semicolon"
@@ -75,7 +74,7 @@ msgstr "Utilizzato solo con edizioni raccolte come un Trade Paperback."
 msgid "USD for US publishers, GBP for UK publishers"
 msgstr "USD per editori statunitensi, GBP per editori britannici"
 
-#: comicsdb/forms/issue.py:102
+#: comicsdb/forms/issue.py:102 user_collection/forms.py:80 wish_list/forms.py:52
 msgid "Search using 'Series Name (Year) #Number' format."
 msgstr "Cerca usando il formato 'Nome Serie (Anno) #Numero'."
 
@@ -84,6 +83,7 @@ msgid "This date should be earlier than the store date"
 msgstr "Questa data dovrebbe essere precedente alla data di uscita in negozio"
 
 #: comicsdb/forms/issue.py:106 comicsdb/models/issue.py:57
+#: user_collection/templates/user_collection/missing_issues_detail.html:80
 msgid "Story Title"
 msgstr "Titolo della Storia"
 
@@ -120,6 +120,8 @@ msgid "Alternative Number"
 msgstr "Numero Alternativo"
 
 #: comicsdb/models/issue.py:61
+#: user_collection/templates/user_collection/collection_list.html:63
+#: user_collection/templates/user_collection/missing_issues_detail.html:81
 msgid "Cover Date"
 msgstr "Data di Copertina"
 
@@ -132,6 +134,7 @@ msgid "Final Order Cutoff Date"
 msgstr "Data Limite per l'Ordine Finale"
 
 #: comicsdb/models/issue.py:64
+#: user_collection/templates/user_collection/missing_issues_detail.html:83
 msgid "Cover Price"
 msgstr "Prezzo di Copertina"
 
@@ -162,17 +165,16 @@ msgstr "Hash della Copertina"
 #: comicsdb/views/issue.py:451
 #, python-format
 msgid "Credit duplication is not allowed for %(publisher)s issues."
-msgstr ""
-"La duplicazione dei crediti non è consentita per gli albi di %(publisher)s."
+msgstr "La duplicazione dei crediti non è consentita per gli albi di %(publisher)s."
 
 #: comicsdb/views/issue.py:461
 #, python-format
 msgid ""
-"%(issue)s already has credits assigned. Duplicate operation cancelled to "
-"preserve existing data."
+"%(issue)s already has credits assigned. Duplicate operation cancelled to preserve "
+"existing data."
 msgstr ""
-"%(issue)s ha già dei crediti assegnati. Operazione di duplicazione annullata "
-"per preservare i dati esistenti."
+"%(issue)s ha già dei crediti assegnati. Operazione di duplicazione annullata per "
+"preservare i dati esistenti."
 
 #: comicsdb/views/issue.py:473
 #, python-format
@@ -187,11 +189,11 @@ msgstr "Nessun credito trovato in %(issue)s da duplicare."
 #: comicsdb/views/issue.py:536
 #, python-format
 msgid ""
-"Successfully duplicated %(credits)s credit(s) from %(issue)s. Skipped "
-"%(skipped)s variant cover credit(s)."
+"Successfully duplicated %(credits)s credit(s) from %(issue)s. Skipped %(skipped)s "
+"variant cover credit(s)."
 msgstr ""
-"Duplicati con successo %(credits)s credito/i da %(issue)s. Saltati "
-"%(skipped)s credito/i di copertina variante."
+"Duplicati con successo %(credits)s credito/i da %(issue)s. Saltati %(skipped)s "
+"credito/i di copertina variante."
 
 #: comicsdb/views/issue.py:544
 #, python-format
@@ -204,8 +206,8 @@ msgid ""
 "No credits were duplicated. Skipped %(skipped)s variant cover credit(s) from "
 "%(issue)s."
 msgstr ""
-"Nessun credito è stato duplicato. Saltati %(skipped)s credito/i di copertina "
-"variante da %(issue)s."
+"Nessun credito è stato duplicato. Saltati %(skipped)s credito/i di copertina variante "
+"da %(issue)s."
 
 #: comicsdb/views/issue.py:604
 #, python-format
@@ -213,8 +215,8 @@ msgid ""
 "This function only works for %(types)s series types. This issue is of type "
 "'%(current_type)s'."
 msgstr ""
-"Questa funzione funziona solo per i tipi di serie %(types)s. Questo albo è "
-"di tipo '%(current_type)s'."
+"Questa funzione funziona solo per i tipi di serie %(types)s. Questo albo è di tipo "
+"'%(current_type)s'."
 
 #: comicsdb/views/issue.py:614
 #, python-format
@@ -232,10 +234,8 @@ msgstr ""
 
 #: comicsdb/views/issue.py:660
 #, python-format
-msgid ""
-"Skipped %(count)s reprinted issue(s) with multiple story titles: %(names)s"
-msgstr ""
-"Saltati %(count)s albo/i ristampato/i con più titoli di storie: %(names)s"
+msgid "Skipped %(count)s reprinted issue(s) with multiple story titles: %(names)s"
+msgstr "Saltati %(count)s albo/i ristampato/i con più titoli di storie: %(names)s"
 
 #: comicsdb/views/issue.py:666
 msgid "No characters or teams found in the reprinted issues."
@@ -300,11 +300,11 @@ msgstr "Elimina Sondaggio"
 #: polls/templates/polls/poll_confirm_delete.html:12
 #, python-format
 msgid ""
-"Are you sure you want to delete <strong>%(title)s</strong>? This will also "
-"delete all votes cast in this poll and cannot be undone."
+"Are you sure you want to delete <strong>%(title)s</strong>? This will also delete all "
+"votes cast in this poll and cannot be undone."
 msgstr ""
-"Sei sicuro di voler eliminare <strong>%(title)s</strong>? Questo eliminerà "
-"anche tutti i voti espressi in questo sondaggio e non può essere annullato."
+"Sei sicuro di voler eliminare <strong>%(title)s</strong>? Questo eliminerà anche "
+"tutti i voti espressi in questo sondaggio e non può essere annullato."
 
 #: polls/templates/polls/poll_confirm_delete.html:20
 #: polls/templates/polls/poll_detail.html:38
@@ -313,6 +313,13 @@ msgstr "Elimina"
 
 #: polls/templates/polls/poll_confirm_delete.html:25
 #: pull_list/templates/pull_list/remove_series_confirm.html:27
+#: user_collection/templates/user_collection/add_issues_from_series.html:82
+#: user_collection/templates/user_collection/collection_confirm_delete.html:31
+#: user_collection/templates/user_collection/collection_form.html:72
+#: user_collection/templates/user_collection/partials/read_dates_list.html:38
+#: wish_list/templates/wish_list/wishlist_acquire_form.html:37
+#: wish_list/templates/wish_list/wishlist_item_confirm_delete.html:26
+#: wish_list/templates/wish_list/wishlist_item_form.html:50
 msgid "Cancel"
 msgstr "Annulla"
 
@@ -325,20 +332,17 @@ msgstr "%(title)s - Metron"
 msgid "Polls"
 msgstr "Sondaggi"
 
-#: polls/templates/polls/poll_detail.html:22
-#: polls/templates/polls/poll_detail.html:104
+#: polls/templates/polls/poll_detail.html:22 polls/templates/polls/poll_detail.html:104
 #: polls/templates/polls/poll_list.html:25
 msgid "Active"
 msgstr "Attivo"
 
-#: polls/templates/polls/poll_detail.html:24
-#: polls/templates/polls/poll_detail.html:104
+#: polls/templates/polls/poll_detail.html:24 polls/templates/polls/poll_detail.html:104
 #: polls/templates/polls/poll_list.html:27
 msgid "Upcoming"
 msgstr "In Arrivo"
 
-#: polls/templates/polls/poll_detail.html:26
-#: polls/templates/polls/poll_detail.html:104
+#: polls/templates/polls/poll_detail.html:26 polls/templates/polls/poll_detail.html:104
 #: polls/templates/polls/poll_list.html:29
 msgid "Closed"
 msgstr "Chiuso"
@@ -429,12 +433,15 @@ msgstr "Hai già votato in questo sondaggio."
 msgid "No choice selected."
 msgstr "Nessuna scelta selezionata."
 
-#: pull_list/forms.py:16
+#: pull_list/forms.py:16 user_collection/forms.py:128
 msgid "Search for a series..."
 msgstr "Cerca una serie..."
 
 #: pull_list/forms.py:20 pull_list/templates/pull_list/pulllist_detail.html:47
-#: templates/partials/navbar.html:74
+#: templates/partials/navbar.html:74 user_collection/forms.py:132
+#: user_collection/templates/user_collection/collection_stats.html:226
+#: user_collection/templates/user_collection/missing_issues_list.html:40
+#: wish_list/templates/wish_list/wishlist_detail.html:83
 msgid "Series"
 msgstr "Serie"
 
@@ -464,6 +471,7 @@ msgid "Add to pull list"
 msgstr "Aggiungi alla pull list"
 
 #: pull_list/templates/pull_list/pulllist_detail.html:3
+#: wish_list/templates/wish_list/wishlist_detail.html:3
 #, python-format
 msgid "%(name)s - Metron"
 msgstr "%(name)s - Metron"
@@ -482,15 +490,22 @@ msgid "Series on Pull List (%(count)s)"
 msgstr "Serie nella Pull List (%(count)s)"
 
 #: pull_list/templates/pull_list/pulllist_detail.html:48
+#: user_collection/templates/user_collection/missing_issues_list.html:41
+#: user_collection/templates/user_collection/partials/collection_filter.html:94
 msgid "Publisher"
 msgstr "Editore"
 
 #: pull_list/templates/pull_list/pulllist_detail.html:49
+#: user_collection/templates/user_collection/missing_issues_list.html:42
 msgid "Type"
 msgstr "Tipo"
 
 #: pull_list/templates/pull_list/pulllist_detail.html:68
 #: pull_list/templates/pull_list/remove_series_confirm.html:30
+#: user_collection/templates/user_collection/collection_detail.html:32
+#: user_collection/templates/user_collection/collection_list.html:139
+#: wish_list/templates/wish_list/wishlist_detail.html:128
+#: wish_list/templates/wish_list/wishlist_item_confirm_delete.html:29
 msgid "Remove"
 msgstr "Rimuovi"
 
@@ -503,10 +518,14 @@ msgid "Upcoming Issues"
 msgstr "Prossimi Albi"
 
 #: pull_list/templates/pull_list/pulllist_detail.html:91
+#: user_collection/templates/user_collection/collection_list.html:62
+#: user_collection/templates/user_collection/missing_issues_detail.html:79
+#: wish_list/templates/wish_list/wishlist_detail.html:82
 msgid "Issue"
 msgstr "Albo"
 
 #: pull_list/templates/pull_list/pulllist_detail.html:92
+#: user_collection/templates/user_collection/missing_issues_detail.html:82
 msgid "Store Date"
 msgstr "Data di Uscita"
 
@@ -528,12 +547,8 @@ msgstr "Conferma Rimozione"
 
 #: pull_list/templates/pull_list/remove_series_confirm.html:19
 #, python-format
-msgid ""
-"Are you sure you want to remove <strong>%(series)s</strong> from your pull "
-"list?"
-msgstr ""
-"Sei sicuro di voler rimuovere <strong>%(series)s</strong> dalla tua pull "
-"list?"
+msgid "Are you sure you want to remove <strong>%(series)s</strong> from your pull list?"
+msgstr "Sei sicuro di voler rimuovere <strong>%(series)s</strong> dalla tua pull list?"
 
 #: pull_list/views.py:37
 #, python-format
@@ -556,11 +571,11 @@ msgstr "Database Fumetti Metron"
 
 #: templates/base.html:13
 msgid ""
-"A community-based comic book database with comprehensive information about "
-"comics, creators, characters, and more."
+"A community-based comic book database with comprehensive information about comics, "
+"creators, characters, and more."
 msgstr ""
-"Un database di fumetti gestito dalla community, con informazioni complete su "
-"fumetti, autori, personaggi e altro ancora."
+"Un database di fumetti gestito dalla community, con informazioni complete su fumetti, "
+"autori, personaggi e altro ancora."
 
 #: templates/base.html:17
 msgid "comics, comic books, database, Marvel, DC, creators, characters"
@@ -613,8 +628,7 @@ msgstr "Quest'opera è distribuita con licenza"
 
 #: templates/partials/footer.html:78
 msgid "Creative Commons Attribution-ShareAlike 4.0 International License"
-msgstr ""
-"Creative Commons Attribuzione-Condividi allo stesso modo 4.0 Internazionale"
+msgstr "Creative Commons Attribuzione-Condividi allo stesso modo 4.0 Internazionale"
 
 #: templates/partials/footer.html:79
 msgid ", except where noted otherwise."
@@ -678,6 +692,7 @@ msgid "Imprints"
 msgstr "Etichette"
 
 #: templates/partials/navbar.html:80
+#: user_collection/templates/user_collection/collection_stats.html:227
 msgid "Issues"
 msgstr "Albi"
 
@@ -714,6 +729,7 @@ msgid "My Reading Lists"
 msgstr "Le Mie Liste di Lettura"
 
 #: templates/partials/navbar.html:138
+#: user_collection/templates/user_collection/reading_history.html:30
 msgid "My Collection"
 msgstr "La Mia Collezione"
 
@@ -792,3 +808,1364 @@ msgstr "Accedi al tuo account"
 #: timeline/templates/timeline.html:4
 msgid "Timeline"
 msgstr "Cronologia"
+
+#: user_collection/forms.py:32 wish_list/forms.py:25
+msgid "Search for an issue..."
+msgstr "Cerca un albo..."
+
+#: user_collection/forms.py:55 wish_list/forms.py:79
+msgid "Local Comic Shop"
+msgstr "Fumetteria Locale"
+
+#: user_collection/forms.py:60
+msgid "Long Box 3"
+msgstr "Scatola 3"
+
+#: user_collection/forms.py:65
+msgid "Additional notes (optional)"
+msgstr "Note aggiuntive (opzionale)"
+
+#: user_collection/forms.py:71
+#: user_collection/templates/user_collection/collection_list.html:64
+#: user_collection/templates/user_collection/collection_stats.html:189
+#: user_collection/templates/user_collection/partials/collection_filter.html:130
+msgid "Format"
+msgstr "Formato"
+
+#: user_collection/forms.py:72
+#: user_collection/templates/user_collection/collection_list.html:65
+#: user_collection/templates/user_collection/partials/collection_filter.html:172
+msgid "Grade"
+msgstr "Grado"
+
+#: user_collection/forms.py:73
+#: user_collection/templates/user_collection/partials/collection_filter.html:194
+msgid "Grading Company"
+msgstr "Società di Valutazione"
+
+#: user_collection/forms.py:74
+msgid "Date Purchased"
+msgstr "Data di Acquisto"
+
+#: user_collection/forms.py:75
+#: user_collection/templates/user_collection/collection_list.html:69
+#: wish_list/forms.py:74
+msgid "Price Paid"
+msgstr "Prezzo Pagato"
+
+#: user_collection/forms.py:76 wish_list/forms.py:80
+msgid "Store/Vendor"
+msgstr "Negozio/Venditore"
+
+#: user_collection/forms.py:77
+msgid "Have you read this issue?"
+msgstr "Hai letto questo albo?"
+
+#: user_collection/forms.py:81
+msgid "Number of copies you own"
+msgstr "Numero di copie possedute"
+
+#: user_collection/forms.py:82
+msgid "Physical print, digital, or both"
+msgstr "Cartaceo, digitale o entrambi"
+
+#: user_collection/forms.py:83
+msgid "Comic book condition grade (CGC scale)"
+msgstr "Grado di condizione del fumetto (scala CGC)"
+
+#: user_collection/forms.py:84
+msgid "Professional grading company (leave blank if user-assessed)"
+msgstr "Società di valutazione professionale (lascia vuoto se valutato dall'utente)"
+
+#: user_collection/forms.py:85
+msgid "When did you purchase this issue?"
+msgstr "Quando hai acquistato questo albo?"
+
+#: user_collection/forms.py:86
+msgid "How much did you pay?"
+msgstr "Quanto hai pagato?"
+
+#: user_collection/forms.py:87
+msgid "Where did you buy it?"
+msgstr "Dove l'hai acquistato?"
+
+#: user_collection/forms.py:88
+msgid "Where is it stored?"
+msgstr "Dove viene conservato?"
+
+#: user_collection/forms.py:89
+msgid "Any additional notes about this item"
+msgstr "Eventuali note aggiuntive su questo elemento"
+
+#: user_collection/forms.py:90
+msgid "Mark this if you've read the issue (read dates managed in detail view)"
+msgstr ""
+"Seleziona questa opzione se hai letto l'albo (le date di lettura si gestiscono nella "
+"vista dettagli)"
+
+#: user_collection/forms.py:109
+msgid "This issue is already in your collection."
+msgstr "Questo albo è già nella tua collezione."
+
+#: user_collection/forms.py:118
+msgid "All issues"
+msgstr "Tutti gli albi"
+
+#: user_collection/forms.py:119
+msgid "Issue range"
+msgstr "Intervallo di albi"
+
+#: user_collection/forms.py:133
+msgid "Select the series to add issues from"
+msgstr "Seleziona la serie da cui aggiungere gli albi"
+
+#: user_collection/forms.py:140
+msgid "Which issues?"
+msgstr "Quali albi?"
+
+#: user_collection/forms.py:141
+msgid "Choose whether to add all issues or specify a range"
+msgstr "Scegli se aggiungere tutti gli albi o specificare un intervallo"
+
+#: user_collection/forms.py:149
+msgid "e.g., 1 or 1.1"
+msgstr "es. 1 o 1.1"
+
+#: user_collection/forms.py:153
+msgid "Start Issue Number"
+msgstr "Numero Albo Iniziale"
+
+#: user_collection/forms.py:154
+msgid "Optional: Issue number to start from (leave blank to start from beginning)"
+msgstr ""
+"Opzionale: numero dell'albo da cui iniziare (lascia vuoto per iniziare dall'inizio)"
+
+#: user_collection/forms.py:162
+msgid "e.g., 50"
+msgstr "es. 50"
+
+#: user_collection/forms.py:166
+msgid "End Issue Number"
+msgstr "Numero Albo Finale"
+
+#: user_collection/forms.py:167
+msgid "Optional: Issue number to end at (leave blank to go to end)"
+msgstr ""
+"Opzionale: numero dell'albo a cui terminare (lascia vuoto per arrivare fino alla fine)"
+
+#: user_collection/forms.py:175
+msgid "Default Format"
+msgstr "Formato Predefinito"
+
+#: user_collection/forms.py:176
+msgid "The format to use for all added issues"
+msgstr "Il formato da usare per tutti gli albi aggiunti"
+
+#: user_collection/forms.py:182
+msgid "Mark as read"
+msgstr "Segna come letto"
+
+#: user_collection/forms.py:183
+msgid "Check this to mark all added issues as read"
+msgstr "Seleziona questa opzione per segnare tutti gli albi aggiunti come letti"
+
+#: user_collection/models.py:15
+msgid "10.0 (Gem Mint)"
+msgstr "10.0 (Gemma Perfetta)"
+
+#: user_collection/models.py:16
+msgid "9.9 (Mint)"
+msgstr "9.9 (Perfetta)"
+
+#: user_collection/models.py:17
+msgid "9.8 (NM/M - Near Mint/Mint)"
+msgstr "9.8 (NM/M - Quasi Perfetta/Perfetta)"
+
+#: user_collection/models.py:18
+msgid "9.6 (NM+ - Near Mint+)"
+msgstr "9.6 (NM+ - Quasi Perfetta+)"
+
+#: user_collection/models.py:19
+msgid "9.4 (NM - Near Mint)"
+msgstr "9.4 (NM - Quasi Perfetta)"
+
+#: user_collection/models.py:20
+msgid "9.2 (NM- - Near Mint-)"
+msgstr "9.2 (NM- - Quasi Perfetta-)"
+
+#: user_collection/models.py:21
+msgid "9.0 (VF/NM - Very Fine/Near Mint)"
+msgstr "9.0 (VF/NM - Molto Bella/Quasi Perfetta)"
+
+#: user_collection/models.py:22
+msgid "8.5 (VF+ - Very Fine+)"
+msgstr "8.5 (VF+ - Molto Bella+)"
+
+#: user_collection/models.py:23
+msgid "8.0 (VF - Very Fine)"
+msgstr "8.0 (VF - Molto Bella)"
+
+#: user_collection/models.py:24
+msgid "7.5 (VF- - Very Fine-)"
+msgstr "7.5 (VF- - Molto Bella-)"
+
+#: user_collection/models.py:25
+msgid "7.0 (FN/VF - Fine/Very Fine)"
+msgstr "7.0 (FN/VF - Bella/Molto Bella)"
+
+#: user_collection/models.py:26
+msgid "6.5 (FN+ - Fine+)"
+msgstr "6.5 (FN+ - Bella+)"
+
+#: user_collection/models.py:27
+msgid "6.0 (FN - Fine)"
+msgstr "6.0 (FN - Bella)"
+
+#: user_collection/models.py:28
+msgid "5.5 (FN- - Fine-)"
+msgstr "5.5 (FN- - Bella-)"
+
+#: user_collection/models.py:29
+msgid "5.0 (VG/FN - Very Good/Fine)"
+msgstr "5.0 (VG/FN - Molto Buona/Bella)"
+
+#: user_collection/models.py:30
+msgid "4.5 (VG+ - Very Good+)"
+msgstr "4.5 (VG+ - Molto Buona+)"
+
+#: user_collection/models.py:31
+msgid "4.0 (VG - Very Good)"
+msgstr "4.0 (VG - Molto Buona)"
+
+#: user_collection/models.py:32
+msgid "3.5 (VG- - Very Good-)"
+msgstr "3.5 (VG- - Molto Buona-)"
+
+#: user_collection/models.py:33
+msgid "3.0 (GD/VG - Good/Very Good)"
+msgstr "3.0 (GD/VG - Buona/Molto Buona)"
+
+#: user_collection/models.py:34
+msgid "2.5 (GD+ - Good+)"
+msgstr "2.5 (GD+ - Buona+)"
+
+#: user_collection/models.py:35
+msgid "2.0 (GD - Good)"
+msgstr "2.0 (GD - Buona)"
+
+#: user_collection/models.py:36
+msgid "1.8 (GD- - Good-)"
+msgstr "1.8 (GD- - Buona-)"
+
+#: user_collection/models.py:37
+msgid "1.5 (FR/GD - Fair/Good)"
+msgstr "1.5 (FR/GD - Discreta/Buona)"
+
+#: user_collection/models.py:38
+msgid "1.0 (FR - Fair)"
+msgstr "1.0 (FR - Discreta)"
+
+#: user_collection/models.py:39
+msgid "0.5 (PR - Poor)"
+msgstr "0.5 (PR - Scadente)"
+
+#: user_collection/models.py:47
+#: user_collection/templates/user_collection/collection_stats.html:199
+msgid "Print"
+msgstr "Cartaceo"
+
+#: user_collection/models.py:48
+#: user_collection/templates/user_collection/collection_stats.html:201
+msgid "Digital"
+msgstr "Digitale"
+
+#: user_collection/models.py:49
+#: user_collection/templates/user_collection/collection_stats.html:203
+msgid "Both"
+msgstr "Entrambi"
+
+#: user_collection/models.py:52
+msgid "CGC (Certified Guaranty Company)"
+msgstr "CGC (Certified Guaranty Company)"
+
+#: user_collection/models.py:53
+msgid "CBCS (Comic Book Certification Service)"
+msgstr "CBCS (Comic Book Certification Service)"
+
+#: user_collection/models.py:54
+msgid "PGX (Professional Grading Experts)"
+msgstr "PGX (Professional Grading Experts)"
+
+#: user_collection/models.py:61
+msgid "The user who owns this collection item"
+msgstr "L'utente proprietario di questo elemento della collezione"
+
+#: user_collection/models.py:67
+msgid "The issue in this collection"
+msgstr "L'albo in questa collezione"
+
+#: user_collection/models.py:71
+msgid "Number of copies owned"
+msgstr "Numero di copie possedute"
+
+#: user_collection/models.py:76
+msgid "Format of the comic (print, digital, or both)"
+msgstr "Formato del fumetto (cartaceo, digitale o entrambi)"
+
+#: user_collection/models.py:86
+msgid "Comic book grade (CGC scale)"
+msgstr "Grado del fumetto (scala CGC)"
+
+#: user_collection/models.py:93
+msgid "Professional grading company (leave blank for user-assessed grade)"
+msgstr ""
+"Società di valutazione professionale (lascia vuoto per grado valutato dall'utente)"
+
+#: user_collection/models.py:98
+msgid "Date when the issue was purchased"
+msgstr "Data di acquisto dell'albo"
+
+#: user_collection/models.py:101
+msgid "Purchase Price"
+msgstr "Prezzo di Acquisto"
+
+#: user_collection/models.py:106
+msgid "Price paid for this issue"
+msgstr "Prezzo pagato per questo albo"
+
+#: user_collection/models.py:109
+msgid "Store or vendor where purchased"
+msgstr "Negozio o venditore presso cui è stato acquistato"
+
+#: user_collection/models.py:114
+msgid "Physical location where the issue is stored"
+msgstr "Luogo fisico in cui è conservato l'albo"
+
+#: user_collection/models.py:116
+msgid "Additional notes about this collection item"
+msgstr "Note aggiuntive su questo elemento della collezione"
+
+#: user_collection/models.py:119
+msgid "Whether the issue has been read"
+msgstr "Se l'albo è stato letto"
+
+#: user_collection/models.py:123
+msgid "Date and time when the issue was last read (synced from read_dates)"
+msgstr "Data e ora dell'ultima lettura dell'albo (sincronizzata da read_dates)"
+
+#: user_collection/models.py:129
+msgid "Star rating (1-5) for this issue"
+msgstr "Valutazione a stelle (1-5) per questo albo"
+
+#: user_collection/models.py:147
+msgid "Collection Item"
+msgstr "Elemento della Collezione"
+
+#: user_collection/models.py:148
+msgid "Collection Items"
+msgstr "Elementi della Collezione"
+
+#: user_collection/models.py:185
+msgid "The collection item this read date belongs to"
+msgstr "L'elemento della collezione a cui appartiene questa data di lettura"
+
+#: user_collection/models.py:187
+msgid "Date and time when the issue was read"
+msgstr "Data e ora della lettura dell'albo"
+
+#: user_collection/models.py:195
+msgid "Read Date"
+msgstr "Data di Lettura"
+
+#: user_collection/models.py:196
+msgid "Read Dates"
+msgstr "Date di Lettura"
+
+#: user_collection/templates/user_collection/add_issues_from_series.html:3
+msgid "Add from Series - My Collection - Metron"
+msgstr "Aggiungi dalla Serie - La Mia Collezione - Metron"
+
+#: user_collection/templates/user_collection/add_issues_from_series.html:9
+msgid "Add Issues from Series"
+msgstr "Aggiungi Albi dalla Serie"
+
+#: user_collection/templates/user_collection/add_issues_from_series.html:10
+msgid "Bulk add to your collection"
+msgstr "Aggiunta massiva alla tua collezione"
+
+#: user_collection/templates/user_collection/add_issues_from_series.html:85
+msgid "Add Issues"
+msgstr "Aggiungi Albi"
+
+#: user_collection/templates/user_collection/add_issues_from_series.html:91
+msgid "How to use:"
+msgstr "Come si usa:"
+
+#: user_collection/templates/user_collection/add_issues_from_series.html:94
+msgid "Select a series:"
+msgstr "Seleziona una serie:"
+
+#: user_collection/templates/user_collection/add_issues_from_series.html:94
+msgid "Start typing in the search box to find a series by name"
+msgstr "Inizia a digitare nella casella di ricerca per trovare una serie per nome"
+
+#: user_collection/templates/user_collection/add_issues_from_series.html:97
+msgid "Choose what to add:"
+msgstr "Scegli cosa aggiungere:"
+
+#: user_collection/templates/user_collection/add_issues_from_series.html:100
+msgid "All issues:"
+msgstr "Tutti gli albi:"
+
+#: user_collection/templates/user_collection/add_issues_from_series.html:100
+msgid "Adds every issue from the series"
+msgstr "Aggiunge tutti gli albi della serie"
+
+#: user_collection/templates/user_collection/add_issues_from_series.html:103
+msgid "Issue range:"
+msgstr "Intervallo di albi:"
+
+#: user_collection/templates/user_collection/add_issues_from_series.html:103
+msgid "Specify a start and/or end issue number (e.g., start at #1, end at #50)"
+msgstr ""
+"Specifica un numero di albo iniziale e/o finale (es. inizia da #1, termina a #50)"
+
+#: user_collection/templates/user_collection/add_issues_from_series.html:107
+msgid "Issues already in your collection will be automatically skipped"
+msgstr "Gli albi già presenti nella tua collezione verranno automaticamente saltati"
+
+#: user_collection/templates/user_collection/add_issues_from_series.html:108
+msgid "All issues will be added with your selected format and quantity 1"
+msgstr "Tutti gli albi verranno aggiunti con il formato selezionato e quantità 1"
+
+#: user_collection/templates/user_collection/add_issues_from_series.html:110
+msgid "Mark as read:"
+msgstr "Segna come letto:"
+
+#: user_collection/templates/user_collection/add_issues_from_series.html:110
+msgid "Check this option if you've already read these issues"
+msgstr "Seleziona questa opzione se hai già letto questi albi"
+
+#: user_collection/templates/user_collection/add_issues_from_series.html:112
+msgid ""
+"You can edit individual items later to add purchase information and update read status"
+msgstr ""
+"Puoi modificare i singoli elementi in seguito per aggiungere informazioni di acquisto "
+"e aggiornare lo stato di lettura"
+
+#: user_collection/templates/user_collection/add_issues_from_series.html:115
+msgid "Tip:"
+msgstr "Suggerimento:"
+
+#: user_collection/templates/user_collection/add_issues_from_series.html:115
+msgid ""
+"This is a quick way to add an entire series to your collection. After adding, you can "
+"update individual issues with purchase details, format preferences, and notes!"
+msgstr ""
+"Questo è un modo rapido per aggiungere un'intera serie alla tua collezione. Dopo "
+"l'aggiunta, puoi aggiornare i singoli albi con dettagli di acquisto, preferenze di "
+"formato e note!"
+
+#: user_collection/templates/user_collection/collection_confirm_delete.html:3
+msgid "Remove %(issue)s - Metron"
+msgstr "Rimuovi %(issue)s - Metron"
+
+#: user_collection/templates/user_collection/collection_confirm_delete.html:6
+#: user_collection/templates/user_collection/collection_confirm_delete.html:34
+msgid "Remove from Collection"
+msgstr "Rimuovi dalla Collezione"
+
+#: user_collection/templates/user_collection/collection_confirm_delete.html:15
+#: wish_list/templates/wish_list/wishlist_item_confirm_delete.html:15
+msgid "Warning"
+msgstr "Attenzione"
+
+#: user_collection/templates/user_collection/collection_confirm_delete.html:19
+msgid "Are you sure you want to remove <strong>%(issue)s</strong> from your collection?"
+msgstr "Sei sicuro di voler rimuovere <strong>%(issue)s</strong> dalla tua collezione?"
+
+#: user_collection/templates/user_collection/collection_confirm_delete.html:22
+msgid "This will also delete the associated purchase information and notes."
+msgstr "Questo eliminerà anche le informazioni di acquisto e le note associate."
+
+#: user_collection/templates/user_collection/collection_confirm_delete.html:24
+#: user_collection/templates/user_collection/partials/read_dates_list.html:30
+#: wish_list/templates/wish_list/wishlist_item_confirm_delete.html:19
+msgid "This action cannot be undone."
+msgstr "Questa azione non può essere annullata."
+
+#: user_collection/templates/user_collection/collection_detail.html:4
+#, python-format
+msgid "%(issue)s - My Collection - Metron"
+msgstr "%(issue)s - La Mia Collezione - Metron"
+
+#: user_collection/templates/user_collection/collection_detail.html:11
+msgid "Collection Item Details"
+msgstr "Dettagli Elemento della Collezione"
+
+#: user_collection/templates/user_collection/collection_detail.html:18
+#: user_collection/templates/user_collection/collection_stats.html:61
+#: user_collection/templates/user_collection/missing_issues_list.html:14
+msgid "Back to Collection"
+msgstr "Torna alla Collezione"
+
+#: user_collection/templates/user_collection/collection_detail.html:27
+#: user_collection/templates/user_collection/collection_list.html:132
+#: wish_list/templates/wish_list/wishlist_detail.html:123
+msgid "Edit"
+msgstr "Modifica"
+
+#: user_collection/templates/user_collection/collection_detail.html:60
+msgid "Issue Information"
+msgstr "Informazioni Albo"
+
+#: user_collection/templates/user_collection/collection_detail.html:63
+msgid "Issue:"
+msgstr "Albo:"
+
+#: user_collection/templates/user_collection/collection_detail.html:67
+msgid "Series:"
+msgstr "Serie:"
+
+#: user_collection/templates/user_collection/collection_detail.html:71
+#: user_collection/templates/user_collection/missing_issues_detail.html:35
+msgid "Publisher:"
+msgstr "Editore:"
+
+#: user_collection/templates/user_collection/collection_detail.html:75
+msgid "Cover Date:"
+msgstr "Data di Copertina:"
+
+#: user_collection/templates/user_collection/collection_detail.html:84
+msgid "Description"
+msgstr "Descrizione"
+
+#: user_collection/templates/user_collection/collection_detail.html:90
+msgid "Grading Information"
+msgstr "Informazioni sulla Valutazione"
+
+#: user_collection/templates/user_collection/collection_detail.html:92
+msgid "Grade:"
+msgstr "Grado:"
+
+#: user_collection/templates/user_collection/collection_detail.html:101
+msgid "Grading Type:"
+msgstr "Tipo di Valutazione:"
+
+#: user_collection/templates/user_collection/collection_detail.html:107
+#, python-format
+msgid "Professionally graded by %(company)s"
+msgstr "Valutato professionalmente da %(company)s"
+
+#: user_collection/templates/user_collection/collection_detail.html:112
+msgid "User-assessed grade"
+msgstr "Grado valutato dall'utente"
+
+#: user_collection/templates/user_collection/collection_detail.html:120
+#: wish_list/forms.py:85
+msgid "Notes"
+msgstr "Note"
+
+#: user_collection/templates/user_collection/collection_detail.html:127
+msgid "Collection Details"
+msgstr "Dettagli Collezione"
+
+#: user_collection/templates/user_collection/collection_detail.html:129
+msgid "Format:"
+msgstr "Formato:"
+
+#: user_collection/templates/user_collection/collection_detail.html:135
+msgid "Quantity:"
+msgstr "Quantità:"
+
+#: user_collection/templates/user_collection/collection_detail.html:140
+msgid "Purchase Date:"
+msgstr "Data di Acquisto:"
+
+#: user_collection/templates/user_collection/collection_detail.html:146
+msgid "Price Paid:"
+msgstr "Prezzo Pagato:"
+
+#: user_collection/templates/user_collection/collection_detail.html:152
+msgid "Store/Vendor:"
+msgstr "Negozio/Venditore:"
+
+#: user_collection/templates/user_collection/collection_detail.html:158
+msgid "Storage Location:"
+msgstr "Luogo di Conservazione:"
+
+#: user_collection/templates/user_collection/collection_detail.html:163
+msgid "Read Status:"
+msgstr "Stato Lettura:"
+
+#: user_collection/templates/user_collection/collection_detail.html:168
+#: user_collection/templates/user_collection/collection_list.html:66
+#: user_collection/templates/user_collection/collection_list.html:103
+#: user_collection/templates/user_collection/partials/collection_filter.html:158
+msgid "Read"
+msgstr "Letto"
+
+#: user_collection/templates/user_collection/collection_detail.html:173
+#: user_collection/templates/user_collection/collection_list.html:107
+#: user_collection/templates/user_collection/partials/collection_filter.html:160
+msgid "Unread"
+msgstr "Non Letto"
+
+#: user_collection/templates/user_collection/collection_detail.html:177
+msgid "Rating:"
+msgstr "Valutazione:"
+
+#: user_collection/templates/user_collection/collection_detail.html:181
+msgid "Read History:"
+msgstr "Cronologia Letture:"
+
+#: user_collection/templates/user_collection/collection_detail.html:185
+msgid "Added to Collection:"
+msgstr "Aggiunto alla Collezione:"
+
+#: user_collection/templates/user_collection/collection_detail.html:189
+msgid "Last Modified:"
+msgstr "Ultima Modifica:"
+
+#: user_collection/templates/user_collection/collection_form.html:5
+msgid "Edit Collection Item - Metron"
+msgstr "Modifica Elemento della Collezione - Metron"
+
+#: user_collection/templates/user_collection/collection_form.html:7
+msgid "Add Collection Item - Metron"
+msgstr "Aggiungi Elemento alla Collezione - Metron"
+
+#: user_collection/templates/user_collection/collection_form.html:19
+msgid "Edit Collection Item"
+msgstr "Modifica Elemento della Collezione"
+
+#: user_collection/templates/user_collection/collection_form.html:21
+msgid "Add Collection Item"
+msgstr "Aggiungi Elemento alla Collezione"
+
+#: user_collection/templates/user_collection/collection_form.html:77
+msgid "Update"
+msgstr "Aggiorna"
+
+#: user_collection/templates/user_collection/collection_form.html:79
+msgid "Add to Collection"
+msgstr "Aggiungi alla Collezione"
+
+#: user_collection/templates/user_collection/collection_list.html:3
+msgid "My Collection - Metron"
+msgstr "La Mia Collezione - Metron"
+
+#: user_collection/templates/user_collection/collection_list.html:6
+msgid "My Comic Collection"
+msgstr "La Mia Collezione di Fumetti"
+
+#: user_collection/templates/user_collection/collection_list.html:14
+msgid "<strong>%(counter)s</strong> item in your collection"
+msgid_plural "<strong>%(counter)s</strong> items in your collection"
+msgstr[0] "<strong>%(counter)s</strong> elemento nella tua collezione"
+msgstr[1] "<strong>%(counter)s</strong> elementi nella tua collezione"
+
+#: user_collection/templates/user_collection/collection_list.html:24
+#: user_collection/templates/user_collection/reading_history.html:25
+msgid "View Statistics"
+msgstr "Visualizza Statistiche"
+
+#: user_collection/templates/user_collection/collection_list.html:29
+msgid "Reading History"
+msgstr "Cronologia Letture"
+
+#: user_collection/templates/user_collection/collection_list.html:34
+#: user_collection/templates/user_collection/missing_issues_detail.html:6
+msgid "Missing Issues"
+msgstr "Albi Mancanti"
+
+#: user_collection/templates/user_collection/collection_list.html:39
+msgid "Add from Series"
+msgstr "Aggiungi dalla Serie"
+
+#: user_collection/templates/user_collection/collection_list.html:44
+msgid "Add Issue"
+msgstr "Aggiungi Albo"
+
+#: user_collection/templates/user_collection/collection_list.html:67
+#: user_collection/templates/user_collection/partials/collection_filter.html:218
+msgid "Rating"
+msgstr "Valutazione"
+
+#: user_collection/templates/user_collection/collection_list.html:68
+msgid "Quantity"
+msgstr "Quantità"
+
+#: user_collection/templates/user_collection/collection_list.html:70
+#: user_collection/templates/user_collection/missing_issues_list.html:45
+msgid "Actions"
+msgstr "Azioni"
+
+#: user_collection/templates/user_collection/collection_list.html:88
+msgid "User-assessed"
+msgstr "Valutato dall'utente"
+
+#: user_collection/templates/user_collection/collection_list.html:103
+#, python-format
+msgid "Read on %(read_date)s"
+msgstr "Letto il %(read_date)s"
+
+#: user_collection/templates/user_collection/collection_list.html:125
+#: user_collection/templates/user_collection/reading_history.html:121
+msgid "View Details"
+msgstr "Visualizza Dettagli"
+
+#: user_collection/templates/user_collection/collection_list.html:157
+msgid "No results found"
+msgstr "Nessun risultato trovato"
+
+#: user_collection/templates/user_collection/collection_list.html:158
+msgid "Try adjusting your search filters"
+msgstr "Prova a modificare i filtri di ricerca"
+
+#: user_collection/templates/user_collection/collection_list.html:162
+msgid "Clear All Filters"
+msgstr "Cancella Tutti i Filtri"
+
+#: user_collection/templates/user_collection/collection_list.html:165
+msgid "Your collection is empty"
+msgstr "La tua collezione è vuota"
+
+#: user_collection/templates/user_collection/collection_list.html:166
+msgid "Start adding issues to track your comic collection!"
+msgstr "Inizia ad aggiungere albi per tenere traccia della tua collezione di fumetti!"
+
+#: user_collection/templates/user_collection/collection_list.html:170
+msgid "Add Your First Issue"
+msgstr "Aggiungi il Tuo Primo Albo"
+
+#: user_collection/templates/user_collection/collection_stats.html:51
+msgid "Collection Statistics - Metron"
+msgstr "Statistiche Collezione - Metron"
+
+#: user_collection/templates/user_collection/collection_stats.html:54
+msgid "Collection Statistics"
+msgstr "Statistiche Collezione"
+
+#: user_collection/templates/user_collection/collection_stats.html:72
+msgid "Total Items"
+msgstr "Elementi Totali"
+
+#: user_collection/templates/user_collection/collection_stats.html:81
+msgid "Total Issues"
+msgstr "Albi Totali"
+
+#: user_collection/templates/user_collection/collection_stats.html:90
+msgid "Total Value"
+msgstr "Valore Totale"
+
+#: user_collection/templates/user_collection/collection_stats.html:105
+msgid "Issues Read"
+msgstr "Albi Letti"
+
+#: user_collection/templates/user_collection/collection_stats.html:114
+msgid "Issues Unread"
+msgstr "Albi Non Letti"
+
+#: user_collection/templates/user_collection/collection_stats.html:123
+msgid "Reading Progress"
+msgstr "Progresso di Lettura"
+
+#: user_collection/templates/user_collection/collection_stats.html:184
+msgid "By Format"
+msgstr "Per Formato"
+
+#: user_collection/templates/user_collection/collection_stats.html:190
+msgid "Count"
+msgstr "Conteggio"
+
+#: user_collection/templates/user_collection/collection_stats.html:215
+msgid "No format data available"
+msgstr "Nessun dato sul formato disponibile"
+
+#: user_collection/templates/user_collection/collection_stats.html:221
+msgid "Top Series"
+msgstr "Serie Principali"
+
+#: user_collection/templates/user_collection/collection_stats.html:244
+msgid "No series data available"
+msgstr "Nessun dato sulla serie disponibile"
+
+#: user_collection/templates/user_collection/missing_issues_detail.html:3
+msgid "Missing Issues - %(name)s - Metron"
+msgstr "Albi Mancanti - %(name)s - Metron"
+
+#: user_collection/templates/user_collection/missing_issues_detail.html:18
+msgid "Back to Missing List"
+msgstr "Torna all'Elenco Mancanti"
+
+#: user_collection/templates/user_collection/missing_issues_detail.html:23
+msgid "Collection"
+msgstr "Collezione"
+
+#: user_collection/templates/user_collection/missing_issues_detail.html:33
+msgid "Series Information"
+msgstr "Informazioni Serie"
+
+#: user_collection/templates/user_collection/missing_issues_detail.html:39
+msgid "Series Type:"
+msgstr "Tipo di Serie:"
+
+#: user_collection/templates/user_collection/missing_issues_detail.html:44
+msgid "Volume:"
+msgstr "Volume:"
+
+#: user_collection/templates/user_collection/missing_issues_detail.html:52
+msgid "Collection Progress"
+msgstr "Progresso della Collezione"
+
+#: user_collection/templates/user_collection/missing_issues_detail.html:55
+#, python-format
+msgid "%(pct)s%% Complete"
+msgstr "%(pct)s%% Completato"
+
+#: user_collection/templates/user_collection/missing_issues_detail.html:64
+msgid "%(counter)s issue missing"
+msgid_plural "%(counter)s issues missing"
+msgstr[0] "%(counter)s albo mancante"
+msgstr[1] "%(counter)s albi mancanti"
+
+#: user_collection/templates/user_collection/missing_issues_detail.html:127
+#: user_collection/templates/user_collection/missing_issues_list.html:94
+msgid "No Missing Issues!"
+msgstr "Nessun Albo Mancante!"
+
+#: user_collection/templates/user_collection/missing_issues_detail.html:128
+msgid "You own all issues from this series."
+msgstr "Possiedi tutti gli albi di questa serie."
+
+#: user_collection/templates/user_collection/missing_issues_list.html:3
+msgid "Missing Issues - My Collection - Metron"
+msgstr "Albi Mancanti - La Mia Collezione - Metron"
+
+#: user_collection/templates/user_collection/missing_issues_list.html:6
+msgid "Missing Issues by Series"
+msgstr "Albi Mancanti per Serie"
+
+#: user_collection/templates/user_collection/missing_issues_list.html:7
+msgid "Find gaps in your collection"
+msgstr "Trova le lacune nella tua collezione"
+
+#: user_collection/templates/user_collection/missing_issues_list.html:21
+msgid "<strong>%(counter)s</strong> series with missing issues"
+msgid_plural "<strong>%(counter)s</strong> series with missing issues"
+msgstr[0] "<strong>%(counter)s</strong> serie con albi mancanti"
+msgstr[1] "<strong>%(counter)s</strong> serie con albi mancanti"
+
+#: user_collection/templates/user_collection/missing_issues_list.html:29
+msgid ""
+"This page shows series where you own at least one issue but are missing others. Use "
+"it to identify gaps in your collection."
+msgstr ""
+"Questa pagina mostra le serie di cui possiedi almeno un albo ma te ne mancano altri. "
+"Usala per identificare le lacune nella tua collezione."
+
+#: user_collection/templates/user_collection/missing_issues_list.html:43
+msgid "Progress"
+msgstr "Progresso"
+
+#: user_collection/templates/user_collection/missing_issues_list.html:44
+msgid "Missing"
+msgstr "Mancanti"
+
+#: user_collection/templates/user_collection/missing_issues_list.html:78
+msgid "View Missing"
+msgstr "Visualizza Mancanti"
+
+#: user_collection/templates/user_collection/missing_issues_list.html:95
+msgid "You have complete runs of all your series."
+msgstr "Possiedi collezioni complete di tutte le tue serie."
+
+#: user_collection/templates/user_collection/partials/collection_filter.html:10
+msgid "Search Collection"
+msgstr "Cerca nella Collezione"
+
+#: user_collection/templates/user_collection/partials/collection_filter.html:18
+msgid "Filters Active"
+msgstr "Filtri Attivi"
+
+#: user_collection/templates/user_collection/partials/collection_filter.html:24
+msgid "Quick Search"
+msgstr "Ricerca Rapida"
+
+#: user_collection/templates/user_collection/partials/collection_filter.html:31
+msgid "Search across series and notes..."
+msgstr "Cerca tra serie e note..."
+
+#: user_collection/templates/user_collection/partials/collection_filter.html:32
+msgid "Quick search"
+msgstr "Ricerca rapida"
+
+#: user_collection/templates/user_collection/partials/collection_filter.html:37
+msgid "Search across series names and notes"
+msgstr "Cerca tra i nomi delle serie e le note"
+
+#: user_collection/templates/user_collection/partials/collection_filter.html:46
+msgid "Advanced Filters"
+msgstr "Filtri Avanzati"
+
+#: user_collection/templates/user_collection/partials/collection_filter.html:53
+msgid "Series Name"
+msgstr "Nome Serie"
+
+#: user_collection/templates/user_collection/partials/collection_filter.html:60
+msgid "e.g., Amazing Spider-Man"
+msgstr "es. Amazing Spider-Man"
+
+#: user_collection/templates/user_collection/partials/collection_filter.html:61
+msgid "Filter by series name"
+msgstr "Filtra per nome serie"
+
+#: user_collection/templates/user_collection/partials/collection_filter.html:70
+msgid "Series Type"
+msgstr "Tipo di Serie"
+
+#: user_collection/templates/user_collection/partials/collection_filter.html:75
+msgid "Filter by series type"
+msgstr "Filtra per tipo di serie"
+
+#: user_collection/templates/user_collection/partials/collection_filter.html:76
+msgid "All Types"
+msgstr "Tutti i Tipi"
+
+#: user_collection/templates/user_collection/partials/collection_filter.html:101
+msgid "e.g., Marvel"
+msgstr "es. Marvel"
+
+#: user_collection/templates/user_collection/partials/collection_filter.html:102
+msgid "Filter by publisher"
+msgstr "Filtra per editore"
+
+#: user_collection/templates/user_collection/partials/collection_filter.html:112
+msgid "Issue Number"
+msgstr "Numero Albo"
+
+#: user_collection/templates/user_collection/partials/collection_filter.html:119
+msgid "e.g., 1"
+msgstr "es. 1"
+
+#: user_collection/templates/user_collection/partials/collection_filter.html:120
+msgid "Filter by issue number"
+msgstr "Filtra per numero albo"
+
+#: user_collection/templates/user_collection/partials/collection_filter.html:133
+msgid "Filter by format"
+msgstr "Filtra per formato"
+
+#: user_collection/templates/user_collection/partials/collection_filter.html:134
+msgid "All Formats"
+msgstr "Tutti i Formati"
+
+#: user_collection/templates/user_collection/partials/collection_filter.html:152
+msgid "Read Status"
+msgstr "Stato Lettura"
+
+#: user_collection/templates/user_collection/partials/collection_filter.html:155
+msgid "Filter by read status"
+msgstr "Filtra per stato di lettura"
+
+#: user_collection/templates/user_collection/partials/collection_filter.html:156
+msgid "All"
+msgstr "Tutti"
+
+#: user_collection/templates/user_collection/partials/collection_filter.html:175
+msgid "Filter by grade"
+msgstr "Filtra per grado"
+
+#: user_collection/templates/user_collection/partials/collection_filter.html:176
+msgid "All Grades"
+msgstr "Tutti i Gradi"
+
+#: user_collection/templates/user_collection/partials/collection_filter.html:199
+msgid "Filter by grading company"
+msgstr "Filtra per società di valutazione"
+
+#: user_collection/templates/user_collection/partials/collection_filter.html:200
+msgid "All Companies"
+msgstr "Tutte le Società"
+
+#: user_collection/templates/user_collection/partials/collection_filter.html:221
+msgid "Filter by rating"
+msgstr "Filtra per valutazione"
+
+#: user_collection/templates/user_collection/partials/collection_filter.html:222
+msgid "All Ratings"
+msgstr "Tutte le Valutazioni"
+
+#: user_collection/templates/user_collection/partials/collection_filter.html:226
+msgid "%(counter)s Star"
+msgid_plural "%(counter)s Stars"
+msgstr[0] "%(counter)s Stella"
+msgstr[1] "%(counter)s Stelle"
+
+#: user_collection/templates/user_collection/partials/collection_filter.html:246
+msgid "Apply Filters"
+msgstr "Applica Filtri"
+
+#: user_collection/templates/user_collection/partials/collection_filter.html:252
+msgid "Clear all filters"
+msgstr "Cancella tutti i filtri"
+
+#: user_collection/templates/user_collection/partials/collection_filter.html:256
+msgid "Clear Filters"
+msgstr "Cancella Filtri"
+
+#: user_collection/templates/user_collection/partials/read_dates_list.html:9
+msgid "Remove read date"
+msgstr "Rimuovi data di lettura"
+
+#: user_collection/templates/user_collection/partials/read_dates_list.html:20
+msgid "Confirm Delete"
+msgstr "Conferma Eliminazione"
+
+#: user_collection/templates/user_collection/partials/read_dates_list.html:22
+msgid "close"
+msgstr "chiudi"
+
+#: user_collection/templates/user_collection/partials/read_dates_list.html:28
+msgid "Are you sure you want to remove the read date <strong>%(read_date)s</strong>?"
+msgstr ""
+"Sei sicuro di voler rimuovere la data di lettura <strong>%(read_date)s</strong>?"
+
+#: user_collection/templates/user_collection/partials/read_dates_list.html:35
+msgid "Remove Read Date"
+msgstr "Rimuovi Data di Lettura"
+
+#: user_collection/templates/user_collection/partials/read_dates_list.html:46
+#: user_collection/templates/user_collection/reading_history.html:83
+msgid "Read %(counter)s time"
+msgid_plural "Read %(counter)s times"
+msgstr[0] "Letto %(counter)s volta"
+msgstr[1] "Letto %(counter)s volte"
+
+#: user_collection/templates/user_collection/partials/read_dates_list.html:49
+msgid "Not read yet"
+msgstr "Non ancora letto"
+
+#: user_collection/templates/user_collection/partials/read_dates_list.html:58
+msgid "Optional: specify date/time"
+msgstr "Opzionale: specifica data/ora"
+
+#: user_collection/templates/user_collection/partials/read_dates_list.html:62
+msgid "Leave blank to use current date/time"
+msgstr "Lascia vuoto per usare la data/ora corrente"
+
+#: user_collection/templates/user_collection/partials/read_dates_list.html:73
+msgid "Add Read Date"
+msgstr "Aggiungi Data di Lettura"
+
+#: user_collection/templates/user_collection/partials/star_rating.html:10
+msgid "Rate %(counter)s star"
+msgid_plural "Rate %(counter)s stars"
+msgstr[0] "Vota %(counter)s stella"
+msgstr[1] "Vota %(counter)s stelle"
+
+#: user_collection/templates/user_collection/partials/star_rating.html:21
+msgid "Clear rating"
+msgstr "Cancella valutazione"
+
+#: user_collection/templates/user_collection/reading_history.html:4
+msgid "Reading History - Metron"
+msgstr "Cronologia Letture - Metron"
+
+#: user_collection/templates/user_collection/reading_history.html:7
+msgid "My Reading History"
+msgstr "La Mia Cronologia di Lettura"
+
+#: user_collection/templates/user_collection/reading_history.html:15
+msgid "<strong>%(counter)s</strong> issue read"
+msgid_plural "<strong>%(counter)s</strong> issues read"
+msgstr[0] "<strong>%(counter)s</strong> albo letto"
+msgstr[1] "<strong>%(counter)s</strong> albi letti"
+
+#: user_collection/templates/user_collection/reading_history.html:55
+msgid "Date Unknown"
+msgstr "Data Sconosciuta"
+
+#: user_collection/templates/user_collection/reading_history.html:73
+msgid "No cover available"
+msgstr "Copertina non disponibile"
+
+#: user_collection/templates/user_collection/reading_history.html:125
+msgid "Details"
+msgstr "Dettagli"
+
+#: user_collection/templates/user_collection/reading_history.html:139
+msgid "No reading history yet"
+msgstr "Nessuna cronologia di lettura ancora"
+
+#: user_collection/templates/user_collection/reading_history.html:140
+msgid "Start reading and marking issues as read to build your reading history!"
+msgstr ""
+"Inizia a leggere e segnare gli albi come letti per costruire la tua cronologia di "
+"lettura!"
+
+#: user_collection/templates/user_collection/reading_history.html:144
+msgid "Go to My Collection"
+msgstr "Vai alla Mia Collezione"
+
+#: user_collection/views.py:115
+msgid "Item added to your collection!"
+msgstr "Elemento aggiunto alla tua collezione!"
+
+#: user_collection/views.py:147
+msgid "Collection item updated!"
+msgstr "Elemento della collezione aggiornato!"
+
+#: user_collection/views.py:168
+msgid "Item removed from your collection."
+msgstr "Elemento rimosso dalla tua collezione."
+
+#: user_collection/views.py:212 user_collection/views.py:229
+#: user_collection/views.py:243
+msgid "Unknown"
+msgstr "Sconosciuto"
+
+#: user_collection/views.py:217
+msgid "Issues by Publisher"
+msgstr "Albi per Editore"
+
+#: user_collection/views.py:234
+msgid "Issues by Series Type"
+msgstr "Albi per Tipo di Serie"
+
+#: user_collection/views.py:248
+msgid "Issues by Format"
+msgstr "Albi per Formato"
+
+#: user_collection/views.py:272
+msgid "Issues Read (Last 30 Days)"
+msgstr "Albi Letti (Ultimi 30 Giorni)"
+
+#: user_collection/views.py:285
+msgid "Issues Read (Last 12 Months)"
+msgstr "Albi Letti (Ultimi 12 Mesi)"
+
+#: user_collection/views.py:302
+msgid "Top Writers"
+msgstr "Migliori Sceneggiatori"
+
+#: user_collection/views.py:327
+msgid "Top Artists"
+msgstr "Migliori Disegnatori"
+
+#: user_collection/views.py:454
+msgid "Added %(count)d issue to your collection"
+msgid_plural "Added %(count)d issues to your collection"
+msgstr[0] "Aggiunto %(count)d albo alla tua collezione"
+msgstr[1] "Aggiunti %(count)d albi alla tua collezione"
+
+#: user_collection/views.py:459
+#, python-format
+msgid "%(phrase)s (marked as read)"
+msgstr "%(phrase)s (segnato come letto)"
+
+#: user_collection/views.py:463
+#, python-format
+msgid "Skipped %(count)d issue already in your collection."
+msgid_plural "Skipped %(count)d issues already in your collection."
+msgstr[0] "Saltato %(count)d albo già nella tua collezione."
+msgstr[1] "Saltati %(count)d albi già nella tua collezione."
+
+#: user_collection/views.py:467
+#, python-format
+msgid "%(added)s. %(skipped)s"
+msgstr "%(added)s. %(skipped)s"
+
+#: user_collection/views.py:472
+#, python-format
+msgid "%(added)s!"
+msgstr "%(added)s!"
+
+#: user_collection/views.py:477
+msgid "All issues from this series are already in your collection."
+msgstr "Tutti gli albi di questa serie sono già nella tua collezione."
+
+#: wish_list/forms.py:41
+msgid "Notes about this item (optional)"
+msgstr "Note su questo elemento (opzionale)"
+
+#: wish_list/forms.py:47
+msgid "Minimum Grade"
+msgstr "Grado Minimo"
+
+#: wish_list/forms.py:48 wish_list/models.py:66
+msgid "Maximum Price"
+msgstr "Prezzo Massimo"
+
+#: wish_list/forms.py:49
+msgid "Priority (1=Highest)"
+msgstr "Priorità (1=Massima)"
+
+#: wish_list/forms.py:53
+msgid "Leave blank if any condition is acceptable."
+msgstr "Lascia vuoto se qualsiasi condizione è accettabile."
+
+#: wish_list/forms.py:54
+msgid "1 is highest priority, 5 is lowest."
+msgstr "1 è la priorità più alta, 5 la più bassa."
+
+#: wish_list/forms.py:67
+msgid "Purchase Date"
+msgstr "Data di Acquisto"
+
+#: wish_list/forms.py:84
+msgid "Additional notes"
+msgstr "Note aggiuntive"
+
+#: wish_list/models.py:23
+#: wish_list/templates/wish_list/partials/wish_list_button.html:11
+msgid "Wish List"
+msgstr "Lista dei Desideri"
+
+#: wish_list/models.py:24
+msgid "Wish Lists"
+msgstr "Liste dei Desideri"
+
+#: wish_list/models.py:35
+msgid "Wanted"
+msgstr "Desiderato"
+
+#: wish_list/models.py:36
+msgid "Found"
+msgstr "Trovato"
+
+#: wish_list/models.py:37
+msgid "Acquired"
+msgstr "Acquisito"
+
+#: wish_list/models.py:83
+msgid "Wish List Item"
+msgstr "Elemento della Lista dei Desideri"
+
+#: wish_list/models.py:84
+msgid "Wish List Items"
+msgstr "Elementi della Lista dei Desideri"
+
+#: wish_list/templates/wish_list/partials/wish_list_button.html:7
+msgid "Remove from wish list"
+msgstr "Rimuovi dalla lista dei desideri"
+
+#: wish_list/templates/wish_list/partials/wish_list_button.html:7
+msgid "Add to wish list"
+msgstr "Aggiungi alla lista dei desideri"
+
+#: wish_list/templates/wish_list/wishlist_acquire_form.html:3
+msgid "Acquire %(issue)s - Metron"
+msgstr "Acquisisci %(issue)s - Metron"
+
+#: wish_list/templates/wish_list/wishlist_acquire_form.html:6
+msgid "Acquire Item"
+msgstr "Acquisisci Elemento"
+
+#: wish_list/templates/wish_list/wishlist_acquire_form.html:7
+msgid "Mark <strong>%(issue)s</strong> as acquired"
+msgstr "Segna <strong>%(issue)s</strong> come acquisito"
+
+#: wish_list/templates/wish_list/wishlist_acquire_form.html:15
+#, python-format
+msgid ""
+"This will mark <strong>%(issue)s</strong> as acquired on your wish list and add it to "
+"your collection. You can optionally record purchase details below."
+msgstr ""
+"Questo segnerà <strong>%(issue)s</strong> come acquisito nella tua lista dei desideri "
+"e lo aggiungerà alla tua collezione. Puoi facoltativamente registrare i dettagli di "
+"acquisto qui sotto."
+
+#: wish_list/templates/wish_list/wishlist_acquire_form.html:40
+msgid "Mark as Acquired"
+msgstr "Segna come Acquisito"
+
+#: wish_list/templates/wish_list/wishlist_detail.html:10
+msgid "Add an Issue"
+msgstr "Aggiungi un Albo"
+
+#: wish_list/templates/wish_list/wishlist_detail.html:64
+msgid "Add to Wish List"
+msgstr "Aggiungi alla Lista dei Desideri"
+
+#: wish_list/templates/wish_list/wishlist_detail.html:74
+#, python-format
+msgid "Items (%(count)s)"
+msgstr "Elementi (%(count)s)"
+
+#: wish_list/templates/wish_list/wishlist_detail.html:81
+msgid "Priority"
+msgstr "Priorità"
+
+#: wish_list/templates/wish_list/wishlist_detail.html:84
+msgid "Status"
+msgstr "Stato"
+
+#: wish_list/templates/wish_list/wishlist_detail.html:85
+msgid "Min Grade"
+msgstr "Grado Min"
+
+#: wish_list/templates/wish_list/wishlist_detail.html:86
+msgid "Max Price"
+msgstr "Prezzo Max"
+
+#: wish_list/templates/wish_list/wishlist_detail.html:117
+msgid "Acquire"
+msgstr "Acquisisci"
+
+#: wish_list/templates/wish_list/wishlist_detail.html:140
+msgid "No items on this wish list yet."
+msgstr "Nessun elemento ancora in questa lista dei desideri."
+
+#: wish_list/templates/wish_list/wishlist_item_confirm_delete.html:3
+msgid "Remove from Wish List - Metron"
+msgstr "Rimuovi dalla Lista dei Desideri - Metron"
+
+#: wish_list/templates/wish_list/wishlist_item_confirm_delete.html:6
+msgid "Remove from Wish List"
+msgstr "Rimuovi dalla Lista dei Desideri"
+
+#: wish_list/templates/wish_list/wishlist_item_confirm_delete.html:18
+msgid "Are you sure you want to remove <strong>%(issue)s</strong> from your wish list?"
+msgstr ""
+"Sei sicuro di voler rimuovere <strong>%(issue)s</strong> dalla tua lista dei desideri?"
+
+#: wish_list/templates/wish_list/wishlist_item_form.html:3
+msgid "Edit Wish List Item - Metron"
+msgstr "Modifica Elemento della Lista dei Desideri - Metron"
+
+#: wish_list/templates/wish_list/wishlist_item_form.html:6
+msgid "Edit Wish List Item"
+msgstr "Modifica Elemento della Lista dei Desideri"
+
+#: wish_list/templates/wish_list/wishlist_item_form.html:53
+msgid "Save Changes"
+msgstr "Salva Modifiche"
+
+#: wish_list/views.py:35
+msgid "%(issue)s is already on your wish list."
+msgstr "%(issue)s è già nella tua lista dei desideri."
+
+#: wish_list/views.py:41
+msgid "Added %(issue)s to your wish list."
+msgstr "Aggiunto %(issue)s alla tua lista dei desideri."
+
+#: wish_list/views.py:69
+#, python-format
+msgid "Updated %(issue)s."
+msgstr "%(issue)s aggiornato."
+
+#: wish_list/views.py:84
+msgid "Removed %(issue)s from your wish list."
+msgstr "Rimosso %(issue)s dalla tua lista dei desideri."
+
+#: wish_list/views.py:116
+#, python-format
+msgid "%(issue)s marked as acquired! Added to your collection."
+msgstr "%(issue)s segnato come acquisito! Aggiunto alla tua collezione."
+
+#: wish_list/views.py:120
+#, python-format
+msgid "%(issue)s marked as acquired! Already in your collection."
+msgstr "%(issue)s segnato come acquisito! Già nella tua collezione."

--- a/locale/it/LC_MESSAGES/django.po
+++ b/locale/it/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: metron\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-13 11:23-0400\n"
+"POT-Creation-Date: 2026-08-13 12:29-0400\n"
 "PO-Revision-Date: 2026-08-13 11:23-0400\n"
 "Last-Translator: Metron Project\n"
 "Language-Team: Italian\n"
@@ -15,6 +15,22 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: api/v1_0/serializers/collection.py:98 api/v1_0/serializers/collection.py:218
+#: api/v1_0/serializers/wish_list.py:79
+#, python-format
+msgid "Issue with id %(id)s does not exist."
+msgstr "Non esiste alcun albo con id %(id)s."
+
+#: api/v1_0/serializers/issue.py:115
+#, python-format
+msgid "Invalid currency '%(currency)s'. Supported: %(valid)s"
+msgstr "Valuta '%(currency)s' non valida. Supportate: %(valid)s"
+
+#: api/v1_0/serializers/issue.py:123 api/v1_0/serializers/issue.py:136
+#, python-format
+msgid "Invalid price format: %(error)s"
+msgstr "Formato del prezzo non valido: %(error)s"
 
 #: comicsdb/admin/issue.py:119 comicsdb/admin/issue.py:148
 #: comicsdb/admin/issue.py:170 comicsdb/admin/series.py:61
@@ -44,7 +60,8 @@ msgstr "Completamento automatico..."
 
 #: comicsdb/forms/issue.py:98
 msgid "Primarily used for legacy numbering for DC and Marvel comics."
-msgstr "Utilizzato principalmente per la numerazione storica dei fumetti DC e Marvel."
+msgstr ""
+"Utilizzato principalmente per la numerazione storica dei fumetti DC e Marvel."
 
 #: comicsdb/forms/issue.py:99
 msgid "Separate multiple story titles by a semicolon"
@@ -145,7 +162,8 @@ msgstr "Hash della Copertina"
 #: comicsdb/views/issue.py:451
 #, python-format
 msgid "Credit duplication is not allowed for %(publisher)s issues."
-msgstr "La duplicazione dei crediti non è consentita per gli albi di %(publisher)s."
+msgstr ""
+"La duplicazione dei crediti non è consentita per gli albi di %(publisher)s."
 
 #: comicsdb/views/issue.py:461
 #, python-format
@@ -153,8 +171,8 @@ msgid ""
 "%(issue)s already has credits assigned. Duplicate operation cancelled to "
 "preserve existing data."
 msgstr ""
-"%(issue)s ha già dei crediti assegnati. Operazione di duplicazione "
-"annullata per preservare i dati esistenti."
+"%(issue)s ha già dei crediti assegnati. Operazione di duplicazione annullata "
+"per preservare i dati esistenti."
 
 #: comicsdb/views/issue.py:473
 #, python-format
@@ -186,8 +204,8 @@ msgid ""
 "No credits were duplicated. Skipped %(skipped)s variant cover credit(s) from "
 "%(issue)s."
 msgstr ""
-"Nessun credito è stato duplicato. Saltati %(skipped)s credito/i di "
-"copertina variante da %(issue)s."
+"Nessun credito è stato duplicato. Saltati %(skipped)s credito/i di copertina "
+"variante da %(issue)s."
 
 #: comicsdb/views/issue.py:604
 #, python-format
@@ -311,7 +329,8 @@ msgstr "Quest'opera è distribuita con licenza"
 
 #: templates/partials/footer.html:78
 msgid "Creative Commons Attribution-ShareAlike 4.0 International License"
-msgstr "Creative Commons Attribuzione-Condividi allo stesso modo 4.0 Internazionale"
+msgstr ""
+"Creative Commons Attribuzione-Condividi allo stesso modo 4.0 Internazionale"
 
 #: templates/partials/footer.html:79
 msgid ", except where noted otherwise."
@@ -497,3 +516,7 @@ msgstr "Accedi al tuo account"
 #: templates/partials/navbar.html:273
 msgid "Log in"
 msgstr "Accedi"
+
+#: timeline/templates/timeline.html:4
+msgid "Timeline"
+msgstr "Cronologia"

--- a/locale/it/LC_MESSAGES/django.po
+++ b/locale/it/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: metron\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-13 16:05-0400\n"
+"POT-Creation-Date: 2026-08-13 18:48-0400\n"
 "PO-Revision-Date: 2026-08-13 11:23-0400\n"
 "Last-Translator: Metron Project\n"
 "Language-Team: Italian\n"
@@ -15,6 +15,452 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: api/templates/api/throttle_enforcement_email.html:8
+msgid "Your Metron API access has been restricted"
+msgstr "Il tuo accesso all'API di Metron è stato limitato"
+
+#: api/templates/api/throttle_enforcement_email.html:49
+#: api/templates/api/throttle_enforcement_email.txt:1
+#: api/templates/api/throttle_notice_email.html:49
+#: api/templates/api/throttle_notice_email.txt:1
+#, python-format
+msgid "Hi %(username)s,"
+msgstr "Ciao %(username)s,"
+
+#: api/templates/api/throttle_enforcement_email.html:55
+msgid ""
+"We previously warned you that your Metron API client was repeatedly hitting our rate "
+"limits without backing off. Since that behavior has continued, we've had to take "
+"action on this account:"
+msgstr ""
+"Ti avevamo già avvisato che il tuo client API di Metron stava ripetutamente superando "
+"i nostri limiti di frequenza senza rallentare. Poiché questo comportamento è "
+"continuato, abbiamo dovuto intervenire su questo account:"
+
+#: api/templates/api/throttle_enforcement_email.html:73
+#, python-format
+msgid ""
+"Most recently, your client received <strong>%(counter)s rate-limited (429) response</"
+"strong> in a single day."
+msgid_plural ""
+"Most recently, your client received <strong>%(counter)s rate-limited (429) responses</"
+"strong> in a single day."
+msgstr[0] ""
+"Più di recente, il tuo client ha ricevuto <strong>%(counter)s risposta limitata "
+"(429)</strong> in un singolo giorno."
+msgstr[1] ""
+"Più di recente, il tuo client ha ricevuto <strong>%(counter)s risposte limitate "
+"(429)</strong> in un singolo giorno."
+
+#: api/templates/api/throttle_enforcement_email.html:75
+#: api/templates/api/throttle_enforcement_email.html:79
+#, python-format
+msgid ""
+"Most recently, your client received <strong>%(counter)s rate-limited (429) response</"
+"strong>"
+msgid_plural ""
+"Most recently, your client received <strong>%(counter)s rate-limited (429) responses</"
+"strong>"
+msgstr[0] ""
+"Più di recente, il tuo client ha ricevuto <strong>%(counter)s risposta limitata "
+"(429)</strong>"
+msgstr[1] ""
+"Più di recente, il tuo client ha ricevuto <strong>%(counter)s risposte limitate "
+"(429)</strong>"
+
+#: api/templates/api/throttle_enforcement_email.html:76
+#: api/templates/api/throttle_notice_email.html:80
+#, python-format
+msgid "recently, including <strong>%(worst)s</strong> in a single day."
+msgstr "recentemente, incluso <strong>%(worst)s</strong> in un singolo giorno."
+
+#: api/templates/api/throttle_enforcement_email.html:80
+#: api/templates/api/throttle_notice_email.html:84
+#, python-format
+msgid "across <strong>%(counter)s day</strong>"
+msgid_plural "across <strong>%(counter)s days</strong>"
+msgstr[0] "attraverso <strong>%(counter)s giorno</strong>"
+msgstr[1] "attraverso <strong>%(counter)s giorni</strong>"
+
+#: api/templates/api/throttle_enforcement_email.html:81
+#: api/templates/api/throttle_notice_email.html:85
+#, python-format
+msgid "including <strong>%(worst)s</strong> in a single day."
+msgstr "incluso <strong>%(worst)s</strong> in un singolo giorno."
+
+#: api/templates/api/throttle_enforcement_email.html:102
+msgid ""
+"<strong>This account has been disabled.</strong> You won't be able to log in or use "
+"the API until an administrator reinstates it."
+msgstr ""
+"<strong>Questo account è stato disabilitato.</strong> Non potrai accedere o "
+"utilizzare l'API finché un amministratore non lo riattiverà."
+
+#: api/templates/api/throttle_enforcement_email.html:104
+msgid ""
+"<strong>All API tokens for this account have been revoked.</strong> You'll need to "
+"generate a new token before you can use the API again."
+msgstr ""
+"<strong>Tutti i token API per questo account sono stati revocati.</strong> Dovrai "
+"generare un nuovo token prima di poter utilizzare nuovamente l'API."
+
+#: api/templates/api/throttle_enforcement_email.html:114
+msgid ""
+"Before using the API again, please make sure your client respects the <code>X-"
+"RateLimit-*</code> response headers and backs off after a 429 response instead of "
+"retrying immediately. For details on our rate limits and how to implement a backoff "
+"strategy, see our <a href=\"https://metron.cloud/wiki/api/handling-rate-limits/\" "
+"style=\"color: #3273dc;\">Rate Limiting documentation</a>."
+msgstr ""
+"Prima di usare nuovamente l'API, assicurati che il tuo client rispetti gli header di "
+"risposta <code>X-RateLimit-*</code> e rallenti dopo una risposta 429 invece di "
+"riprovare immediatamente. Per dettagli sui nostri limiti di frequenza e su come "
+"implementare una strategia di backoff, consulta la nostra <a href=\"https://"
+"metron.cloud/wiki/api/handling-rate-limits/\" style=\"color: #3273dc;"
+"\">documentazione sul Rate Limiting</a>."
+
+#: api/templates/api/throttle_enforcement_email.html:120
+msgid ""
+"If you have any questions, or believe this was done in error, please reply to this "
+"email so we can review it."
+msgstr ""
+"Se hai domande, o ritieni che questo sia stato fatto per errore, rispondi a questa "
+"email in modo da poterlo esaminare."
+
+#: api/templates/api/throttle_enforcement_email.html:131
+#: api/templates/api/throttle_enforcement_email.txt:29
+#: api/templates/api/throttle_notice_email.html:150
+#: api/templates/api/throttle_notice_email.txt:35 templates/base.html:9
+#: templates/partials/social_meta.html:10 templates/partials/social_meta.html:21
+#: users/templates/registration/account_activation_email.html:210
+#: users/templates/registration/account_activation_email.txt:21
+msgid "Metron Comic Book Database"
+msgstr "Database Fumetti Metron"
+
+#: api/templates/api/throttle_enforcement_email.html:137
+#: api/templates/api/throttle_enforcement_email.txt:30
+#: api/templates/api/throttle_notice_email.html:156
+#: api/templates/api/throttle_notice_email.txt:36
+#: users/templates/registration/account_activation_email.html:216
+#: users/templates/registration/account_activation_email.txt:22
+msgid "A community-driven project for comic book enthusiasts"
+msgstr "Un progetto guidato dalla community per appassionati di fumetti"
+
+#: api/templates/api/throttle_enforcement_email.html:144
+#: api/templates/api/throttle_notice_email.html:163
+#: users/templates/registration/account_activation_email.html:223
+msgid "Visit Website"
+msgstr "Visita il Sito"
+
+#: api/templates/api/throttle_enforcement_email.html:150
+#: api/templates/api/throttle_notice_email.html:169 templates/404.html:82
+#: templates/500.html:82 templates/partials/footer.html:10
+#: users/templates/registration/account_activation_email.html:229
+msgid "Contact Us"
+msgstr "Contattaci"
+
+#: api/templates/api/throttle_enforcement_email.html:157
+#: api/templates/api/throttle_notice_email.html:176 templates/partials/footer.html:95
+#: users/templates/registration/account_activation_email.html:236
+#, python-format
+msgid "&copy; %(current_year)s Metron Project. All rights reserved."
+msgstr "&copy; %(current_year)s Metron Project. Tutti i diritti riservati."
+
+#: api/templates/api/throttle_enforcement_email.txt:3
+msgid ""
+"We previously warned you that your Metron API client was repeatedly hitting our\n"
+"rate limits without backing off. Since that behavior has continued, we've had\n"
+"to take action on this account:"
+msgstr ""
+"Ti avevamo già avvisato che il tuo client API di Metron stava ripetutamente superando "
+"i\n"
+"nostri limiti di frequenza senza rallentare. Poiché questo comportamento è "
+"continuato, abbiamo dovuto\n"
+"intervenire su questo account:"
+
+#: api/templates/api/throttle_enforcement_email.txt:7
+#, python-format
+msgid ""
+"Most recently, your client received %(counter)s rate-limited (429) response\n"
+"in a single day."
+msgid_plural ""
+"Most recently, your client received %(counter)s rate-limited (429) responses\n"
+"in a single day."
+msgstr[0] ""
+"Più di recente, il tuo client ha ricevuto %(counter)s risposta limitata (429)\n"
+"in un singolo giorno."
+msgstr[1] ""
+"Più di recente, il tuo client ha ricevuto %(counter)s risposte limitate (429)\n"
+"in un singolo giorno."
+
+#: api/templates/api/throttle_enforcement_email.txt:9
+#: api/templates/api/throttle_enforcement_email.txt:10
+#, python-format
+msgid "Most recently, your client received %(counter)s rate-limited (429) response"
+msgid_plural ""
+"Most recently, your client received %(counter)s rate-limited (429) responses"
+msgstr[0] ""
+"Più di recente, il tuo client ha ricevuto %(counter)s risposta limitata (429)"
+msgstr[1] ""
+"Più di recente, il tuo client ha ricevuto %(counter)s risposte limitate (429)"
+
+#: api/templates/api/throttle_enforcement_email.txt:10
+#: api/templates/api/throttle_notice_email.txt:14
+#, python-format
+msgid "recently, including %(worst)s in a single day."
+msgstr "recentemente, incluso %(worst)s in un singolo giorno."
+
+#: api/templates/api/throttle_enforcement_email.txt:11
+#: api/templates/api/throttle_notice_email.txt:15
+#, python-format
+msgid "across %(counter)s day"
+msgid_plural "across %(counter)s days"
+msgstr[0] "attraverso %(counter)s giorno"
+msgstr[1] "attraverso %(counter)s giorni"
+
+#: api/templates/api/throttle_enforcement_email.txt:11
+#: api/templates/api/throttle_notice_email.txt:15
+#, python-format
+msgid ""
+"including %(worst)s\n"
+"in a single day."
+msgstr ""
+"incluso %(worst)s\n"
+"in un singolo giorno."
+
+#: api/templates/api/throttle_enforcement_email.txt:14
+msgid ""
+"This account has been disabled. You won't be able to log in or use the API\n"
+"until an administrator reinstates it."
+msgstr ""
+"Questo account è stato disabilitato. Non potrai accedere o utilizzare l'API\n"
+"finché un amministratore non lo riattiverà."
+
+#: api/templates/api/throttle_enforcement_email.txt:15
+msgid ""
+"All API tokens for this account have been revoked. You'll need to generate a\n"
+"new token before you can use the API again."
+msgstr ""
+"Tutti i token API per questo account sono stati revocati. Dovrai generare un\n"
+"nuovo token prima di poter utilizzare nuovamente l'API."
+
+#: api/templates/api/throttle_enforcement_email.txt:18
+msgid ""
+"Before using the API again, please make sure your client respects the\n"
+"X-RateLimit-* response headers and backs off after a 429 response instead of\n"
+"retrying immediately. For details on our rate limits and how to implement a\n"
+"backoff strategy, see:"
+msgstr ""
+"Prima di usare nuovamente l'API, assicurati che il tuo client rispetti gli\n"
+"header di risposta X-RateLimit-* e rallenti dopo una risposta 429 invece di\n"
+"riprovare immediatamente. Per dettagli sui nostri limiti di frequenza e su\n"
+"come implementare una strategia di backoff, vedi:"
+
+#: api/templates/api/throttle_enforcement_email.txt:25
+msgid ""
+"If you have any questions, or believe this was done in error, please reply to\n"
+"this email so we can review it."
+msgstr ""
+"Se hai domande, o ritieni che questo sia stato fatto per errore, rispondi a\n"
+"questa email in modo da poterlo esaminare."
+
+#: api/templates/api/throttle_enforcement_email.txt:32
+#: api/templates/api/throttle_notice_email.txt:38
+msgid "Website:"
+msgstr "Sito web:"
+
+#: api/templates/api/throttle_enforcement_email.txt:34
+#: api/templates/api/throttle_notice_email.txt:40
+msgid "Contact:"
+msgstr "Contatto:"
+
+#: api/templates/api/throttle_enforcement_email.txt:37
+#: api/templates/api/throttle_notice_email.txt:43
+#: users/templates/registration/account_activation_email.txt:29
+#, python-format
+msgid "(c) %(current_year)s Metron Project. All rights reserved."
+msgstr "(c) %(current_year)s Metron Project. Tutti i diritti riservati."
+
+#: api/templates/api/throttle_notice_email.html:8
+msgid "Your Metron API client is being rate-limited"
+msgstr "Il tuo client API di Metron è soggetto a limitazione di frequenza"
+
+#: api/templates/api/throttle_notice_email.html:56
+#, python-format
+msgid ""
+"We've noticed that your Metron API client hit our rate limits hard, with %(count)s "
+"rate-limited (429) responses in a single day. When a client keeps retrying "
+"immediately after a 429 response instead of backing off, it adds unnecessary load to "
+"the site for everyone."
+msgstr ""
+"Abbiamo notato che il tuo client API di Metron ha superato pesantemente i nostri "
+"limiti di frequenza, con %(count)s risposte limitate (429) in un singolo giorno. "
+"Quando un client continua a riprovare immediatamente dopo una risposta 429 invece di "
+"rallentare, aggiunge un carico non necessario al sito per tutti."
+
+#: api/templates/api/throttle_notice_email.html:58
+msgid ""
+"We've noticed that your Metron API client has repeatedly hit our rate limits over the "
+"past several days. When a client keeps retrying immediately after a 429 response "
+"instead of backing off, it adds unnecessary load to the site for everyone."
+msgstr ""
+"Abbiamo notato che il tuo client API di Metron ha ripetutamente superato i nostri "
+"limiti di frequenza negli ultimi giorni. Quando un client continua a riprovare "
+"immediatamente dopo una risposta 429 invece di rallentare, aggiunge un carico non "
+"necessario al sito per tutti."
+
+#: api/templates/api/throttle_notice_email.html:77
+#, python-format
+msgid ""
+"Your client received <strong>%(counter)s rate-limited (429) response</strong> in a "
+"single day."
+msgid_plural ""
+"Your client received <strong>%(counter)s rate-limited (429) responses</strong> in a "
+"single day."
+msgstr[0] ""
+"Il tuo client ha ricevuto <strong>%(counter)s risposta limitata (429)</strong> in un "
+"singolo giorno."
+msgstr[1] ""
+"Il tuo client ha ricevuto <strong>%(counter)s risposte limitate (429)</strong> in un "
+"singolo giorno."
+
+#: api/templates/api/throttle_notice_email.html:79
+#: api/templates/api/throttle_notice_email.html:83
+#, python-format
+msgid "Your client received <strong>%(counter)s rate-limited (429) response</strong>"
+msgid_plural ""
+"Your client received <strong>%(counter)s rate-limited (429) responses</strong>"
+msgstr[0] ""
+"Il tuo client ha ricevuto <strong>%(counter)s risposta limitata (429)</strong>"
+msgstr[1] ""
+"Il tuo client ha ricevuto <strong>%(counter)s risposte limitate (429)</strong>"
+
+#: api/templates/api/throttle_notice_email.html:105
+msgid ""
+"Every API response includes <code>X-RateLimit-*</code> headers showing your current "
+"limit, remaining requests, and when the window resets. A 429 response means you've "
+"exceeded that limit for the current window - the fix is to slow down and wait before "
+"retrying, rather than retrying immediately."
+msgstr ""
+"Ogni risposta dell'API include gli header <code>X-RateLimit-*</code> che mostrano il "
+"tuo limite attuale, le richieste rimanenti e quando la finestra si azzera. Una "
+"risposta 429 significa che hai superato quel limite per la finestra corrente - la "
+"soluzione è rallentare e attendere prima di riprovare, invece di riprovare "
+"immediatamente."
+
+#: api/templates/api/throttle_notice_email.html:114
+msgid ""
+"For details on our current rate limits and how to implement a backoff strategy, see "
+"our <a href=\"https://metron.cloud/wiki/api/handling-rate-limits/\" style=\"color: "
+"#3273dc;\">Rate Limiting documentation</a>."
+msgstr ""
+"Per dettagli sui nostri limiti di frequenza attuali e su come implementare una "
+"strategia di backoff, consulta la nostra <a href=\"https://metron.cloud/wiki/api/"
+"handling-rate-limits/\" style=\"color: #3273dc;\">documentazione sul Rate Limiting</"
+"a>."
+
+#: api/templates/api/throttle_notice_email.html:130
+msgid ""
+"<strong>Important:</strong> If this behavior continues, we may revoke API access for "
+"this account to protect the site for other users."
+msgstr ""
+"<strong>Importante:</strong> Se questo comportamento continua, potremmo revocare "
+"l'accesso API per questo account per proteggere il sito per gli altri utenti."
+
+#: api/templates/api/throttle_notice_email.html:139
+msgid ""
+"If you have any questions, or believe you're seeing this in error, just reply to this "
+"email."
+msgstr ""
+"Se hai domande, o ritieni che questo sia un errore, rispondi semplicemente a questa "
+"email."
+
+#: api/templates/api/throttle_notice_email.txt:3
+#, python-format
+msgid ""
+"We've noticed that your Metron API client hit our rate limits hard, with\n"
+"%(count)s rate-limited (429) responses in a single day. When a client keeps\n"
+"retrying immediately after a 429 response instead of backing off, it adds\n"
+"unnecessary load to the site for everyone."
+msgstr ""
+"Abbiamo notato che il tuo client API di Metron ha superato pesantemente i\n"
+"nostri limiti di frequenza, con %(count)s risposte limitate (429) in un\n"
+"singolo giorno. Quando un client continua a riprovare immediatamente dopo\n"
+"una risposta 429 invece di rallentare, aggiunge un carico non necessario al\n"
+"sito per tutti."
+
+#: api/templates/api/throttle_notice_email.txt:6
+msgid ""
+"We've noticed that your Metron API client has repeatedly hit our rate limits over\n"
+"the past several days. When a client keeps retrying immediately after a 429\n"
+"response instead of backing off, it adds unnecessary load to the site for\n"
+"everyone."
+msgstr ""
+"Abbiamo notato che il tuo client API di Metron ha ripetutamente superato i\n"
+"nostri limiti di frequenza negli ultimi giorni. Quando un client continua a\n"
+"riprovare immediatamente dopo una risposta 429 invece di rallentare,\n"
+"aggiunge un carico non necessario al sito per tutti."
+
+#: api/templates/api/throttle_notice_email.txt:11
+#, python-format
+msgid ""
+"Your client received %(counter)s rate-limited (429) response\n"
+"in a single day."
+msgid_plural ""
+"Your client received %(counter)s rate-limited (429) responses\n"
+"in a single day."
+msgstr[0] ""
+"Il tuo client ha ricevuto %(counter)s risposta limitata (429)\n"
+"in un singolo giorno."
+msgstr[1] ""
+"Il tuo client ha ricevuto %(counter)s risposte limitate (429)\n"
+"in un singolo giorno."
+
+#: api/templates/api/throttle_notice_email.txt:13
+#: api/templates/api/throttle_notice_email.txt:14
+#, python-format
+msgid "Your client received %(counter)s rate-limited (429) response"
+msgid_plural "Your client received %(counter)s rate-limited (429) responses"
+msgstr[0] "Il tuo client ha ricevuto %(counter)s risposta limitata (429)"
+msgstr[1] "Il tuo client ha ricevuto %(counter)s risposte limitate (429)"
+
+#: api/templates/api/throttle_notice_email.txt:18
+msgid ""
+"Every API response includes X-RateLimit-* headers showing your current limit,\n"
+"remaining requests, and when the window resets. A 429 response also means you've\n"
+"exceeded that limit for the current window - the fix is to slow down and wait\n"
+"before retrying, rather than retrying immediately."
+msgstr ""
+"Ogni risposta dell'API include gli header X-RateLimit-* che mostrano il tuo\n"
+"limite attuale, le richieste rimanenti e quando la finestra si azzera. Una\n"
+"risposta 429 significa anche che hai superato quel limite per la finestra\n"
+"corrente - la soluzione è rallentare e attendere prima di riprovare, invece\n"
+"di riprovare immediatamente."
+
+#: api/templates/api/throttle_notice_email.txt:23
+msgid ""
+"For details on our current rate limits and how to implement a backoff strategy,\n"
+"see:"
+msgstr ""
+"Per dettagli sui nostri limiti di frequenza attuali e su come implementare\n"
+"una strategia di backoff, vedi:"
+
+#: api/templates/api/throttle_notice_email.txt:28
+msgid ""
+"IMPORTANT: If this behavior continues, we may revoke API access for this account\n"
+"to protect the site for other users."
+msgstr ""
+"IMPORTANTE: Se questo comportamento continua, potremmo revocare l'accesso\n"
+"API per questo account per proteggere il sito per gli altri utenti."
+
+#: api/templates/api/throttle_notice_email.txt:31
+msgid ""
+"If you have any questions, or believe you're seeing this in error, just reply to\n"
+"this email."
+msgstr ""
+"Se hai domande, o ritieni che questo sia un errore, rispondi semplicemente a\n"
+"questa email."
 
 #: api/v1_0/serializers/collection.py:98 api/v1_0/serializers/collection.py:218
 #: api/v1_0/serializers/wish_list.py:79
@@ -54,7 +500,11 @@ msgid_plural "%d issues were updated"
 msgstr[0] "%d albo è stato aggiornato"
 msgstr[1] "%d albi sono stati aggiornati"
 
-#: comicsdb/forms/issue.py:50
+#: comicsdb/forms/character.py:31 comicsdb/forms/creator.py:34
+msgid "Separate multiple aliases by a comma"
+msgstr "Separa più alias con una virgola"
+
+#: comicsdb/forms/credits.py:21 comicsdb/forms/issue.py:50
 msgid "Autocomplete..."
 msgstr "Completamento automatico..."
 
@@ -83,11 +533,13 @@ msgid "This date should be earlier than the store date"
 msgstr "Questa data dovrebbe essere precedente alla data di uscita in negozio"
 
 #: comicsdb/forms/issue.py:106 comicsdb/models/issue.py:57
+#: comicsdb/templates/comicsdb/issue_detail.html:290
 #: user_collection/templates/user_collection/missing_issues_detail.html:80
 msgid "Story Title"
 msgstr "Titolo della Storia"
 
 #: comicsdb/forms/issue.py:107 comicsdb/models/issue.py:58
+#: comicsdb/templates/comicsdb/issue_detail.html:280
 msgid "Collection Title"
 msgstr "Titolo della Raccolta"
 
@@ -115,7 +567,182 @@ msgstr "Il campo Titolo della Raccolta non è consentito per questa serie."
 msgid "Arcs cannot be added to Trade Paperbacks."
 msgstr "Gli archi narrativi non possono essere aggiunti ai Trade Paperback."
 
+#: comicsdb/forms/publisher.py:28
+msgid "Currently only US and UK Publishers are supported"
+msgstr "Attualmente sono supportati solo Editori di US e UK"
+
+#: comicsdb/forms/series.py:30
+#: comicsdb/templates/comicsdb/partials/issue_filter.html:122
+#: comicsdb/templates/comicsdb/partials/series_filter.html:113
+#: comicsdb/templates/comicsdb/publisher_list.html:8
+#: comicsdb/views/issue_list_helpers.py:62 comicsdb/views/series_list_helpers.py:20
+#: pull_list/templates/pull_list/pulllist_detail.html:48
+#: reading_lists/templates/reading_lists/partials/readinglist_filter.html:89
+#: reading_lists/views.py:46
+#: user_collection/templates/user_collection/missing_issues_list.html:41
+#: user_collection/templates/user_collection/partials/collection_filter.html:94
+msgid "Publisher"
+msgstr "Editore"
+
+#: comicsdb/forms/series.py:35 comicsdb/templates/comicsdb/imprint_list.html:8
+#: comicsdb/templates/comicsdb/partials/series_filter.html:131
+#: comicsdb/views/series_list_helpers.py:22
+msgid "Imprint"
+msgstr "Etichetta"
+
+#: comicsdb/forms/series.py:42 comicsdb/models/series.py:52
+msgid "Alternative Names"
+msgstr "Nomi Alternativi"
+
+#: comicsdb/forms/series.py:43
+msgid "Separate multiple alternative names by a semicolon"
+msgstr "Separa più nomi alternativi con un punto e virgola"
+
+#: comicsdb/forms/series.py:72
+msgid ""
+"This is <strong>not</strong> the year the series began. If you have a question, "
+"contact the site administrator."
+msgstr ""
+"Questo <strong>non</strong> è l'anno in cui la serie è iniziata. In caso di domande, "
+"contatta l'amministratore del sito."
+
+#: comicsdb/forms/series.py:76
+msgid ""
+"Most of the time it will be the same as the series name, but if the title starts with "
+"an article like 'The' it might be remove so that it is listed with like named series."
+msgstr ""
+"Nella maggior parte dei casi sarà uguale al nome della serie, ma se il titolo inizia "
+"con un articolo come 'The' potrebbe essere rimosso in modo che sia elencato insieme a "
+"serie con nomi simili."
+
+#: comicsdb/forms/series.py:80
+msgid "Leave blank if a One-Shot, Annual, or Ongoing Series."
+msgstr "Lascia vuoto se si tratta di un One-Shot, un Annual o una Serie in corso."
+
+#: comicsdb/forms/series.py:82
+msgid ""
+"Associate the series with another series. For example, an annual with it's primary "
+"series."
+msgstr ""
+"Associa la serie a un'altra serie. Ad esempio, un annual con la sua serie principale."
+
+#: comicsdb/forms/series.py:85
+msgid "Hold down “Control”, or “Command” on a Mac, to select more than one."
+msgstr "Tieni premuto “Control”, o “Command” su Mac, per selezionarne più di uno."
+
+#: comicsdb/forms/series.py:87
+msgid ""
+"Whether a series has a collection title. Normally this only applies to Trade "
+"Paperbacks. For example, the 2015 Deathstroke Trade Paperback which has a collection "
+"title of 'Gods of War'."
+msgstr ""
+"Indica se una serie ha un titolo di raccolta. Normalmente questo si applica solo ai "
+"Trade Paperback. Ad esempio, il Trade Paperback di Deathstroke del 2015 ha un titolo "
+"di raccolta 'Gods of War'."
+
+#: comicsdb/forms/series.py:93 comicsdb/templates/comicsdb/series_detail.html:388
+msgid "Associated Series"
+msgstr "Serie Associate"
+
+#: comicsdb/forms/series.py:93
+msgid "Allow collection title?"
+msgstr "Consenti titolo della raccolta?"
+
+#: comicsdb/forms/series.py:125
+msgid ""
+"Adding a Comic Vine ID  is not allowed for Trade Paperbacks, due to the consolidation "
+"work being done there."
+msgstr ""
+"L'aggiunta di un ID Comic Vine non è consentita per i Trade Paperback, a causa del "
+"lavoro di consolidamento in corso."
+
+#: comicsdb/forms/series.py:141
+msgid "Collections are not allowed to have an associated series."
+msgstr "Le raccolte non possono avere una serie associata."
+
+#: comicsdb/forms/universe.py:29 comicsdb/forms/universe.py:33
+msgid ""
+"Do not use a hyphen to separate text in this field. For example, <i>'Earth 2'</i> "
+"should <b>not</b> be <i>'Earth-2'</i>."
+msgstr ""
+"Non usare un trattino per separare il testo in questo campo. Ad esempio, <i>'Earth "
+"2'</i> <b>non</b> deve essere <i>'Earth-2'</i>."
+
+#: comicsdb/models/announcement.py:7 comicsdb/templates/comicsdb/issue_form.html:34
+#: comicsdb/templates/comicsdb/model_with_attribution_form.html:36
+msgid "Primary"
+msgstr "Primario"
+
+#: comicsdb/models/announcement.py:8
+msgid "Success"
+msgstr "Successo"
+
+#: comicsdb/models/announcement.py:9
+msgid "Link"
+msgstr "Link"
+
+#: comicsdb/models/announcement.py:10
+#: reading_lists/templates/reading_lists/readinglist_confirm_delete.html:15
+#: user_collection/templates/user_collection/collection_confirm_delete.html:15
+#: wish_list/templates/wish_list/wishlist_item_confirm_delete.html:15
+msgid "Warning"
+msgstr "Attenzione"
+
+#: comicsdb/models/announcement.py:11
+msgid "Danger"
+msgstr "Pericolo"
+
+#: comicsdb/models/attribution.py:9
+msgid "Marvel"
+msgstr "Marvel"
+
+#: comicsdb/models/attribution.py:10
+msgid "Wikipedia"
+msgstr "Wikipedia"
+
+#: comicsdb/models/attribution.py:11 comicsdb/templates/comicsdb/arc_detail.html:217
+#: comicsdb/templates/comicsdb/character_detail.html:309
+#: comicsdb/templates/comicsdb/creator_detail.html:256
+#: comicsdb/templates/comicsdb/imprint_detail.html:206
+#: comicsdb/templates/comicsdb/issue_detail.html:682
+#: comicsdb/templates/comicsdb/partials/issue_filter.html:385
+#: comicsdb/templates/comicsdb/publisher_detail.html:320
+#: comicsdb/templates/comicsdb/series_detail.html:362
+#: comicsdb/templates/comicsdb/team_detail.html:276
+#: comicsdb/templates/comicsdb/universe_detail.html:327
+msgid "Grand Comics Database"
+msgstr "Grand Comics Database"
+
+#: comicsdb/models/attribution.py:12
+msgid "DC"
+msgstr "DC"
+
+#: comicsdb/models/common.py:44 reading_lists/forms.py:69
+#: user_collection/templates/user_collection/collection_detail.html:84
+msgid "Description"
+msgstr "Descrizione"
+
+#: comicsdb/models/common.py:45
+#: comicsdb/templates/comicsdb/partials/issue_filter.html:366
+#: comicsdb/views/issue_list_helpers.py:73
+msgid "Comic Vine ID"
+msgstr "ID Comic Vine"
+
+#: comicsdb/models/common.py:46 comicsdb/views/issue_list_helpers.py:74
+msgid "GCD ID"
+msgstr "ID GCD"
+
+#: comicsdb/models/common.py:59
+msgid "Star rating (1-5)"
+msgstr "Valutazione a stelle (1-5)"
+
+#: comicsdb/models/credits.py:31 comicsdb/templates/comicsdb/issue_form.html:35
+#: comicsdb/templates/comicsdb/issue_form.html:97
+msgid "Credits"
+msgstr "Crediti"
+
 #: comicsdb/models/issue.py:60
+#: comicsdb/templates/comicsdb/partials/issue_filter.html:163
 msgid "Alternative Number"
 msgstr "Numero Alternativo"
 
@@ -139,6 +766,7 @@ msgid "Cover Price"
 msgstr "Prezzo di Copertina"
 
 #: comicsdb/models/issue.py:66
+#: comicsdb/templates/comicsdb/partials/issue_filter.html:348
 msgid "Distributor SKU"
 msgstr "SKU del Distributore"
 
@@ -147,6 +775,7 @@ msgid "ISBN"
 msgstr "ISBN"
 
 #: comicsdb/models/issue.py:68
+#: comicsdb/templates/comicsdb/partials/issue_filter.html:330
 msgid "UPC Code"
 msgstr "Codice UPC"
 
@@ -161,6 +790,2619 @@ msgstr "Copertina"
 #: comicsdb/models/issue.py:71
 msgid "Cover Hash"
 msgstr "Hash della Copertina"
+
+#: comicsdb/models/series.py:42
+msgid "Cancelled"
+msgstr "Annullata"
+
+#: comicsdb/models/series.py:43
+msgid "Completed"
+msgstr "Completata"
+
+#: comicsdb/models/series.py:44
+msgid "Hiatus"
+msgstr "In Pausa"
+
+#: comicsdb/models/series.py:45
+msgid "Ongoing"
+msgstr "In Corso"
+
+#: comicsdb/models/series.py:54
+msgid "Volume Number"
+msgstr "Numero Volume"
+
+#: comicsdb/models/series.py:55 comicsdb/views/series_list_helpers.py:24
+msgid "Year Began"
+msgstr "Anno di Inizio"
+
+#: comicsdb/models/series.py:56 comicsdb/views/series_list_helpers.py:27
+msgid "Year Ended"
+msgstr "Anno di Fine"
+
+#: comicsdb/models/series.py:64
+msgid "Allow Collection Title"
+msgstr "Consenti Titolo della Raccolta"
+
+#: comicsdb/models/series.py:67
+msgid ""
+"Whether a series has a collection title. Normally this only applies to Trade "
+"Paperbacks."
+msgstr ""
+"Indica se una serie ha un titolo di raccolta. Normalmente questo si applica solo ai "
+"Trade Paperback."
+
+#: comicsdb/models/series.py:120 comicsdb/templates/comicsdb/imprint_list.html:11
+#: comicsdb/templates/comicsdb/partials/issue_filter.html:57
+#: comicsdb/templates/comicsdb/publisher_list.html:11
+#: comicsdb/templates/comicsdb/series_list.html:11
+#: comicsdb/templates/comicsdb/series_list.html:30
+#: comicsdb/templates/comicsdb/series_list.html:66
+#: comicsdb/templates/comicsdb/statistics.html:32
+#: comicsdb/views/issue_list_helpers.py:59 pull_list/forms.py:20
+#: pull_list/templates/pull_list/pulllist_detail.html:47 reading_lists/forms.py:137
+#: reading_lists/templates/reading_lists/readinglist_detail.html:100
+#: templates/partials/navbar.html:74 user_collection/forms.py:132
+#: user_collection/templates/user_collection/collection_stats.html:226
+#: user_collection/templates/user_collection/missing_issues_list.html:40
+#: users/templates/users/customuser_detail.html:230
+#: wish_list/templates/wish_list/wishlist_detail.html:83
+msgid "Series"
+msgstr "Serie"
+
+#: comicsdb/templates/comicsdb/arc_detail.html:13
+msgid "Story arc navigation"
+msgstr "Navigazione arco narrativo"
+
+#: comicsdb/templates/comicsdb/arc_detail.html:18
+#, python-format
+msgid "Go to %(previous_arc)s"
+msgstr "Vai a %(previous_arc)s"
+
+#: comicsdb/templates/comicsdb/arc_detail.html:20
+#: comicsdb/templates/comicsdb/arc_detail.html:25
+msgid "Previous Arc"
+msgstr "Arco Precedente"
+
+#: comicsdb/templates/comicsdb/arc_detail.html:31
+#, python-format
+msgid "Go to %(next_arc)s"
+msgstr "Vai a %(next_arc)s"
+
+#: comicsdb/templates/comicsdb/arc_detail.html:32
+#: comicsdb/templates/comicsdb/arc_detail.html:37
+msgid "Next Arc"
+msgstr "Arco Successivo"
+
+#: comicsdb/templates/comicsdb/arc_detail.html:47
+#: comicsdb/templates/comicsdb/arc_list.html:13
+msgid "Add a new story arc"
+msgstr "Aggiungi un nuovo arco narrativo"
+
+#: comicsdb/templates/comicsdb/arc_detail.html:49
+#: comicsdb/templates/comicsdb/character_detail.html:50
+#: comicsdb/templates/comicsdb/creator_detail.html:50
+#: comicsdb/templates/comicsdb/imprint_detail.html:56
+#: comicsdb/templates/comicsdb/issue_detail.html:108
+#: comicsdb/templates/comicsdb/issue_list.html:52
+#: comicsdb/templates/comicsdb/partials/list_header.html:64
+#: comicsdb/templates/comicsdb/publisher_detail.html:56
+#: comicsdb/templates/comicsdb/series_detail.html:75
+#: comicsdb/templates/comicsdb/series_list.html:45
+#: comicsdb/templates/comicsdb/team_detail.html:50
+#: comicsdb/templates/comicsdb/universe_detail.html:50
+#: comicsdb/templates/comicsdb/week_list.html:57
+#: reading_lists/templates/reading_lists/add_issue_autocomplete.html:195
+msgid "New"
+msgstr "Nuovo"
+
+#: comicsdb/templates/comicsdb/arc_detail.html:57
+#: comicsdb/templates/comicsdb/character_detail.html:58
+#: comicsdb/templates/comicsdb/creator_detail.html:58
+#: comicsdb/templates/comicsdb/history_list.html:24
+#: comicsdb/templates/comicsdb/imprint_detail.html:64
+#: comicsdb/templates/comicsdb/issue_detail.html:162
+#: comicsdb/templates/comicsdb/publisher_detail.html:64
+#: comicsdb/templates/comicsdb/series_detail.html:83
+#: comicsdb/templates/comicsdb/team_detail.html:58
+#: comicsdb/templates/comicsdb/universe_detail.html:58
+#: user_collection/templates/user_collection/collection_list.html:70
+#: user_collection/templates/user_collection/missing_issues_list.html:45
+msgid "Actions"
+msgstr "Azioni"
+
+#: comicsdb/templates/comicsdb/arc_detail.html:66
+#: comicsdb/templates/comicsdb/character_detail.html:67
+#: comicsdb/templates/comicsdb/creator_detail.html:67
+#: comicsdb/templates/comicsdb/imprint_detail.html:73
+#: comicsdb/templates/comicsdb/issue_detail.html:171
+#: comicsdb/templates/comicsdb/publisher_detail.html:73
+#: comicsdb/templates/comicsdb/series_detail.html:92
+#: comicsdb/templates/comicsdb/team_detail.html:67
+#: comicsdb/templates/comicsdb/universe_detail.html:67
+#: reading_lists/templates/reading_lists/readinglist_detail.html:173
+#: user_collection/templates/user_collection/collection_detail.html:27
+#: user_collection/templates/user_collection/collection_list.html:132
+#: wish_list/templates/wish_list/wishlist_detail.html:123
+msgid "Edit"
+msgstr "Modifica"
+
+#: comicsdb/templates/comicsdb/arc_detail.html:71
+#: comicsdb/templates/comicsdb/character_detail.html:72
+#: comicsdb/templates/comicsdb/creator_detail.html:72
+#: comicsdb/templates/comicsdb/imprint_detail.html:78
+#: comicsdb/templates/comicsdb/issue_detail.html:176
+#: comicsdb/templates/comicsdb/publisher_detail.html:78
+#: comicsdb/templates/comicsdb/series_detail.html:97
+#: comicsdb/templates/comicsdb/team_detail.html:72
+#: comicsdb/templates/comicsdb/universe_detail.html:72
+msgid "History"
+msgstr "Cronologia"
+
+#: comicsdb/templates/comicsdb/arc_detail.html:78
+#: comicsdb/templates/comicsdb/character_detail.html:79
+#: comicsdb/templates/comicsdb/creator_detail.html:79
+#: comicsdb/templates/comicsdb/imprint_detail.html:85
+#: comicsdb/templates/comicsdb/issue_detail.html:183
+#: comicsdb/templates/comicsdb/partials/attribution_formset.html:18
+#: comicsdb/templates/comicsdb/partials/credits_formset.html:18
+#: comicsdb/templates/comicsdb/partials/variants_formset.html:30
+#: comicsdb/templates/comicsdb/publisher_detail.html:85
+#: comicsdb/templates/comicsdb/series_detail.html:104
+#: comicsdb/templates/comicsdb/team_detail.html:79
+#: comicsdb/templates/comicsdb/universe_detail.html:79
+#: polls/templates/polls/poll_confirm_delete.html:20
+#: polls/templates/polls/poll_detail.html:38
+#: reading_lists/templates/reading_lists/readinglist_confirm_delete.html:32
+#: reading_lists/templates/reading_lists/readinglist_detail.html:177
+msgid "Delete"
+msgstr "Elimina"
+
+#: comicsdb/templates/comicsdb/arc_detail.html:112
+#, python-format
+msgid "No image for %(arc.name)s"
+msgstr "Nessuna immagine per %(arc.name)s"
+
+#: comicsdb/templates/comicsdb/arc_detail.html:122
+#: comicsdb/templates/comicsdb/character_detail.html:123
+#: comicsdb/templates/comicsdb/creator_detail.html:123
+#: comicsdb/templates/comicsdb/imprint_detail.html:129
+#: comicsdb/templates/comicsdb/issue_detail.html:299
+#: comicsdb/templates/comicsdb/publisher_detail.html:129
+#: comicsdb/templates/comicsdb/series_detail.html:150
+#: comicsdb/templates/comicsdb/team_detail.html:123
+#: comicsdb/templates/comicsdb/universe_detail.html:123
+msgid "Summary"
+msgstr "Riassunto"
+
+#: comicsdb/templates/comicsdb/arc_detail.html:126
+#: comicsdb/templates/comicsdb/character_detail.html:127
+#: comicsdb/templates/comicsdb/creator_detail.html:127
+#: comicsdb/templates/comicsdb/imprint_detail.html:133
+#: comicsdb/templates/comicsdb/publisher_detail.html:133
+#: comicsdb/templates/comicsdb/series_detail.html:154
+#: comicsdb/templates/comicsdb/team_detail.html:127
+#: comicsdb/templates/comicsdb/universe_detail.html:127
+msgid "No information available."
+msgstr "Nessuna informazione disponibile."
+
+#: comicsdb/templates/comicsdb/arc_detail.html:129
+#: comicsdb/templates/comicsdb/character_detail.html:130
+#: comicsdb/templates/comicsdb/creator_detail.html:130
+#: comicsdb/templates/comicsdb/imprint_detail.html:136
+#: comicsdb/templates/comicsdb/issue_detail.html:306
+#: comicsdb/templates/comicsdb/publisher_detail.html:136
+#: comicsdb/templates/comicsdb/series_detail.html:157
+#: comicsdb/templates/comicsdb/team_detail.html:130
+#: comicsdb/templates/comicsdb/universe_detail.html:130
+#, python-format
+msgid ""
+"Last edited on <time datetime=\"%(modified_time|date:'c')s\">%(modified_time)s</time> "
+"by"
+msgstr ""
+"Ultima modifica il <time datetime=\"%(modified_time|date:'c')s\">%(modified_time)s</"
+"time> di"
+
+#: comicsdb/templates/comicsdb/arc_detail.html:136
+#, python-format
+msgid "Issues (%(issue_count)s)"
+msgstr "Albi (%(issue_count)s)"
+
+#: comicsdb/templates/comicsdb/arc_detail.html:153
+#: comicsdb/templates/comicsdb/partials/arc_issue_items.html:17
+#: reading_lists/templates/reading_lists/partials/readinglist_item_list.html:14
+#: reading_lists/templates/reading_lists/readinglist_detail.html:232
+msgid "Load More Issues"
+msgstr "Carica Altri Albi"
+
+#: comicsdb/templates/comicsdb/arc_detail.html:173
+msgid "Story Arc Details"
+msgstr "Dettagli Arco Narrativo"
+
+#: comicsdb/templates/comicsdb/arc_detail.html:175
+#: comicsdb/templates/comicsdb/character_detail.html:190
+#: comicsdb/templates/comicsdb/creator_detail.html:202
+#: comicsdb/templates/comicsdb/series_detail.html:292
+#: comicsdb/templates/comicsdb/team_detail.html:196
+#: comicsdb/templates/comicsdb/universe_detail.html:297
+msgid "Number of Issues:"
+msgstr "Numero di Albi:"
+
+#: comicsdb/templates/comicsdb/arc_detail.html:183
+#: comicsdb/templates/comicsdb/character_detail.html:275
+#: comicsdb/templates/comicsdb/creator_detail.html:222
+#: comicsdb/templates/comicsdb/imprint_detail.html:172
+#: comicsdb/templates/comicsdb/issue_detail.html:648
+#: comicsdb/templates/comicsdb/publisher_detail.html:286
+#: comicsdb/templates/comicsdb/series_detail.html:328
+#: comicsdb/templates/comicsdb/team_detail.html:242
+#: comicsdb/templates/comicsdb/universe_detail.html:312
+msgid "Identification Numbers"
+msgstr "Numeri di Identificazione"
+
+#: comicsdb/templates/comicsdb/arc_detail.html:185
+#: comicsdb/templates/comicsdb/character_detail.html:277
+#: comicsdb/templates/comicsdb/creator_detail.html:224
+#: comicsdb/templates/comicsdb/imprint_detail.html:174
+#: comicsdb/templates/comicsdb/issue_detail.html:650
+#: comicsdb/templates/comicsdb/publisher_detail.html:288
+#: comicsdb/templates/comicsdb/series_detail.html:330
+#: comicsdb/templates/comicsdb/team_detail.html:244
+#: comicsdb/templates/comicsdb/universe_detail.html:314
+msgid "Metron:"
+msgstr "Metron:"
+
+#: comicsdb/templates/comicsdb/arc_detail.html:191
+#: comicsdb/templates/comicsdb/arc_detail.html:192
+#: comicsdb/templates/comicsdb/character_detail.html:283
+#: comicsdb/templates/comicsdb/character_detail.html:284
+#: comicsdb/templates/comicsdb/creator_detail.html:230
+#: comicsdb/templates/comicsdb/creator_detail.html:231
+#: comicsdb/templates/comicsdb/imprint_detail.html:180
+#: comicsdb/templates/comicsdb/imprint_detail.html:181
+#: comicsdb/templates/comicsdb/issue_detail.html:656
+#: comicsdb/templates/comicsdb/issue_detail.html:657
+#: comicsdb/templates/comicsdb/publisher_detail.html:294
+#: comicsdb/templates/comicsdb/publisher_detail.html:295
+#: comicsdb/templates/comicsdb/series_detail.html:336
+#: comicsdb/templates/comicsdb/series_detail.html:337
+#: comicsdb/templates/comicsdb/team_detail.html:250
+#: comicsdb/templates/comicsdb/team_detail.html:251
+#: comicsdb/templates/comicsdb/universe_detail.html:320
+#: comicsdb/templates/comicsdb/universe_detail.html:321
+msgid "Copy Metron ID"
+msgstr "Copia ID Metron"
+
+#: comicsdb/templates/comicsdb/arc_detail.html:197
+#: comicsdb/templates/comicsdb/character_detail.html:289
+#: comicsdb/templates/comicsdb/creator_detail.html:236
+#: comicsdb/templates/comicsdb/imprint_detail.html:186
+#: comicsdb/templates/comicsdb/issue_detail.html:662
+#: comicsdb/templates/comicsdb/publisher_detail.html:300
+#: comicsdb/templates/comicsdb/series_detail.html:342
+#: comicsdb/templates/comicsdb/team_detail.html:256
+msgid "Comic Vine:"
+msgstr "Comic Vine:"
+
+#: comicsdb/templates/comicsdb/arc_detail.html:209
+#: comicsdb/templates/comicsdb/arc_detail.html:210
+#: comicsdb/templates/comicsdb/character_detail.html:301
+#: comicsdb/templates/comicsdb/character_detail.html:302
+#: comicsdb/templates/comicsdb/creator_detail.html:248
+#: comicsdb/templates/comicsdb/creator_detail.html:249
+#: comicsdb/templates/comicsdb/imprint_detail.html:198
+#: comicsdb/templates/comicsdb/imprint_detail.html:199
+#: comicsdb/templates/comicsdb/issue_detail.html:674
+#: comicsdb/templates/comicsdb/issue_detail.html:675
+#: comicsdb/templates/comicsdb/publisher_detail.html:312
+#: comicsdb/templates/comicsdb/publisher_detail.html:313
+#: comicsdb/templates/comicsdb/series_detail.html:354
+#: comicsdb/templates/comicsdb/series_detail.html:355
+#: comicsdb/templates/comicsdb/team_detail.html:268
+#: comicsdb/templates/comicsdb/team_detail.html:269
+msgid "Copy Comic Vine ID"
+msgstr "Copia ID Comic Vine"
+
+#: comicsdb/templates/comicsdb/arc_detail.html:230
+#: comicsdb/templates/comicsdb/arc_detail.html:231
+#: comicsdb/templates/comicsdb/character_detail.html:322
+#: comicsdb/templates/comicsdb/character_detail.html:323
+#: comicsdb/templates/comicsdb/creator_detail.html:269
+#: comicsdb/templates/comicsdb/creator_detail.html:270
+#: comicsdb/templates/comicsdb/imprint_detail.html:219
+#: comicsdb/templates/comicsdb/imprint_detail.html:220
+#: comicsdb/templates/comicsdb/issue_detail.html:695
+#: comicsdb/templates/comicsdb/issue_detail.html:696
+#: comicsdb/templates/comicsdb/publisher_detail.html:333
+#: comicsdb/templates/comicsdb/publisher_detail.html:334
+#: comicsdb/templates/comicsdb/series_detail.html:375
+#: comicsdb/templates/comicsdb/series_detail.html:376
+#: comicsdb/templates/comicsdb/team_detail.html:289
+#: comicsdb/templates/comicsdb/team_detail.html:290
+#: comicsdb/templates/comicsdb/universe_detail.html:340
+#: comicsdb/templates/comicsdb/universe_detail.html:341
+msgid "Copy GCD ID"
+msgstr "Copia ID GCD"
+
+#: comicsdb/templates/comicsdb/arc_list.html:3
+msgid "Story Arcs - Metron"
+msgstr "Archi Narrativi - Metron"
+
+#: comicsdb/templates/comicsdb/arc_list.html:6
+msgid "Story Arcs List"
+msgstr "Elenco Archi Narrativi"
+
+#: comicsdb/templates/comicsdb/arc_list.html:8
+#: comicsdb/templates/comicsdb/issue_detail.html:632 reading_lists/forms.py:204
+msgid "Story Arc"
+msgstr "Arco Narrativo"
+
+#: comicsdb/templates/comicsdb/arc_list.html:9
+#: comicsdb/templates/comicsdb/issue_detail.html:630
+#: comicsdb/templates/comicsdb/statistics.html:62 templates/partials/navbar.html:106
+msgid "Story Arcs"
+msgstr "Archi Narrativi"
+
+#: comicsdb/templates/comicsdb/arc_list.html:10
+msgid "Find an arc"
+msgstr "Cerca un arco narrativo"
+
+#: comicsdb/templates/comicsdb/arc_list.html:11
+#: comicsdb/templates/comicsdb/character_list.html:11
+#: comicsdb/templates/comicsdb/creator_list.html:11
+#: comicsdb/templates/comicsdb/issue_list.html:73
+#: comicsdb/templates/comicsdb/team_list.html:11
+#: comicsdb/templates/comicsdb/universe_list.html:11
+#: pull_list/templates/pull_list/pulllist_detail.html:91
+#: user_collection/templates/user_collection/collection_list.html:62
+#: user_collection/templates/user_collection/missing_issues_detail.html:79
+#: wish_list/templates/wish_list/wishlist_detail.html:82
+msgid "Issue"
+msgstr "Albo"
+
+#: comicsdb/templates/comicsdb/arc_list.html:12
+#: comicsdb/templates/comicsdb/character_list.html:12
+#: comicsdb/templates/comicsdb/creator_list.html:12
+#: comicsdb/templates/comicsdb/issue_list.html:12
+#: comicsdb/templates/comicsdb/issue_list.html:74
+#: comicsdb/templates/comicsdb/statistics.html:38
+#: comicsdb/templates/comicsdb/team_list.html:12
+#: comicsdb/templates/comicsdb/universe_list.html:12
+#: reading_lists/templates/reading_lists/readinglist_detail.html:84
+#: templates/partials/navbar.html:80
+#: user_collection/templates/user_collection/collection_stats.html:227
+#: users/templates/users/customuser_detail.html:241
+msgid "Issues"
+msgstr "Albi"
+
+#: comicsdb/templates/comicsdb/attribution.html:8
+#: comicsdb/templates/comicsdb/issue_form.html:37
+#: comicsdb/templates/comicsdb/issue_form.html:107
+#: comicsdb/templates/comicsdb/model_with_attribution_form.html:37
+#: comicsdb/templates/comicsdb/model_with_attribution_form.html:51
+#: reading_lists/views.py:48
+msgid "Attribution"
+msgstr "Attribuzione"
+
+#: comicsdb/templates/comicsdb/attribution.html:13
+#, python-format
+msgid ""
+"This article uses material from <a href=\"%(url)s\" target=\"_blank\" rel=\"noopener "
+"noreferrer\">Wikipedia</a>, which is released under the <a href=\"https://"
+"creativecommons.org/licenses/by-sa/3.0/\" target=\"_blank\" rel=\"noopener "
+"noreferrer\">Creative Commons Attribution-Share-Alike License 3.0</a>."
+msgstr ""
+"Questo articolo utilizza materiale tratto da <a href=\"%(url)s\" target=\"_blank\" "
+"rel=\"noopener noreferrer\">Wikipedia</a>, rilasciato sotto la <a href=\"https://"
+"creativecommons.org/licenses/by-sa/3.0/\" target=\"_blank\" rel=\"noopener "
+"noreferrer\">licenza Creative Commons Attribuzione-Condividi allo stesso modo 3.0</a>."
+
+#: comicsdb/templates/comicsdb/attribution.html:17
+#, python-format
+msgid ""
+"Some data provided by <a href=\"%(url)s\" target=\"_blank\" rel=\"noopener "
+"noreferrer\">Marvel</a>."
+msgstr ""
+"Alcuni dati forniti da <a href=\"%(url)s\" target=\"_blank\" rel=\"noopener "
+"noreferrer\">Marvel</a>."
+
+#: comicsdb/templates/comicsdb/attribution.html:22
+#, python-format
+msgid ""
+"This article uses material from the <a href=\"%(url)s\" target=\"_blank\" "
+"rel=\"noopener noreferrer\">Grand Comics Database&#8482;</a>, which is released under "
+"the <a href=\"https://creativecommons.org/licenses/by-sa/4.0/\" target=\"_blank\" "
+"rel=\"noopener noreferrer\">Creative Commons Attribution-ShareAlike 4.0 International "
+"License (CC BY-SA 4.0)</a>."
+msgstr ""
+"Questo articolo utilizza materiale tratto dal <a href=\"%(url)s\" target=\"_blank\" "
+"rel=\"noopener noreferrer\">Grand Comics Database&#8482;</a>, rilasciato sotto la <a "
+"href=\"https://creativecommons.org/licenses/by-sa/4.0/\" target=\"_blank\" "
+"rel=\"noopener noreferrer\">licenza Creative Commons Attribuzione-Condividi allo "
+"stesso modo 4.0 Internazionale (CC BY-SA 4.0)</a>."
+
+#: comicsdb/templates/comicsdb/attribution.html:26
+#, python-format
+msgid ""
+"Some data provided by <a href=\"%(url)s\" target=\"_blank\" rel=\"noopener "
+"noreferrer\">DC</a>."
+msgstr ""
+"Alcuni dati forniti da <a href=\"%(url)s\" target=\"_blank\" rel=\"noopener "
+"noreferrer\">DC</a>."
+
+#: comicsdb/templates/comicsdb/attribution.html:32
+#, python-format
+msgid ""
+"Data provided by <a href=\"%(url)s\" target=\"_blank\" rel=\"noopener "
+"noreferrer\">external source</a>."
+msgstr ""
+"Dati forniti da <a href=\"%(url)s\" target=\"_blank\" rel=\"noopener "
+"noreferrer\">fonte esterna</a>."
+
+#: comicsdb/templates/comicsdb/character_detail.html:14
+msgid "Character navigation"
+msgstr "Navigazione personaggio"
+
+#: comicsdb/templates/comicsdb/character_detail.html:19
+#, python-format
+msgid "Go to %(previous_character)s"
+msgstr "Vai a %(previous_character)s"
+
+#: comicsdb/templates/comicsdb/character_detail.html:21
+#: comicsdb/templates/comicsdb/character_detail.html:26
+msgid "Previous Character"
+msgstr "Personaggio Precedente"
+
+#: comicsdb/templates/comicsdb/character_detail.html:32
+#, python-format
+msgid "Go to %(next_character)s"
+msgstr "Vai a %(next_character)s"
+
+#: comicsdb/templates/comicsdb/character_detail.html:33
+#: comicsdb/templates/comicsdb/character_detail.html:38
+msgid "Next Character"
+msgstr "Personaggio Successivo"
+
+#: comicsdb/templates/comicsdb/character_detail.html:48
+#: comicsdb/templates/comicsdb/character_list.html:13
+msgid "Add a new character"
+msgstr "Aggiungi un nuovo personaggio"
+
+#: comicsdb/templates/comicsdb/character_detail.html:113
+#, python-format
+msgid "No image for %(character.name)s"
+msgstr "Nessuna immagine per %(character.name)s"
+
+#: comicsdb/templates/comicsdb/character_detail.html:137
+#: comicsdb/templates/comicsdb/universe_detail.html:239
+#, python-format
+msgid "Series Appearances (%(series_count)s)"
+msgstr "Apparizioni in Serie (%(series_count)s)"
+
+#: comicsdb/templates/comicsdb/character_detail.html:151
+#: comicsdb/templates/comicsdb/creator_detail.html:151
+#: comicsdb/templates/comicsdb/partials/character_series_items.html:13
+#: comicsdb/templates/comicsdb/partials/creator_series_items.html:13
+#: comicsdb/templates/comicsdb/partials/universe_series_items.html:13
+#: comicsdb/templates/comicsdb/universe_detail.html:253 user_collection/models.py:48
+#: user_collection/templates/user_collection/collection_stats.html:201
+msgid "Digital"
+msgstr "Digitale"
+
+#: comicsdb/templates/comicsdb/character_detail.html:156
+#: comicsdb/templates/comicsdb/creator_detail.html:156
+#: comicsdb/templates/comicsdb/partials/character_series_items.html:18
+#: comicsdb/templates/comicsdb/partials/creator_series_items.html:18
+#: comicsdb/templates/comicsdb/partials/universe_series_items.html:18
+#: comicsdb/templates/comicsdb/series_detail.html:193
+#: comicsdb/templates/comicsdb/series_detail.html:235
+#: comicsdb/templates/comicsdb/universe_detail.html:258
+#: reading_lists/templates/reading_lists/partials/readinglist_card.html:25
+#: reading_lists/templates/reading_lists/readinglist_detail.html:333
+#: reading_lists/templates/reading_lists/readinglist_detail.html:381
+#, python-format
+msgid "%(counter)s issue"
+msgid_plural "%(counter)s issues"
+msgstr[0] "%(counter)s albo"
+msgstr[1] "%(counter)s albi"
+
+#: comicsdb/templates/comicsdb/character_detail.html:168
+#: comicsdb/templates/comicsdb/creator_detail.html:168
+#: comicsdb/templates/comicsdb/partials/character_series_items.html:31
+#: comicsdb/templates/comicsdb/partials/creator_series_items.html:31
+#: comicsdb/templates/comicsdb/partials/universe_series_items.html:31
+#: comicsdb/templates/comicsdb/universe_detail.html:270
+msgid "Load More Series"
+msgstr "Carica Altre Serie"
+
+#: comicsdb/templates/comicsdb/character_detail.html:188
+msgid "Character Details"
+msgstr "Dettagli Personaggio"
+
+#: comicsdb/templates/comicsdb/character_detail.html:196
+#: comicsdb/templates/comicsdb/universe_detail.html:302
+msgid "First Appearance:"
+msgstr "Prima Apparizione:"
+
+#: comicsdb/templates/comicsdb/character_detail.html:205
+#: comicsdb/templates/comicsdb/creator_detail.html:209
+msgid "Aliases:"
+msgstr "Alias:"
+
+#: comicsdb/templates/comicsdb/character_detail.html:207
+#: comicsdb/templates/comicsdb/creator_detail.html:211
+msgid "Alias:"
+msgstr "Alias:"
+
+#: comicsdb/templates/comicsdb/character_detail.html:220
+#: comicsdb/templates/comicsdb/creator_list.html:9
+#: comicsdb/templates/comicsdb/statistics.html:50
+#: comicsdb/templates/comicsdb/team_detail.html:206 templates/partials/navbar.html:87
+#: users/templates/users/customuser_detail.html:263
+msgid "Creators"
+msgstr "Autori"
+
+#: comicsdb/templates/comicsdb/character_detail.html:222
+#: comicsdb/templates/comicsdb/creator_list.html:8
+#: comicsdb/templates/comicsdb/partials/credits_formset.html:16
+#: comicsdb/templates/comicsdb/team_detail.html:208 reading_lists/models.py:62
+#: reading_lists/templates/reading_lists/partials/readinglist_filter.html:71
+#: reading_lists/views.py:45
+msgid "Creator"
+msgstr "Autore"
+
+#: comicsdb/templates/comicsdb/character_detail.html:239
+#: comicsdb/templates/comicsdb/statistics.html:56
+#: comicsdb/templates/comicsdb/team_list.html:9 reading_lists/models.py:66
+#: templates/partials/navbar.html:99 users/templates/users/customuser_detail.html:274
+msgid "Teams"
+msgstr "Squadre"
+
+#: comicsdb/templates/comicsdb/character_detail.html:241
+#: comicsdb/templates/comicsdb/team_list.html:8
+msgid "Team"
+msgstr "Squadra"
+
+#: comicsdb/templates/comicsdb/character_detail.html:258
+#: comicsdb/templates/comicsdb/team_detail.html:225
+#: comicsdb/templates/comicsdb/universe_list.html:9 templates/partials/navbar.html:112
+#: users/templates/users/customuser_detail.html:307
+msgid "Universes"
+msgstr "Universi"
+
+#: comicsdb/templates/comicsdb/character_detail.html:260
+#: comicsdb/templates/comicsdb/team_detail.html:227
+#: comicsdb/templates/comicsdb/universe_list.html:8
+msgid "Universe"
+msgstr "Universo"
+
+#: comicsdb/templates/comicsdb/character_list.html:3
+msgid "Characters - Metron"
+msgstr "Personaggi - Metron"
+
+#: comicsdb/templates/comicsdb/character_list.html:6
+msgid "Characters List"
+msgstr "Elenco Personaggi"
+
+#: comicsdb/templates/comicsdb/character_list.html:8
+msgid "Character"
+msgstr "Personaggio"
+
+#: comicsdb/templates/comicsdb/character_list.html:9
+#: comicsdb/templates/comicsdb/statistics.html:44 reading_lists/models.py:65
+#: templates/partials/navbar.html:93 users/templates/users/customuser_detail.html:252
+msgid "Characters"
+msgstr "Personaggi"
+
+#: comicsdb/templates/comicsdb/character_list.html:10
+msgid "Find a character"
+msgstr "Cerca un personaggio"
+
+#: comicsdb/templates/comicsdb/confirm_delete.html:4
+#: comicsdb/templates/comicsdb/confirm_delete.html:14
+msgid "Confirm Deletion"
+msgstr "Conferma Eliminazione"
+
+#: comicsdb/templates/comicsdb/confirm_delete.html:22
+msgid "Warning: This action cannot be undone"
+msgstr "Attenzione: questa azione non può essere annullata"
+
+#: comicsdb/templates/comicsdb/confirm_delete.html:26
+#, python-format
+msgid "Are you sure you want to permanently delete <strong>\"%(object)s\"</strong>?"
+msgstr "Sei sicuro di voler eliminare definitivamente <strong>\"%(object)s\"</strong>?"
+
+#: comicsdb/templates/comicsdb/confirm_delete.html:28
+msgid "This will remove all associated data and cannot be recovered."
+msgstr "Questo rimuoverà tutti i dati associati e non potrà essere recuperato."
+
+#: comicsdb/templates/comicsdb/confirm_delete.html:39
+msgid "Yes, Delete"
+msgstr "Sì, Elimina"
+
+#: comicsdb/templates/comicsdb/confirm_delete.html:45
+msgid "Cancel and return"
+msgstr "Annulla e torna indietro"
+
+#: comicsdb/templates/comicsdb/confirm_delete.html:49
+#: comicsdb/templates/comicsdb/issue_form.html:25
+#: comicsdb/templates/comicsdb/model_with_attribution_form.html:27
+#: polls/templates/polls/poll_confirm_delete.html:25
+#: pull_list/templates/pull_list/remove_series_confirm.html:27
+#: reading_lists/templates/reading_lists/add_issue_autocomplete.html:42
+#: reading_lists/templates/reading_lists/add_issues_from_arc.html:43
+#: reading_lists/templates/reading_lists/add_issues_from_series.html:76
+#: reading_lists/templates/reading_lists/partials/readinglist_item_edit.html:68
+#: reading_lists/templates/reading_lists/readinglist_confirm_assign_metron.html:29
+#: reading_lists/templates/reading_lists/readinglist_confirm_delete.html:29
+#: reading_lists/templates/reading_lists/readinglist_form.html:114
+#: reading_lists/templates/reading_lists/remove_issue_confirm.html:25
+#: user_collection/templates/user_collection/add_issues_from_series.html:82
+#: user_collection/templates/user_collection/collection_confirm_delete.html:31
+#: user_collection/templates/user_collection/collection_form.html:72
+#: user_collection/templates/user_collection/partials/read_dates_list.html:38
+#: users/templates/users/change_profile.html:120
+#: users/templates/users/delete_account.html:44
+#: wish_list/templates/wish_list/wishlist_acquire_form.html:37
+#: wish_list/templates/wish_list/wishlist_item_confirm_delete.html:26
+#: wish_list/templates/wish_list/wishlist_item_form.html:50
+msgid "Cancel"
+msgstr "Annulla"
+
+#: comicsdb/templates/comicsdb/confirm_delete.html:57
+msgid "Before you delete:"
+msgstr "Prima di eliminare:"
+
+#: comicsdb/templates/comicsdb/confirm_delete.html:59
+msgid "Make sure this is the correct item to delete"
+msgstr "Assicurati che questo sia l'elemento corretto da eliminare"
+
+#: comicsdb/templates/comicsdb/confirm_delete.html:60
+msgid "Consider if other records depend on this data"
+msgstr "Considera se altri record dipendono da questi dati"
+
+#: comicsdb/templates/comicsdb/confirm_delete.html:61
+msgid "This action is permanent and irreversible"
+msgstr "Questa azione è permanente e irreversibile"
+
+#: comicsdb/templates/comicsdb/creator_detail.html:14
+msgid "Creator navigation"
+msgstr "Navigazione autore"
+
+#: comicsdb/templates/comicsdb/creator_detail.html:19
+#, python-format
+msgid "Go to %(previous_creator)s"
+msgstr "Vai a %(previous_creator)s"
+
+#: comicsdb/templates/comicsdb/creator_detail.html:21
+#: comicsdb/templates/comicsdb/creator_detail.html:26
+msgid "Previous Creator"
+msgstr "Autore Precedente"
+
+#: comicsdb/templates/comicsdb/creator_detail.html:32
+#, python-format
+msgid "Go to %(next_creator)s"
+msgstr "Vai a %(next_creator)s"
+
+#: comicsdb/templates/comicsdb/creator_detail.html:33
+#: comicsdb/templates/comicsdb/creator_detail.html:38
+msgid "Next Creator"
+msgstr "Autore Successivo"
+
+#: comicsdb/templates/comicsdb/creator_detail.html:48
+#: comicsdb/templates/comicsdb/creator_list.html:13
+msgid "Add a new creator"
+msgstr "Aggiungi un nuovo autore"
+
+#: comicsdb/templates/comicsdb/creator_detail.html:113
+#, python-format
+msgid "No image for %(creator.name)s"
+msgstr "Nessuna immagine per %(creator.name)s"
+
+#: comicsdb/templates/comicsdb/creator_detail.html:137
+#, python-format
+msgid "Series (%(series_count)s)"
+msgstr "Serie (%(series_count)s)"
+
+#: comicsdb/templates/comicsdb/creator_detail.html:188
+msgid "Creator Details"
+msgstr "Dettagli Autore"
+
+#: comicsdb/templates/comicsdb/creator_detail.html:191
+msgid "Birth:"
+msgstr "Nascita:"
+
+#: comicsdb/templates/comicsdb/creator_detail.html:197
+msgid "Death:"
+msgstr "Morte:"
+
+#: comicsdb/templates/comicsdb/creator_list.html:3
+msgid "Creators - Metron"
+msgstr "Autori - Metron"
+
+#: comicsdb/templates/comicsdb/creator_list.html:6
+msgid "Creators List"
+msgstr "Elenco Autori"
+
+#: comicsdb/templates/comicsdb/creator_list.html:10
+msgid "Find a creator"
+msgstr "Cerca un autore"
+
+#: comicsdb/templates/comicsdb/history_list.html:4
+#, python-format
+msgid "Edit History - %(object)s"
+msgstr "Cronologia Modifiche - %(object)s"
+
+#: comicsdb/templates/comicsdb/history_list.html:9
+msgid "Edit History"
+msgstr "Cronologia Modifiche"
+
+#: comicsdb/templates/comicsdb/history_list.html:21
+msgid "Date"
+msgstr "Data"
+
+#: comicsdb/templates/comicsdb/history_list.html:22
+msgid "User"
+msgstr "Utente"
+
+#: comicsdb/templates/comicsdb/history_list.html:23
+msgid "Change Type"
+msgstr "Tipo di Modifica"
+
+#: comicsdb/templates/comicsdb/history_list.html:37 user_collection/views.py:212
+#: user_collection/views.py:229 user_collection/views.py:243
+msgid "Unknown"
+msgstr "Sconosciuto"
+
+#: comicsdb/templates/comicsdb/history_list.html:42
+#: users/templates/users/api_token.html:86
+msgid "Created"
+msgstr "Creato"
+
+#: comicsdb/templates/comicsdb/history_list.html:44
+msgid "Updated"
+msgstr "Aggiornato"
+
+#: comicsdb/templates/comicsdb/history_list.html:46
+msgid "Deleted"
+msgstr "Eliminato"
+
+#: comicsdb/templates/comicsdb/history_list.html:53
+msgid "View Changes"
+msgstr "Visualizza Modifiche"
+
+#: comicsdb/templates/comicsdb/history_list.html:61
+msgid "Changed Fields:"
+msgstr "Campi Modificati:"
+
+#: comicsdb/templates/comicsdb/history_list.html:83
+#, python-format
+msgid "No edit history available for this %(model_name)s."
+msgstr "Nessuna cronologia modifiche disponibile per %(model_name)s."
+
+#: comicsdb/templates/comicsdb/history_list.html:90
+#, python-format
+msgid "Back to %(model_name)s"
+msgstr "Torna a %(model_name)s"
+
+#: comicsdb/templates/comicsdb/home.html:8
+msgid ""
+"Metron is a community-based comic book database with a public REST API. Search and "
+"discover comic books with comprehensive metadata."
+msgstr ""
+"Metron è un database di fumetti gestito dalla community con un'API REST pubblica. "
+"Cerca e scopri fumetti con metadati completi."
+
+#: comicsdb/templates/comicsdb/home.html:15
+msgid "Metron - Comic Book Database"
+msgstr "Metron - Database di Fumetti"
+
+#: comicsdb/templates/comicsdb/home.html:25
+msgid "Dismiss announcement"
+msgstr "Ignora annuncio"
+
+#: comicsdb/templates/comicsdb/home.html:38 templates/partials/navbar.html:12
+msgid "Metron logo"
+msgstr "Logo Metron"
+
+#: comicsdb/templates/comicsdb/home.html:43
+msgid "Comic Book Database"
+msgstr "Database di Fumetti"
+
+#: comicsdb/templates/comicsdb/home.html:45
+msgid "Built by the community, for the community."
+msgstr "Costruito dalla community, per la community."
+
+#: comicsdb/templates/comicsdb/home.html:50
+msgid "Browse Comics"
+msgstr "Sfoglia i Fumetti"
+
+#: comicsdb/templates/comicsdb/home.html:54 comicsdb/templates/comicsdb/home.html:118
+#: comicsdb/templates/comicsdb/home.html:240
+msgid "Read the Wiki"
+msgstr "Leggi il Wiki"
+
+#: comicsdb/templates/comicsdb/home.html:58
+msgid "Sign Up Free"
+msgstr "Iscriviti Gratis"
+
+#: comicsdb/templates/comicsdb/home.html:70
+msgid "What is Metron?"
+msgstr "Cos'è Metron?"
+
+#: comicsdb/templates/comicsdb/home.html:72
+msgid ""
+"A community-built, open database for comic book metadata — free from corporate "
+"control."
+msgstr ""
+"Un database aperto per i metadati dei fumetti, costruito dalla community — libero dal "
+"controllo aziendale."
+
+#: comicsdb/templates/comicsdb/home.html:78
+msgid ""
+"<strong>Metron</strong> is a community-based site whose goal is to build an open "
+"database with a <a href=\"https://en.wikipedia.org/wiki/"
+"Representational_state_transfer\" target=\"_blank\" rel=\"noopener noreferrer\">REST</"
+"a> API for comic books."
+msgstr ""
+"<strong>Metron</strong> è un sito gestito dalla community il cui obiettivo è "
+"costruire un database aperto con un'API <a href=\"https://en.wikipedia.org/wiki/"
+"Representational_state_transfer\" target=\"_blank\" rel=\"noopener noreferrer\">REST</"
+"a> per i fumetti."
+
+#: comicsdb/templates/comicsdb/home.html:81
+msgid ""
+"Originally, when this project was created, the only comic book database that provided "
+"a REST API for users was <a href=\"https://comicvine.gamespot.com/\" "
+"target=\"_blank\" rel=\"noopener noreferrer\">Comic Vine</a>. Unfortunately, it's a "
+"corporately-owned service and the community that uses it has no control over the "
+"resources provided to maintain it or ensure its continued accessibility. This project "
+"was started to create an alternative."
+msgstr ""
+"Originariamente, quando questo progetto è stato creato, l'unico database di fumetti "
+"che forniva un'API REST agli utenti era <a href=\"https://comicvine.gamespot.com/\" "
+"target=\"_blank\" rel=\"noopener noreferrer\">Comic Vine</a>. Purtroppo, è un "
+"servizio di proprietà aziendale e la community che lo utilizza non ha alcun controllo "
+"sulle risorse fornite per mantenerlo o garantirne l'accessibilità continua. Questo "
+"progetto è nato per creare un'alternativa."
+
+#: comicsdb/templates/comicsdb/home.html:84
+msgid ""
+"<strong>Note:</strong> Recently, the <a href=\"https://www.comics.org/\" "
+"target=\"_blank\" rel=\"noopener noreferrer\">Grand Comics Database</a> created an <a "
+"href=\"https://github.com/GrandComicsDatabase/gcd-django/wiki/API\" target=\"_blank\" "
+"rel=\"noopener noreferrer\">API</a>, which you may wish to explore as an alternative."
+msgstr ""
+"<strong>Nota:</strong> Recentemente, il <a href=\"https://www.comics.org/\" "
+"target=\"_blank\" rel=\"noopener noreferrer\">Grand Comics Database</a> ha creato "
+"un'<a href=\"https://github.com/GrandComicsDatabase/gcd-django/wiki/API\" "
+"target=\"_blank\" rel=\"noopener noreferrer\">API</a>, che potresti voler esplorare "
+"come alternativa."
+
+#: comicsdb/templates/comicsdb/home.html:93
+msgid "What Metron Offers"
+msgstr "Cosa Offre Metron"
+
+#: comicsdb/templates/comicsdb/home.html:95
+msgid "Everything you need to discover, track, and organize your comic collection."
+msgstr ""
+"Tutto ciò di cui hai bisogno per scoprire, tracciare e organizzare la tua collezione "
+"di fumetti."
+
+#: comicsdb/templates/comicsdb/home.html:108
+msgid "REST API"
+msgstr "API REST"
+
+#: comicsdb/templates/comicsdb/home.html:111
+msgid ""
+"Access comic book metadata programmatically. Use the Python wrapper <a href=\"https://"
+"github.com/Metron-Project/mokkari\" target=\"_blank\" rel=\"noopener "
+"noreferrer\">Mokkari</a> to integrate Metron data into your projects with ease."
+msgstr ""
+"Accedi ai metadati dei fumetti in modo programmatico. Usa il wrapper Python <a "
+"href=\"https://github.com/Metron-Project/mokkari\" target=\"_blank\" rel=\"noopener "
+"noreferrer\">Mokkari</a> per integrare facilmente i dati di Metron nei tuoi progetti."
+
+#: comicsdb/templates/comicsdb/home.html:125
+msgid "Software"
+msgstr "Software"
+
+#: comicsdb/templates/comicsdb/home.html:138
+msgid "Collections"
+msgstr "Collezioni"
+
+#: comicsdb/templates/comicsdb/home.html:141
+msgid ""
+"Catalog and organize the comics you own. Track grades, purchase history, reading "
+"status, and personal ratings for your physical or digital library."
+msgstr ""
+"Cataloga e organizza i fumetti che possiedi. Tieni traccia di gradi, cronologia degli "
+"acquisti, stato di lettura e valutazioni personali per la tua libreria fisica o "
+"digitale."
+
+#: comicsdb/templates/comicsdb/home.html:148
+msgid "View Collection"
+msgstr "Visualizza Collezione"
+
+#: comicsdb/templates/comicsdb/home.html:161
+#: reading_lists/templates/reading_lists/readinglist_list.html:3
+#: reading_lists/templates/reading_lists/readinglist_list.html:6
+#: templates/partials/navbar.html:119
+msgid "Reading Lists"
+msgstr "Liste di Lettura"
+
+#: comicsdb/templates/comicsdb/home.html:164
+msgid ""
+"Create custom lists of issues to read, mark your progress, and share your reading "
+"order with others. Perfect for story arcs and event crossovers."
+msgstr ""
+"Crea liste personalizzate di albi da leggere, segna i tuoi progressi e condividi il "
+"tuo ordine di lettura con altri. Perfetto per archi narrativi e crossover di eventi."
+
+#: comicsdb/templates/comicsdb/home.html:171
+msgid "View Reading Lists"
+msgstr "Visualizza Liste di Lettura"
+
+#: comicsdb/templates/comicsdb/home.html:184 wish_list/models.py:23
+#: wish_list/templates/wish_list/partials/wish_list_button.html:11
+msgid "Wish List"
+msgstr "Lista dei Desideri"
+
+#: comicsdb/templates/comicsdb/home.html:187
+msgid ""
+"Keep track of issues you want to acquire. Never lose track of the comics you're "
+"hunting for while shopping or trading with other collectors."
+msgstr ""
+"Tieni traccia degli albi che vuoi acquisire. Non perdere mai di vista i fumetti che "
+"stai cercando mentre fai acquisti o scambi con altri collezionisti."
+
+#: comicsdb/templates/comicsdb/home.html:194
+msgid "View Wish List"
+msgstr "Visualizza Lista dei Desideri"
+
+#: comicsdb/templates/comicsdb/home.html:207 pull_list/models.py:27
+#: pull_list/templates/pull_list/partials/pull_list_button.html:11
+msgid "Pull List"
+msgstr "Pull List"
+
+#: comicsdb/templates/comicsdb/home.html:210
+msgid ""
+"Follow the series you love. Add ongoing titles to your pull list and get a "
+"consolidated view of everything you're currently collecting — so you never miss a new "
+"release."
+msgstr ""
+"Segui le serie che ami. Aggiungi titoli in corso alla tua pull list e ottieni una "
+"visione consolidata di tutto ciò che stai attualmente collezionando — così non ti "
+"perderai mai una nuova uscita."
+
+#: comicsdb/templates/comicsdb/home.html:217
+msgid "View Pull List"
+msgstr "Visualizza Pull List"
+
+#: comicsdb/templates/comicsdb/home.html:230
+msgid "Quick Scrobble"
+msgstr "Scrobble Rapido"
+
+#: comicsdb/templates/comicsdb/home.html:233
+msgid ""
+"Mark issues as read instantly via the API — great for comic servers and automation. "
+"Manage reading history programmatically at <code>/api/collection/</code>."
+msgstr ""
+"Segna gli albi come letti istantaneamente tramite l'API — ideale per server di "
+"fumetti e automazione. Gestisci la cronologia di lettura in modo programmatico su "
+"<code>/api/collection/</code>."
+
+#: comicsdb/templates/comicsdb/home.html:252
+msgid "Interactive Timeline"
+msgstr "Cronologia Interattiva"
+
+#: comicsdb/templates/comicsdb/home.html:261
+msgid ""
+"Discover the history of our community, and learn about the events that made our "
+"community what it is today."
+msgstr ""
+"Scopri la storia della nostra community e conosci gli eventi che l'hanno resa quello "
+"che è oggi."
+
+#: comicsdb/templates/comicsdb/home.html:265
+msgid "Check it out!"
+msgstr "Dai un'occhiata!"
+
+#: comicsdb/templates/comicsdb/home.html:276
+msgid "Get Involved"
+msgstr "Partecipa"
+
+#: comicsdb/templates/comicsdb/home.html:278
+msgid "Metron is a community project — everyone is welcome to contribute."
+msgstr "Metron è un progetto della community — tutti sono i benvenuti a contribuire."
+
+#: comicsdb/templates/comicsdb/home.html:289
+msgid "Add Comic Data"
+msgstr "Aggiungi Dati sui Fumetti"
+
+#: comicsdb/templates/comicsdb/home.html:293
+#, python-format
+msgid ""
+"Sign up for an account and help grow the database. Read the <a "
+"href=\"%(wiki_root_url)s\">Wiki</a> to learn the contribution guidelines before "
+"getting started."
+msgstr ""
+"Registra un account e aiuta a far crescere il database. Leggi il <a "
+"href=\"%(wiki_root_url)s\">Wiki</a> per conoscere le linee guida per contribuire "
+"prima di iniziare."
+
+#: comicsdb/templates/comicsdb/home.html:300 users/templates/registration/signup.html:69
+msgid "Create Account"
+msgstr "Crea Account"
+
+#: comicsdb/templates/comicsdb/home.html:311
+msgid "Contribute Code"
+msgstr "Contribuisci al Codice"
+
+#: comicsdb/templates/comicsdb/home.html:314
+msgid ""
+"Metron is built with <a href=\"https://www.djangoproject.com/\" target=\"_blank\" "
+"rel=\"noopener noreferrer\">Django</a>. Check out the source on <a href=\"https://"
+"github.com/Metron-Project/metron\" target=\"_blank\" rel=\"noopener "
+"noreferrer\">GitHub</a> and help improve the platform."
+msgstr ""
+"Metron è costruito con <a href=\"https://www.djangoproject.com/\" target=\"_blank\" "
+"rel=\"noopener noreferrer\">Django</a>. Consulta il codice sorgente su <a "
+"href=\"https://github.com/Metron-Project/metron\" target=\"_blank\" rel=\"noopener "
+"noreferrer\">GitHub</a> e aiuta a migliorare la piattaforma."
+
+#: comicsdb/templates/comicsdb/home.html:324
+msgid "View on GitHub"
+msgstr "Visualizza su GitHub"
+
+#: comicsdb/templates/comicsdb/home.html:335
+msgid "Support the Project"
+msgstr "Sostieni il Progetto"
+
+#: comicsdb/templates/comicsdb/home.html:338
+msgid ""
+"Help cover server and development costs by donating through <a href=\"https://"
+"opencollective.com/metron\" target=\"_blank\" rel=\"noopener "
+"noreferrer\">OpenCollective</a>. Every contribution helps keep Metron running."
+msgstr ""
+"Aiuta a coprire i costi del server e dello sviluppo donando tramite <a href=\"https://"
+"opencollective.com/metron\" target=\"_blank\" rel=\"noopener "
+"noreferrer\">OpenCollective</a>. Ogni contributo aiuta a mantenere Metron attivo."
+
+#: comicsdb/templates/comicsdb/home.html:348
+msgid "Donate"
+msgstr "Dona"
+
+#: comicsdb/templates/comicsdb/home.html:356
+msgid "Have Questions?"
+msgstr "Hai Domande?"
+
+#: comicsdb/templates/comicsdb/home.html:360
+msgid "Feel free to reach out through any of these channels:"
+msgstr "Sentiti libero di contattarci attraverso uno di questi canali:"
+
+#: comicsdb/templates/comicsdb/home.html:370 templates/partials/footer.html:32
+msgid "Matrix Chat"
+msgstr "Chat Matrix"
+
+#: comicsdb/templates/comicsdb/home.html:381 templates/partials/footer.html:44
+#: users/templates/registration/account_activation_sent.html:73
+msgid "GitHub Discussions"
+msgstr "Discussioni GitHub"
+
+#: comicsdb/templates/comicsdb/home.html:389
+msgid "Email Admin"
+msgstr "Email all'Amministratore"
+
+#: comicsdb/templates/comicsdb/imprint_detail.html:14
+msgid "Imprint navigation"
+msgstr "Navigazione etichetta"
+
+#: comicsdb/templates/comicsdb/imprint_detail.html:19
+#, python-format
+msgid "Go to %(previous_imprint)s"
+msgstr "Vai a %(previous_imprint)s"
+
+#: comicsdb/templates/comicsdb/imprint_detail.html:21
+#: comicsdb/templates/comicsdb/imprint_detail.html:26
+msgid "Previous Imprint"
+msgstr "Etichetta Precedente"
+
+#: comicsdb/templates/comicsdb/imprint_detail.html:32
+#, python-format
+msgid "Go to %(next_imprint)s"
+msgstr "Vai a %(next_imprint)s"
+
+#: comicsdb/templates/comicsdb/imprint_detail.html:33
+#: comicsdb/templates/comicsdb/imprint_detail.html:38
+msgid "Next Imprint"
+msgstr "Etichetta Successiva"
+
+#: comicsdb/templates/comicsdb/imprint_detail.html:47
+msgid "View series list for this imprint"
+msgstr "Visualizza elenco serie per questa etichetta"
+
+#: comicsdb/templates/comicsdb/imprint_detail.html:49
+#: comicsdb/templates/comicsdb/publisher_detail.html:49
+msgid "Series List"
+msgstr "Elenco Serie"
+
+#: comicsdb/templates/comicsdb/imprint_detail.html:54
+#: comicsdb/templates/comicsdb/imprint_list.html:12
+msgid "Add a new imprint"
+msgstr "Aggiungi una nuova etichetta"
+
+#: comicsdb/templates/comicsdb/imprint_detail.html:119
+#: comicsdb/templates/comicsdb/partials/publisher_imprint_items.html:21
+#: comicsdb/templates/comicsdb/publisher_detail.html:162
+#, python-format
+msgid "No image for %(imprint.name)s"
+msgstr "Nessuna immagine per %(imprint.name)s"
+
+#: comicsdb/templates/comicsdb/imprint_detail.html:150
+msgid "Imprint Details"
+msgstr "Dettagli Etichetta"
+
+#: comicsdb/templates/comicsdb/imprint_detail.html:152
+#: comicsdb/templates/comicsdb/series_detail.html:257
+#: comicsdb/templates/comicsdb/universe_detail.html:292
+#: user_collection/templates/user_collection/collection_detail.html:71
+#: user_collection/templates/user_collection/missing_issues_detail.html:35
+msgid "Publisher:"
+msgstr "Editore:"
+
+#: comicsdb/templates/comicsdb/imprint_detail.html:157
+#: comicsdb/templates/comicsdb/publisher_detail.html:267
+msgid "Founded:"
+msgstr "Fondata:"
+
+#: comicsdb/templates/comicsdb/imprint_detail.html:163
+#: comicsdb/templates/comicsdb/publisher_detail.html:277
+msgid "Number of Series:"
+msgstr "Numero di Serie:"
+
+#: comicsdb/templates/comicsdb/imprint_list.html:3
+msgid "Imprints - Metron"
+msgstr "Etichette - Metron"
+
+#: comicsdb/templates/comicsdb/imprint_list.html:6
+msgid "Imprints List"
+msgstr "Elenco Etichette"
+
+#: comicsdb/templates/comicsdb/imprint_list.html:9 templates/partials/navbar.html:68
+#: users/templates/users/customuser_detail.html:285
+msgid "Imprints"
+msgstr "Etichette"
+
+#: comicsdb/templates/comicsdb/imprint_list.html:10
+msgid "Find an imprint"
+msgstr "Cerca un'etichetta"
+
+#: comicsdb/templates/comicsdb/issue_detail.html:6
+#, python-format
+msgid "%(issue)s Information"
+msgstr "Informazioni su %(issue)s"
+
+#: comicsdb/templates/comicsdb/issue_detail.html:38 templates/registration/login.html:26
+#: templates/registration/password_reset_confirm.html:26
+#: user_collection/templates/user_collection/partials/read_dates_list.html:22
+#: users/templates/registration/password_change_form.html:26
+#: users/templates/registration/signup.html:30
+#: users/templates/users/change_profile.html:26
+#: users/templates/users/customuser_detail.html:486
+msgid "close"
+msgstr "chiudi"
+
+#: comicsdb/templates/comicsdb/issue_detail.html:52
+#, python-format
+msgid "Issue #%(issue_number)s"
+msgstr "Albo #%(issue_number)s"
+
+#: comicsdb/templates/comicsdb/issue_detail.html:71
+msgid "Issue navigation"
+msgstr "Navigazione albo"
+
+#: comicsdb/templates/comicsdb/issue_detail.html:76
+#, python-format
+msgid "Go to %(previous_issue)s"
+msgstr "Vai a %(previous_issue)s"
+
+#: comicsdb/templates/comicsdb/issue_detail.html:78
+#: comicsdb/templates/comicsdb/issue_detail.html:83
+msgid "Previous Issue"
+msgstr "Albo Precedente"
+
+#: comicsdb/templates/comicsdb/issue_detail.html:89
+#, python-format
+msgid "Go to %(next_issue)s"
+msgstr "Vai a %(next_issue)s"
+
+#: comicsdb/templates/comicsdb/issue_detail.html:90
+#: comicsdb/templates/comicsdb/issue_detail.html:95
+msgid "Next Issue"
+msgstr "Albo Successivo"
+
+#: comicsdb/templates/comicsdb/issue_detail.html:106
+#: comicsdb/templates/comicsdb/issue_list.html:47
+#: comicsdb/templates/comicsdb/issue_list.html:48
+#: comicsdb/templates/comicsdb/issue_list.html:75
+#: comicsdb/templates/comicsdb/week_list.html:52
+#: comicsdb/templates/comicsdb/week_list.html:53
+#: comicsdb/templates/comicsdb/week_list.html:93
+#: comicsdb/templates/comicsdb/week_list.html:94
+msgid "Add a new issue"
+msgstr "Aggiungi un nuovo albo"
+
+#: comicsdb/templates/comicsdb/issue_detail.html:118
+msgid "Duplicate credits from previous issue"
+msgstr "Duplica crediti dall'albo precedente"
+
+#: comicsdb/templates/comicsdb/issue_detail.html:120
+#: comicsdb/templates/comicsdb/issue_detail.html:129
+msgid "Duplicate Credits"
+msgstr "Duplica Crediti"
+
+#: comicsdb/templates/comicsdb/issue_detail.html:127
+msgid "No previous issue or credits already exist"
+msgstr "Nessun albo precedente o i crediti esistono già"
+
+#: comicsdb/templates/comicsdb/issue_detail.html:141
+msgid "Sync resources from reprints"
+msgstr "Sincronizza risorse dalle ristampe"
+
+#: comicsdb/templates/comicsdb/issue_detail.html:143
+#: comicsdb/templates/comicsdb/issue_detail.html:152
+msgid "Sync"
+msgstr "Sincronizza"
+
+#: comicsdb/templates/comicsdb/issue_detail.html:150
+msgid "No sync available"
+msgstr "Nessuna sincronizzazione disponibile"
+
+#: comicsdb/templates/comicsdb/issue_detail.html:210
+msgid "View larger cover image"
+msgstr "Visualizza immagine di copertina più grande"
+
+#: comicsdb/templates/comicsdb/issue_detail.html:221
+msgid "Main Cover"
+msgstr "Copertina Principale"
+
+#: comicsdb/templates/comicsdb/issue_detail.html:223
+msgid "Click to enlarge"
+msgstr "Clicca per ingrandire"
+
+#: comicsdb/templates/comicsdb/issue_detail.html:228
+#: reading_lists/templates/reading_lists/partials/readinglist_item.html:22
+#: reading_lists/templates/reading_lists/partials/readinglist_item_edit.html:22
+#, python-format
+msgid "No image for %(issue)s"
+msgstr "Nessuna immagine per %(issue)s"
+
+#: comicsdb/templates/comicsdb/issue_detail.html:251
+#, python-format
+msgid "No image for %(variant.name)s"
+msgstr "Nessuna immagine per %(variant.name)s"
+
+#: comicsdb/templates/comicsdb/issue_detail.html:261
+#, python-format
+msgid "Price: %(price)s"
+msgstr "Prezzo: %(price)s"
+
+#: comicsdb/templates/comicsdb/issue_detail.html:263
+#, python-format
+msgid "SKU: %(sku)s"
+msgstr "SKU: %(sku)s"
+
+#: comicsdb/templates/comicsdb/issue_detail.html:265
+#, python-format
+msgid "UPC: %(upc)s"
+msgstr "UPC: %(upc)s"
+
+#: comicsdb/templates/comicsdb/issue_detail.html:288
+msgid "Story Titles"
+msgstr "Titoli delle Storie"
+
+#: comicsdb/templates/comicsdb/issue_detail.html:303
+msgid "No summary available."
+msgstr "Nessun riassunto disponibile."
+
+#: comicsdb/templates/comicsdb/issue_detail.html:313
+#, python-format
+msgid "Credit (%(counter)s)"
+msgid_plural "Credits (%(counter)s)"
+msgstr[0] "Credito (%(counter)s)"
+msgstr[1] "Crediti (%(counter)s)"
+
+#: comicsdb/templates/comicsdb/issue_detail.html:332
+#: comicsdb/templates/comicsdb/partials/issue_credit_items.html:20
+#, python-format
+msgid "No image for %(credit.creator)s"
+msgstr "Nessuna immagine per %(credit.creator)s"
+
+#: comicsdb/templates/comicsdb/issue_detail.html:361
+#: comicsdb/templates/comicsdb/partials/issue_credit_items.html:50
+msgid "Load More Credits"
+msgstr "Carica Altri Crediti"
+
+#: comicsdb/templates/comicsdb/issue_detail.html:373
+#: comicsdb/templates/comicsdb/universe_detail.html:137
+#, python-format
+msgid "Character (%(counter)s)"
+msgid_plural "Characters (%(counter)s)"
+msgstr[0] "Personaggio (%(counter)s)"
+msgstr[1] "Personaggi (%(counter)s)"
+
+#: comicsdb/templates/comicsdb/issue_detail.html:392
+#: comicsdb/templates/comicsdb/partials/issue_character_items.html:20
+#: comicsdb/templates/comicsdb/partials/team_member_items.html:20
+#: comicsdb/templates/comicsdb/partials/universe_character_items.html:20
+#: comicsdb/templates/comicsdb/team_detail.html:156
+#: comicsdb/templates/comicsdb/universe_detail.html:156
+#, python-format
+msgid "No image for %(character)s"
+msgstr "Nessuna immagine per %(character)s"
+
+#: comicsdb/templates/comicsdb/issue_detail.html:411
+#: comicsdb/templates/comicsdb/partials/issue_character_items.html:40
+#: comicsdb/templates/comicsdb/partials/universe_character_items.html:40
+#: comicsdb/templates/comicsdb/universe_detail.html:176
+msgid "Load More Characters"
+msgstr "Carica Altri Personaggi"
+
+#: comicsdb/templates/comicsdb/issue_detail.html:423
+#: comicsdb/templates/comicsdb/universe_detail.html:188
+#, python-format
+msgid "Team (%(counter)s)"
+msgid_plural "Teams (%(counter)s)"
+msgstr[0] "Squadra (%(counter)s)"
+msgstr[1] "Squadre (%(counter)s)"
+
+#: comicsdb/templates/comicsdb/issue_detail.html:442
+#: comicsdb/templates/comicsdb/partials/issue_team_items.html:20
+#: comicsdb/templates/comicsdb/partials/universe_team_items.html:20
+#: comicsdb/templates/comicsdb/universe_detail.html:207
+#, python-format
+msgid "No image for %(team)s"
+msgstr "Nessuna immagine per %(team)s"
+
+#: comicsdb/templates/comicsdb/issue_detail.html:461
+#: comicsdb/templates/comicsdb/partials/issue_team_items.html:40
+#: comicsdb/templates/comicsdb/partials/universe_team_items.html:40
+#: comicsdb/templates/comicsdb/universe_detail.html:227
+msgid "Load More Teams"
+msgstr "Carica Altre Squadre"
+
+#: comicsdb/templates/comicsdb/issue_detail.html:473
+#: comicsdb/templates/comicsdb/publisher_detail.html:200
+#, python-format
+msgid "Universe (%(counter)s)"
+msgid_plural "Universes (%(counter)s)"
+msgstr[0] "Universo (%(counter)s)"
+msgstr[1] "Universi (%(counter)s)"
+
+#: comicsdb/templates/comicsdb/issue_detail.html:492
+#: comicsdb/templates/comicsdb/partials/issue_universe_items.html:20
+#, python-format
+msgid "No image for %(universe)s"
+msgstr "Nessuna immagine per %(universe)s"
+
+#: comicsdb/templates/comicsdb/issue_detail.html:511
+#: comicsdb/templates/comicsdb/partials/issue_universe_items.html:40
+#: comicsdb/templates/comicsdb/partials/publisher_universe_items.html:47
+#: comicsdb/templates/comicsdb/publisher_detail.html:245
+msgid "Load More Universes"
+msgstr "Carica Altri Universi"
+
+#: comicsdb/templates/comicsdb/issue_detail.html:524
+#, python-format
+msgid "Reprint (%(counter)s)"
+msgid_plural "Reprints (%(counter)s)"
+msgstr[0] "Ristampa (%(counter)s)"
+msgstr[1] "Ristampe (%(counter)s)"
+
+#: comicsdb/templates/comicsdb/issue_detail.html:530
+msgid "from"
+msgstr "da"
+
+#: comicsdb/templates/comicsdb/issue_detail.html:532
+msgid "in"
+msgstr "in"
+
+#: comicsdb/templates/comicsdb/issue_detail.html:553
+msgid "Issue Details"
+msgstr "Dettagli Albo"
+
+#: comicsdb/templates/comicsdb/issue_detail.html:555
+#: user_collection/templates/user_collection/collection_detail.html:67
+msgid "Series:"
+msgstr "Serie:"
+
+#: comicsdb/templates/comicsdb/issue_detail.html:559
+msgid "Number:"
+msgstr "Numero:"
+
+#: comicsdb/templates/comicsdb/issue_detail.html:564
+msgid "Alternative Number:"
+msgstr "Numero Alternativo:"
+
+#: comicsdb/templates/comicsdb/issue_detail.html:569
+#: user_collection/templates/user_collection/collection_detail.html:75
+msgid "Cover Date:"
+msgstr "Data di Copertina:"
+
+#: comicsdb/templates/comicsdb/issue_detail.html:574
+msgid "In Store Date:"
+msgstr "Data di Uscita:"
+
+#: comicsdb/templates/comicsdb/issue_detail.html:581
+msgid "Final Order Cutoff"
+msgstr "Scadenza Ordine Finale"
+
+#: comicsdb/templates/comicsdb/issue_detail.html:581
+msgid "Date:"
+msgstr "Data:"
+
+#: comicsdb/templates/comicsdb/issue_detail.html:591
+msgid "Cover Price:"
+msgstr "Prezzo di Copertina:"
+
+#: comicsdb/templates/comicsdb/issue_detail.html:597
+msgid "Page Count:"
+msgstr "Numero di Pagine:"
+
+#: comicsdb/templates/comicsdb/issue_detail.html:602
+#: user_collection/templates/user_collection/collection_detail.html:177
+msgid "Rating:"
+msgstr "Valutazione:"
+
+#: comicsdb/templates/comicsdb/issue_detail.html:607
+msgid "Distributor SKU:"
+msgstr "SKU Distributore:"
+
+#: comicsdb/templates/comicsdb/issue_detail.html:613
+msgid "ISBN:"
+msgstr "ISBN:"
+
+#: comicsdb/templates/comicsdb/issue_detail.html:619
+msgid "UPC:"
+msgstr "UPC:"
+
+#: comicsdb/templates/comicsdb/issue_form.html:5
+#: comicsdb/templates/comicsdb/issue_form.html:21
+msgid "Issue Form"
+msgstr "Modulo Albo"
+
+#: comicsdb/templates/comicsdb/issue_form.html:29
+msgid "Save Issue"
+msgstr "Salva Albo"
+
+#: comicsdb/templates/comicsdb/issue_form.html:33
+#: comicsdb/templates/comicsdb/model_with_attribution_form.html:35
+msgid "Form sections"
+msgstr "Sezioni del modulo"
+
+#: comicsdb/templates/comicsdb/issue_form.html:36
+msgid "Variants"
+msgstr "Varianti"
+
+#: comicsdb/templates/comicsdb/issue_form.html:42
+#: comicsdb/templates/comicsdb/model_with_attribution_form.html:42
+msgid "Primary Information"
+msgstr "Informazioni Principali"
+
+#: comicsdb/templates/comicsdb/issue_form.html:47
+msgid "Identity"
+msgstr "Identità"
+
+#: comicsdb/templates/comicsdb/issue_form.html:60
+msgid "Publication"
+msgstr "Pubblicazione"
+
+#: comicsdb/templates/comicsdb/issue_form.html:71
+#: comicsdb/templates/comicsdb/partials/issue_filter.html:325
+msgid "Codes & IDs"
+msgstr "Codici & ID"
+
+#: comicsdb/templates/comicsdb/issue_form.html:82
+msgid "Cover Image"
+msgstr "Immagine di Copertina"
+
+#: comicsdb/templates/comicsdb/issue_form.html:87
+msgid "Relationships"
+msgstr "Relazioni"
+
+#: comicsdb/templates/comicsdb/issue_form.html:102
+msgid "Variant Covers"
+msgstr "Copertine Varianti"
+
+#: comicsdb/templates/comicsdb/issue_list.html:6
+msgid "Issues - Metron"
+msgstr "Albi - Metron"
+
+#: comicsdb/templates/comicsdb/issue_list.html:27
+msgid "Issue list navigation"
+msgstr "Navigazione elenco albi"
+
+#: comicsdb/templates/comicsdb/issue_list.html:32
+#: comicsdb/templates/comicsdb/issue_list.html:34
+#, python-format
+msgid "<strong>%(counter_fmt)s</strong> Issue"
+msgid_plural "<strong>%(counter_fmt)s</strong> Issues"
+msgstr[0] "<strong>%(counter_fmt)s</strong> Albo"
+msgstr[1] "<strong>%(counter_fmt)s</strong> Albi"
+
+#: comicsdb/templates/comicsdb/issue_list.html:66
+#: comicsdb/templates/comicsdb/series_list.html:59
+#: comicsdb/templates/comicsdb/week_list.html:71
+#: reading_lists/templates/reading_lists/readinglist_list.html:72
+#: user_collection/templates/user_collection/collection_list.html:157
+msgid "No results found"
+msgstr "Nessun risultato trovato"
+
+#: comicsdb/templates/comicsdb/issue_list.html:67
+#: comicsdb/templates/comicsdb/series_list.html:60
+#: comicsdb/templates/comicsdb/week_list.html:72
+#: reading_lists/templates/reading_lists/readinglist_list.html:73
+#: user_collection/templates/user_collection/collection_list.html:158
+msgid "Try adjusting your search filters"
+msgstr "Prova a modificare i filtri di ricerca"
+
+#: comicsdb/templates/comicsdb/issue_list.html:70
+#: comicsdb/templates/comicsdb/series_list.html:63
+#: comicsdb/templates/comicsdb/week_list.html:75
+#: reading_lists/templates/reading_lists/readinglist_list.html:76
+#: user_collection/templates/user_collection/collection_list.html:162
+msgid "Clear All Filters"
+msgstr "Cancella Tutti i Filtri"
+
+#: comicsdb/templates/comicsdb/model_with_attribution_form.html:5
+#: comicsdb/templates/comicsdb/model_with_attribution_form.html:17
+msgid "Form"
+msgstr "Modulo"
+
+#: comicsdb/templates/comicsdb/model_with_attribution_form.html:31
+#: reading_lists/templates/reading_lists/partials/readinglist_item_edit.html:58
+msgid "Save"
+msgstr "Salva"
+
+#: comicsdb/templates/comicsdb/partials/active_filters.html:13
+msgid "Active filters:"
+msgstr "Filtri attivi:"
+
+#: comicsdb/templates/comicsdb/partials/active_filters.html:23
+#: comicsdb/templates/comicsdb/partials/active_filters.html:24
+#, python-format
+msgid "Remove %(chip_label)s filter"
+msgstr "Rimuovi filtro %(chip_label)s"
+
+#: comicsdb/templates/comicsdb/partials/active_filters.html:29
+msgid "Clear all"
+msgstr "Cancella tutto"
+
+#: comicsdb/templates/comicsdb/partials/attribution_formset.html:16
+#: reading_lists/forms.py:72
+msgid "Source"
+msgstr "Fonte"
+
+#: comicsdb/templates/comicsdb/partials/attribution_formset.html:17
+msgid "URL"
+msgstr "URL"
+
+#: comicsdb/templates/comicsdb/partials/attribution_formset.html:65
+#: comicsdb/templates/comicsdb/partials/credits_formset.html:63
+#: comicsdb/templates/comicsdb/partials/variants_formset.html:77
+msgid "Mark for deletion"
+msgstr "Contrassegna per l'eliminazione"
+
+#: comicsdb/templates/comicsdb/partials/attribution_formset.html:75
+#: comicsdb/templates/comicsdb/partials/attribution_formset_row.html:41
+#: comicsdb/templates/comicsdb/partials/credits_formset.html:73
+#: comicsdb/templates/comicsdb/partials/credits_formset_row.html:39
+#: comicsdb/templates/comicsdb/partials/variants_formset.html:87
+#: comicsdb/templates/comicsdb/partials/variants_formset_row.html:41
+msgid "Remove this row"
+msgstr "Rimuovi questa riga"
+
+#: comicsdb/templates/comicsdb/partials/attribution_formset.html:96
+msgid "Add another attribution"
+msgstr "Aggiungi un'altra attribuzione"
+
+#: comicsdb/templates/comicsdb/partials/card_grid.html:34
+#, python-format
+msgid "View details for %(item)s"
+msgstr "Visualizza dettagli per %(item)s"
+
+#: comicsdb/templates/comicsdb/partials/card_grid.html:57
+#, python-format
+msgid "No image available for %(item.name)s"
+msgstr "Nessuna immagine disponibile per %(item.name)s"
+
+#: comicsdb/templates/comicsdb/partials/card_grid_count.html:12
+#: comicsdb/templates/comicsdb/partials/card_grid_count.html:20
+#, python-format
+msgid "%(c)s %(label)s for %(item)s"
+msgstr "%(c)s %(label)s per %(item)s"
+
+#: comicsdb/templates/comicsdb/partials/card_grid_count.html:26
+#, python-format
+msgid "No %(count_label_plural)s"
+msgstr "Nessun %(count_label_plural)s"
+
+#: comicsdb/templates/comicsdb/partials/card_grid_count.html:26
+#, python-format
+msgid "0 %(count_label_plural)s"
+msgstr "0 %(count_label_plural)s"
+
+#: comicsdb/templates/comicsdb/partials/credits_formset.html:17
+msgid "Role"
+msgstr "Ruolo"
+
+#: comicsdb/templates/comicsdb/partials/credits_formset.html:94
+msgid "Add another creator credit"
+msgstr "Aggiungi un altro credito autore"
+
+#: comicsdb/templates/comicsdb/partials/empty_state.html:19
+#, python-format
+msgid "No %(item_type_plural)s Available"
+msgstr "Nessun %(item_type_plural)s Disponibile"
+
+#: comicsdb/templates/comicsdb/partials/empty_state.html:22
+#, python-format
+msgid "Get started by creating your first %(item_type_lower)s."
+msgstr "Inizia creando il tuo primo %(item_type_lower)s."
+
+#: comicsdb/templates/comicsdb/partials/empty_state.html:24
+#, python-format
+msgid "No %(item_type_plural)s have been added yet."
+msgstr "Non è ancora stato aggiunto nessun %(item_type_plural)s."
+
+#: comicsdb/templates/comicsdb/partials/empty_state.html:35
+#, python-format
+msgid "Create %(item_type)s"
+msgstr "Crea %(item_type)s"
+
+#: comicsdb/templates/comicsdb/partials/issue_card_grid.html:24
+#: comicsdb/views/issue_list_helpers.py:35
+msgid "Recently added"
+msgstr "Aggiunto di recente"
+
+#: comicsdb/templates/comicsdb/partials/issue_card_grid.html:24
+msgid "New!"
+msgstr "Nuovo!"
+
+#: comicsdb/templates/comicsdb/partials/issue_card_grid.html:34
+#: comicsdb/templates/comicsdb/partials/issue_card_grid.html:46
+#, python-format
+msgid "View details for %(issue)s"
+msgstr "Visualizza dettagli per %(issue)s"
+
+#: comicsdb/templates/comicsdb/partials/issue_card_grid.html:48
+#, python-format
+msgid "No image available for %(issue)s"
+msgstr "Nessuna immagine disponibile per %(issue)s"
+
+#: comicsdb/templates/comicsdb/partials/issue_filter.html:16
+msgid "Search Issues"
+msgstr "Cerca Albi"
+
+#: comicsdb/templates/comicsdb/partials/issue_filter.html:24
+#: comicsdb/templates/comicsdb/partials/series_filter.html:18
+#: reading_lists/templates/reading_lists/partials/readinglist_filter.html:18
+#: user_collection/templates/user_collection/partials/collection_filter.html:18
+msgid "Filters Active"
+msgstr "Filtri Attivi"
+
+#: comicsdb/templates/comicsdb/partials/issue_filter.html:30
+#: comicsdb/templates/comicsdb/partials/series_filter.html:24
+#: reading_lists/templates/reading_lists/partials/readinglist_filter.html:24
+#: user_collection/templates/user_collection/partials/collection_filter.html:24
+msgid "Quick Search"
+msgstr "Ricerca Rapida"
+
+#: comicsdb/templates/comicsdb/partials/issue_filter.html:37
+msgid "Search by series name..."
+msgstr "Cerca per nome della serie..."
+
+#: comicsdb/templates/comicsdb/partials/issue_filter.html:38
+#: comicsdb/templates/comicsdb/partials/series_filter.html:32
+#: reading_lists/templates/reading_lists/partials/readinglist_filter.html:32
+#: user_collection/templates/user_collection/partials/collection_filter.html:32
+msgid "Quick search"
+msgstr "Ricerca rapida"
+
+#: comicsdb/templates/comicsdb/partials/issue_filter.html:43
+msgid "Search series names (supports multi-word search)"
+msgstr "Cerca nomi delle serie (supporta la ricerca multi-parola)"
+
+#: comicsdb/templates/comicsdb/partials/issue_filter.html:52
+#: comicsdb/templates/comicsdb/partials/series_filter.html:46
+#: reading_lists/templates/reading_lists/partials/readinglist_filter.html:46
+#: user_collection/templates/user_collection/partials/collection_filter.html:46
+msgid "Advanced Filters"
+msgstr "Filtri Avanzati"
+
+#: comicsdb/templates/comicsdb/partials/issue_filter.html:62
+#: comicsdb/templates/comicsdb/partials/series_filter.html:53
+#: user_collection/templates/user_collection/partials/collection_filter.html:53
+msgid "Series Name"
+msgstr "Nome Serie"
+
+#: comicsdb/templates/comicsdb/partials/issue_filter.html:69
+#: comicsdb/templates/comicsdb/partials/series_filter.html:60
+#: user_collection/templates/user_collection/partials/collection_filter.html:60
+msgid "e.g., Amazing Spider-Man"
+msgstr "es. Amazing Spider-Man"
+
+#: comicsdb/templates/comicsdb/partials/issue_filter.html:70
+#: comicsdb/templates/comicsdb/partials/series_filter.html:61
+#: user_collection/templates/user_collection/partials/collection_filter.html:61
+msgid "Filter by series name"
+msgstr "Filtra per nome serie"
+
+#: comicsdb/templates/comicsdb/partials/issue_filter.html:80
+#: comicsdb/templates/comicsdb/partials/series_filter.html:89
+#: user_collection/templates/user_collection/partials/collection_filter.html:70
+msgid "Series Type"
+msgstr "Tipo di Serie"
+
+#: comicsdb/templates/comicsdb/partials/issue_filter.html:85
+#: comicsdb/templates/comicsdb/partials/series_filter.html:94
+#: user_collection/templates/user_collection/partials/collection_filter.html:75
+msgid "Filter by series type"
+msgstr "Filtra per tipo di serie"
+
+#: comicsdb/templates/comicsdb/partials/issue_filter.html:86
+#: comicsdb/templates/comicsdb/partials/series_filter.html:95
+#: reading_lists/templates/reading_lists/partials/readinglist_filter.html:111
+#: user_collection/templates/user_collection/partials/collection_filter.html:76
+msgid "All Types"
+msgstr "Tutti i Tipi"
+
+#: comicsdb/templates/comicsdb/partials/issue_filter.html:104
+msgid "Series Volume"
+msgstr "Volume della Serie"
+
+#: comicsdb/templates/comicsdb/partials/issue_filter.html:111
+#: comicsdb/templates/comicsdb/partials/issue_filter.html:152
+#: comicsdb/templates/comicsdb/partials/series_filter.html:191
+#: user_collection/templates/user_collection/partials/collection_filter.html:119
+msgid "e.g., 1"
+msgstr "es. 1"
+
+#: comicsdb/templates/comicsdb/partials/issue_filter.html:112
+msgid "Filter by series volume"
+msgstr "Filtra per volume della serie"
+
+#: comicsdb/templates/comicsdb/partials/issue_filter.html:129
+#: comicsdb/templates/comicsdb/partials/series_filter.html:120
+#: reading_lists/templates/reading_lists/partials/readinglist_filter.html:96
+#: user_collection/templates/user_collection/partials/collection_filter.html:101
+msgid "e.g., Marvel"
+msgstr "es. Marvel"
+
+#: comicsdb/templates/comicsdb/partials/issue_filter.html:130
+#: comicsdb/templates/comicsdb/partials/series_filter.html:121
+#: reading_lists/templates/reading_lists/partials/readinglist_filter.html:97
+#: user_collection/templates/user_collection/partials/collection_filter.html:102
+msgid "Filter by publisher"
+msgstr "Filtra per editore"
+
+#: comicsdb/templates/comicsdb/partials/issue_filter.html:140
+msgid "Issue Numbers"
+msgstr "Numeri degli Albi"
+
+#: comicsdb/templates/comicsdb/partials/issue_filter.html:145
+#: user_collection/templates/user_collection/partials/collection_filter.html:112
+msgid "Issue Number"
+msgstr "Numero Albo"
+
+#: comicsdb/templates/comicsdb/partials/issue_filter.html:153
+#: user_collection/templates/user_collection/partials/collection_filter.html:120
+msgid "Filter by issue number"
+msgstr "Filtra per numero albo"
+
+#: comicsdb/templates/comicsdb/partials/issue_filter.html:170
+msgid "e.g., 616"
+msgstr "es. 616"
+
+#: comicsdb/templates/comicsdb/partials/issue_filter.html:171
+msgid "Filter by alternative number"
+msgstr "Filtra per numero alternativo"
+
+#: comicsdb/templates/comicsdb/partials/issue_filter.html:181
+msgid "Dates"
+msgstr "Date"
+
+#: comicsdb/templates/comicsdb/partials/issue_filter.html:186
+msgid "Cover Year"
+msgstr "Anno di Copertina"
+
+#: comicsdb/templates/comicsdb/partials/issue_filter.html:189
+msgid "Filter by cover year"
+msgstr "Filtra per anno di copertina"
+
+#: comicsdb/templates/comicsdb/partials/issue_filter.html:190
+msgid "All Years"
+msgstr "Tutti gli Anni"
+
+#: comicsdb/templates/comicsdb/partials/issue_filter.html:218
+msgid "Cover Month"
+msgstr "Mese di Copertina"
+
+#: comicsdb/templates/comicsdb/partials/issue_filter.html:223
+msgid "Filter by cover month"
+msgstr "Filtra per mese di copertina"
+
+#: comicsdb/templates/comicsdb/partials/issue_filter.html:224
+msgid "All Months"
+msgstr "Tutti i Mesi"
+
+#: comicsdb/templates/comicsdb/partials/issue_filter.html:225
+#: comicsdb/views/issue_list_helpers.py:78
+msgid "January"
+msgstr "Gennaio"
+
+#: comicsdb/templates/comicsdb/partials/issue_filter.html:226
+#: comicsdb/views/issue_list_helpers.py:79
+msgid "February"
+msgstr "Febbraio"
+
+#: comicsdb/templates/comicsdb/partials/issue_filter.html:227
+#: comicsdb/views/issue_list_helpers.py:80
+msgid "March"
+msgstr "Marzo"
+
+#: comicsdb/templates/comicsdb/partials/issue_filter.html:228
+#: comicsdb/views/issue_list_helpers.py:81
+msgid "April"
+msgstr "Aprile"
+
+#: comicsdb/templates/comicsdb/partials/issue_filter.html:229
+#: comicsdb/views/issue_list_helpers.py:82
+msgid "May"
+msgstr "Maggio"
+
+#: comicsdb/templates/comicsdb/partials/issue_filter.html:230
+#: comicsdb/views/issue_list_helpers.py:83
+msgid "June"
+msgstr "Giugno"
+
+#: comicsdb/templates/comicsdb/partials/issue_filter.html:231
+#: comicsdb/views/issue_list_helpers.py:84
+msgid "July"
+msgstr "Luglio"
+
+#: comicsdb/templates/comicsdb/partials/issue_filter.html:232
+#: comicsdb/views/issue_list_helpers.py:85
+msgid "August"
+msgstr "Agosto"
+
+#: comicsdb/templates/comicsdb/partials/issue_filter.html:233
+#: comicsdb/views/issue_list_helpers.py:86
+msgid "September"
+msgstr "Settembre"
+
+#: comicsdb/templates/comicsdb/partials/issue_filter.html:236
+#: comicsdb/views/issue_list_helpers.py:87
+msgid "October"
+msgstr "Ottobre"
+
+#: comicsdb/templates/comicsdb/partials/issue_filter.html:240
+#: comicsdb/views/issue_list_helpers.py:88
+msgid "November"
+msgstr "Novembre"
+
+#: comicsdb/templates/comicsdb/partials/issue_filter.html:244
+#: comicsdb/views/issue_list_helpers.py:89
+msgid "December"
+msgstr "Dicembre"
+
+#: comicsdb/templates/comicsdb/partials/issue_filter.html:257
+msgid "Store Date From"
+msgstr "Data di Uscita Da"
+
+#: comicsdb/templates/comicsdb/partials/issue_filter.html:264
+msgid "Filter by store date from"
+msgstr "Filtra per data di uscita da"
+
+#: comicsdb/templates/comicsdb/partials/issue_filter.html:274
+msgid "Store Date To"
+msgstr "Data di Uscita A"
+
+#: comicsdb/templates/comicsdb/partials/issue_filter.html:281
+msgid "Filter by store date to"
+msgstr "Filtra per data di uscita a"
+
+#: comicsdb/templates/comicsdb/partials/issue_filter.html:291
+msgid "FOC Date From"
+msgstr "Data FOC Da"
+
+#: comicsdb/templates/comicsdb/partials/issue_filter.html:298
+msgid "Filter by FOC date from"
+msgstr "Filtra per data FOC da"
+
+#: comicsdb/templates/comicsdb/partials/issue_filter.html:308
+msgid "FOC Date To"
+msgstr "Data FOC A"
+
+#: comicsdb/templates/comicsdb/partials/issue_filter.html:315
+msgid "Filter by FOC date to"
+msgstr "Filtra per data FOC a"
+
+#: comicsdb/templates/comicsdb/partials/issue_filter.html:337
+msgid "e.g., 76194134186700111"
+msgstr "es. 76194134186700111"
+
+#: comicsdb/templates/comicsdb/partials/issue_filter.html:338
+msgid "Filter by UPC code"
+msgstr "Filtra per codice UPC"
+
+#: comicsdb/templates/comicsdb/partials/issue_filter.html:355
+msgid "e.g., JUN240001"
+msgstr "es. JUN240001"
+
+#: comicsdb/templates/comicsdb/partials/issue_filter.html:356
+msgid "Filter by distributor SKU"
+msgstr "Filtra per SKU distributore"
+
+#: comicsdb/templates/comicsdb/partials/issue_filter.html:373
+msgid "e.g., 12345"
+msgstr "es. 12345"
+
+#: comicsdb/templates/comicsdb/partials/issue_filter.html:374
+msgid "Filter by Comic Vine ID"
+msgstr "Filtra per ID Comic Vine"
+
+#: comicsdb/templates/comicsdb/partials/issue_filter.html:385
+msgid "ID"
+msgstr "ID"
+
+#: comicsdb/templates/comicsdb/partials/issue_filter.html:393
+msgid "e.g., 67890"
+msgstr "es. 67890"
+
+#: comicsdb/templates/comicsdb/partials/issue_filter.html:394
+msgid "Filter by GCD ID"
+msgstr "Filtra per ID GCD"
+
+#: comicsdb/templates/comicsdb/partials/issue_filter.html:410
+#: comicsdb/templates/comicsdb/partials/series_filter.html:230
+#: reading_lists/templates/reading_lists/partials/readinglist_filter.html:223
+#: user_collection/templates/user_collection/partials/collection_filter.html:246
+msgid "Apply Filters"
+msgstr "Applica Filtri"
+
+#: comicsdb/templates/comicsdb/partials/issue_filter.html:416
+#: comicsdb/templates/comicsdb/partials/series_filter.html:236
+#: reading_lists/templates/reading_lists/partials/readinglist_filter.html:229
+#: user_collection/templates/user_collection/partials/collection_filter.html:252
+msgid "Clear all filters"
+msgstr "Cancella tutti i filtri"
+
+#: comicsdb/templates/comicsdb/partials/issue_filter.html:420
+#: comicsdb/templates/comicsdb/partials/series_filter.html:240
+#: reading_lists/templates/reading_lists/partials/readinglist_filter.html:233
+#: user_collection/templates/user_collection/partials/collection_filter.html:256
+msgid "Clear Filters"
+msgstr "Cancella Filtri"
+
+#: comicsdb/templates/comicsdb/partials/issue_sort.html:12
+msgid "Sort issues"
+msgstr "Ordina albi"
+
+#: comicsdb/templates/comicsdb/partials/issue_sort.html:20
+#: comicsdb/templates/comicsdb/partials/issue_sort.html:36
+msgid "Sort"
+msgstr "Ordina"
+
+#: comicsdb/templates/comicsdb/partials/issue_sort.html:26
+msgid "Sort order"
+msgstr "Ordine"
+
+#: comicsdb/templates/comicsdb/partials/list_header.html:15
+#: comicsdb/templates/comicsdb/series_list.html:25
+#: users/templates/users/customuser_list.html:13
+msgid "List navigation and actions"
+msgstr "Navigazione ed azioni elenco"
+
+#: comicsdb/templates/comicsdb/partials/list_header.html:30
+#: comicsdb/templates/comicsdb/partials/list_header.html:33
+#, python-format
+msgid "Search %(title_plural)s"
+msgstr "Cerca %(title_plural)s"
+
+#: comicsdb/templates/comicsdb/partials/list_header.html:42
+#: comicsdb/templates/comicsdb/partials/list_header.html:46
+#: comicsdb/views/issue_list_helpers.py:58 comicsdb/views/series_list_helpers.py:16
+#: reading_lists/views.py:43 users/templates/users/customuser_list.html:37
+#: users/templates/users/customuser_list.html:41
+msgid "Search"
+msgstr "Cerca"
+
+#: comicsdb/templates/comicsdb/partials/pagination.html:20
+msgid "Go to previous page"
+msgstr "Vai alla pagina precedente"
+
+#: comicsdb/templates/comicsdb/partials/pagination.html:20
+#: comicsdb/templates/comicsdb/partials/pagination.html:25
+#: reading_lists/templates/reading_lists/readinglist_detail.html:132
+msgid "Previous"
+msgstr "Precedente"
+
+#: comicsdb/templates/comicsdb/partials/pagination.html:23
+msgid "This is the first page"
+msgstr "Questa è la prima pagina"
+
+#: comicsdb/templates/comicsdb/partials/pagination.html:31
+msgid "Go to next page"
+msgstr "Vai alla pagina successiva"
+
+#: comicsdb/templates/comicsdb/partials/pagination.html:31
+#: comicsdb/templates/comicsdb/partials/pagination.html:36
+msgid "Next page"
+msgstr "Pagina successiva"
+
+#: comicsdb/templates/comicsdb/partials/pagination.html:34
+msgid "This is the last page"
+msgstr "Questa è l'ultima pagina"
+
+#: comicsdb/templates/comicsdb/partials/pagination.html:50
+#, python-format
+msgid "Page %(page_num)s"
+msgstr "Pagina %(page_num)s"
+
+#: comicsdb/templates/comicsdb/partials/pagination.html:57
+#, python-format
+msgid "Go to page %(page_num)s"
+msgstr "Vai alla pagina %(page_num)s"
+
+#: comicsdb/templates/comicsdb/partials/publisher_imprint_items.html:31
+#: comicsdb/templates/comicsdb/publisher_detail.html:172
+#, python-format
+msgid "%(counter_fmt)s series"
+msgid_plural "%(counter_fmt)s series"
+msgstr[0] "%(counter_fmt)s serie"
+msgstr[1] "%(counter_fmt)s serie"
+
+#: comicsdb/templates/comicsdb/partials/publisher_imprint_items.html:47
+#: comicsdb/templates/comicsdb/publisher_detail.html:188
+msgid "Load More Imprints"
+msgstr "Carica Altre Etichette"
+
+#: comicsdb/templates/comicsdb/partials/publisher_universe_items.html:21
+#: comicsdb/templates/comicsdb/publisher_detail.html:219
+#: comicsdb/templates/comicsdb/universe_detail.html:113
+#, python-format
+msgid "No image for %(universe.name)s"
+msgstr "Nessuna immagine per %(universe.name)s"
+
+#: comicsdb/templates/comicsdb/partials/publisher_universe_items.html:31
+#: comicsdb/templates/comicsdb/partials/series_card_grid.html:55
+#: comicsdb/templates/comicsdb/publisher_detail.html:229
+#, python-format
+msgid "%(counter_fmt)s issue"
+msgid_plural "%(counter_fmt)s issues"
+msgstr[0] "%(counter_fmt)s albo"
+msgstr[1] "%(counter_fmt)s albi"
+
+#: comicsdb/templates/comicsdb/partials/series_card_grid.html:22
+#, python-format
+msgid "View details for %(series)s"
+msgstr "Visualizza dettagli per %(series)s"
+
+#: comicsdb/templates/comicsdb/partials/series_card_grid.html:34
+#, python-format
+msgid "No image available for %(series)s"
+msgstr "Nessuna immagine disponibile per %(series)s"
+
+#: comicsdb/templates/comicsdb/partials/series_card_grid.html:48
+#, python-format
+msgid "View publisher %(publisher)s"
+msgstr "Visualizza editore %(publisher)s"
+
+#: comicsdb/templates/comicsdb/partials/series_card_grid.html:54
+#, python-format
+msgid "%(counter_fmt)s issue for %(series)s"
+msgid_plural "%(counter_fmt)s issues for %(series)s"
+msgstr[0] "%(counter_fmt)s albo per %(series)s"
+msgstr[1] "%(counter_fmt)s albi per %(series)s"
+
+#: comicsdb/templates/comicsdb/partials/series_card_grid.html:58
+msgid "No issues"
+msgstr "Nessun albo"
+
+#: comicsdb/templates/comicsdb/partials/series_card_grid.html:58
+msgid "0 issues"
+msgstr "0 albi"
+
+#: comicsdb/templates/comicsdb/partials/series_filter.html:10
+msgid "Search Series"
+msgstr "Cerca Serie"
+
+#: comicsdb/templates/comicsdb/partials/series_filter.html:31
+msgid "Search series names..."
+msgstr "Cerca nomi delle serie..."
+
+#: comicsdb/templates/comicsdb/partials/series_filter.html:37
+msgid "Search series names and alternative names (supports multi-word search)"
+msgstr "Cerca nomi delle serie e nomi alternativi (supporta la ricerca multi-parola)"
+
+#: comicsdb/templates/comicsdb/partials/series_filter.html:71
+#: comicsdb/views/series_list_helpers.py:18
+msgid "Alternative Name"
+msgstr "Nome Alternativo"
+
+#: comicsdb/templates/comicsdb/partials/series_filter.html:78
+msgid "e.g., Betty & Veronica Spectacular"
+msgstr "es. Betty & Veronica Spectacular"
+
+#: comicsdb/templates/comicsdb/partials/series_filter.html:79
+msgid "Filter by alternative series name"
+msgstr "Filtra per nome alternativo della serie"
+
+#: comicsdb/templates/comicsdb/partials/series_filter.html:138
+msgid "e.g., Vertigo"
+msgstr "es. Vertigo"
+
+#: comicsdb/templates/comicsdb/partials/series_filter.html:139
+msgid "Filter by imprint"
+msgstr "Filtra per etichetta"
+
+#: comicsdb/templates/comicsdb/partials/series_filter.html:149
+msgid "Year Began (From)"
+msgstr "Anno di Inizio (Da)"
+
+#: comicsdb/templates/comicsdb/partials/series_filter.html:156
+msgid "e.g., 1960"
+msgstr "es. 1960"
+
+#: comicsdb/templates/comicsdb/partials/series_filter.html:157
+msgid "Filter by year began (from)"
+msgstr "Filtra per anno di inizio (da)"
+
+#: comicsdb/templates/comicsdb/partials/series_filter.html:166
+msgid "Year Began (To)"
+msgstr "Anno di Inizio (A)"
+
+#: comicsdb/templates/comicsdb/partials/series_filter.html:173
+msgid "e.g., 2020"
+msgstr "es. 2020"
+
+#: comicsdb/templates/comicsdb/partials/series_filter.html:174
+msgid "Filter by year began (to)"
+msgstr "Filtra per anno di inizio (a)"
+
+#: comicsdb/templates/comicsdb/partials/series_filter.html:184
+#: comicsdb/views/issue_list_helpers.py:61 comicsdb/views/series_list_helpers.py:29
+msgid "Volume"
+msgstr "Volume"
+
+#: comicsdb/templates/comicsdb/partials/series_filter.html:192
+msgid "Filter by volume"
+msgstr "Filtra per volume"
+
+#: comicsdb/templates/comicsdb/partials/series_filter.html:202
+#: comicsdb/views/series_list_helpers.py:28
+#: wish_list/templates/wish_list/wishlist_detail.html:84
+msgid "Status"
+msgstr "Stato"
+
+#: comicsdb/templates/comicsdb/partials/series_filter.html:205
+msgid "Filter by status"
+msgstr "Filtra per stato"
+
+#: comicsdb/templates/comicsdb/partials/series_filter.html:206
+msgid "All Statuses"
+msgstr "Tutti gli Stati"
+
+#: comicsdb/templates/comicsdb/partials/team_member_items.html:40
+#: comicsdb/templates/comicsdb/team_detail.html:175
+msgid "Load More Members"
+msgstr "Carica Altri Membri"
+
+#: comicsdb/templates/comicsdb/partials/variants_formset.html:25
+msgid "Image"
+msgstr "Immagine"
+
+#: comicsdb/templates/comicsdb/partials/variants_formset.html:26
+#: comicsdb/views/series_list_helpers.py:17 reading_lists/views.py:44
+#: users/templates/users/api_token.html:85
+msgid "Name"
+msgstr "Nome"
+
+#: comicsdb/templates/comicsdb/partials/variants_formset.html:27
+msgid "Price"
+msgstr "Prezzo"
+
+#: comicsdb/templates/comicsdb/partials/variants_formset.html:28
+#: comicsdb/views/issue_list_helpers.py:72
+msgid "SKU"
+msgstr "SKU"
+
+#: comicsdb/templates/comicsdb/partials/variants_formset.html:29
+#: comicsdb/views/issue_list_helpers.py:71
+msgid "UPC"
+msgstr "UPC"
+
+#: comicsdb/templates/comicsdb/partials/variants_formset.html:108
+msgid "Add another variant cover"
+msgstr "Aggiungi un'altra copertina variante"
+
+#: comicsdb/templates/comicsdb/publisher_detail.html:14
+msgid "Publisher navigation"
+msgstr "Navigazione editore"
+
+#: comicsdb/templates/comicsdb/publisher_detail.html:19
+#, python-format
+msgid "Go to %(previous_publisher)s"
+msgstr "Vai a %(previous_publisher)s"
+
+#: comicsdb/templates/comicsdb/publisher_detail.html:21
+#: comicsdb/templates/comicsdb/publisher_detail.html:26
+msgid "Previous Publisher"
+msgstr "Editore Precedente"
+
+#: comicsdb/templates/comicsdb/publisher_detail.html:32
+#, python-format
+msgid "Go to %(next_publisher)s"
+msgstr "Vai a %(next_publisher)s"
+
+#: comicsdb/templates/comicsdb/publisher_detail.html:33
+#: comicsdb/templates/comicsdb/publisher_detail.html:38
+msgid "Next Publisher"
+msgstr "Editore Successivo"
+
+#: comicsdb/templates/comicsdb/publisher_detail.html:47
+msgid "View series list for this publisher"
+msgstr "Visualizza elenco serie per questo editore"
+
+#: comicsdb/templates/comicsdb/publisher_detail.html:54
+#: comicsdb/templates/comicsdb/publisher_list.html:12
+msgid "Add a new publisher"
+msgstr "Aggiungi un nuovo editore"
+
+#: comicsdb/templates/comicsdb/publisher_detail.html:119
+#, python-format
+msgid "No image for %(publisher.name)s"
+msgstr "Nessuna immagine per %(publisher.name)s"
+
+#: comicsdb/templates/comicsdb/publisher_detail.html:143
+#, python-format
+msgid "Imprint (%(counter)s)"
+msgid_plural "Imprints (%(counter)s)"
+msgstr[0] "Etichetta (%(counter)s)"
+msgstr[1] "Etichette (%(counter)s)"
+
+#: comicsdb/templates/comicsdb/publisher_detail.html:264
+msgid "Publisher Details"
+msgstr "Dettagli Editore"
+
+#: comicsdb/templates/comicsdb/publisher_detail.html:272
+msgid "Country:"
+msgstr "Nazione:"
+
+#: comicsdb/templates/comicsdb/publisher_list.html:3
+msgid "Publishers - Metron"
+msgstr "Editori - Metron"
+
+#: comicsdb/templates/comicsdb/publisher_list.html:6
+msgid "Publishers List"
+msgstr "Elenco Editori"
+
+#: comicsdb/templates/comicsdb/publisher_list.html:9
+#: comicsdb/templates/comicsdb/statistics.html:26
+#: reading_lists/templates/reading_lists/readinglist_detail.html:96
+#: reading_lists/templates/reading_lists/readinglist_detail.html:327
+#: reading_lists/templates/reading_lists/readinglist_detail.html:344
+#: templates/partials/navbar.html:62 users/templates/users/customuser_detail.html:219
+msgid "Publishers"
+msgstr "Editori"
+
+#: comicsdb/templates/comicsdb/publisher_list.html:10
+msgid "Find a publisher"
+msgstr "Cerca un editore"
+
+#: comicsdb/templates/comicsdb/series_detail.html:32
+msgid "Series navigation"
+msgstr "Navigazione serie"
+
+#: comicsdb/templates/comicsdb/series_detail.html:37
+#, python-format
+msgid "Go to %(previous_series)s"
+msgstr "Vai a %(previous_series)s"
+
+#: comicsdb/templates/comicsdb/series_detail.html:39
+#: comicsdb/templates/comicsdb/series_detail.html:44
+msgid "Previous Series"
+msgstr "Serie Precedente"
+
+#: comicsdb/templates/comicsdb/series_detail.html:50
+#, python-format
+msgid "Go to %(next_series)s"
+msgstr "Vai a %(next_series)s"
+
+#: comicsdb/templates/comicsdb/series_detail.html:51
+#: comicsdb/templates/comicsdb/series_detail.html:56
+msgid "Next Series"
+msgstr "Serie Successiva"
+
+#: comicsdb/templates/comicsdb/series_detail.html:65
+msgid "View issue list for this series"
+msgstr "Visualizza elenco albi per questa serie"
+
+#: comicsdb/templates/comicsdb/series_detail.html:67
+msgid "Issue List"
+msgstr "Elenco Albi"
+
+#: comicsdb/templates/comicsdb/series_detail.html:73
+#: comicsdb/templates/comicsdb/series_list.html:40
+#: comicsdb/templates/comicsdb/series_list.html:41
+#: comicsdb/templates/comicsdb/series_list.html:67
+msgid "Add a new series"
+msgstr "Aggiungi una nuova serie"
+
+#: comicsdb/templates/comicsdb/series_detail.html:139
+#, python-format
+msgid "No image for %(series)s"
+msgstr "Nessuna immagine per %(series)s"
+
+#: comicsdb/templates/comicsdb/series_detail.html:164
+#, python-format
+msgid "Most Issue Credits (%(count)s)"
+msgstr "Maggiori Crediti per Albo (%(count)s)"
+
+#: comicsdb/templates/comicsdb/series_detail.html:183
+#, python-format
+msgid "No image for %(creator.creators__name)s"
+msgstr "Nessuna immagine per %(creator.creators__name)s"
+
+#: comicsdb/templates/comicsdb/series_detail.html:206
+#, python-format
+msgid "Top Character Appearances (%(count)s)"
+msgstr "Principali Apparizioni di Personaggi (%(count)s)"
+
+#: comicsdb/templates/comicsdb/series_detail.html:225
+#, python-format
+msgid "No image for %(character.characters__name)s"
+msgstr "Nessuna immagine per %(character.characters__name)s"
+
+#: comicsdb/templates/comicsdb/series_detail.html:255
+msgid "Series Details"
+msgstr "Dettagli Serie"
+
+#: comicsdb/templates/comicsdb/series_detail.html:262
+msgid "Imprint:"
+msgstr "Etichetta:"
+
+#: comicsdb/templates/comicsdb/series_detail.html:267
+#: reading_lists/templates/reading_lists/readinglist_detail.html:270
+msgid "Type:"
+msgstr "Tipo:"
+
+#: comicsdb/templates/comicsdb/series_detail.html:271
+#: polls/templates/polls/poll_detail.html:102
+msgid "Status:"
+msgstr "Stato:"
+
+#: comicsdb/templates/comicsdb/series_detail.html:276
+#: user_collection/templates/user_collection/missing_issues_detail.html:44
+msgid "Volume:"
+msgstr "Volume:"
+
+#: comicsdb/templates/comicsdb/series_detail.html:281
+msgid "Started:"
+msgstr "Iniziata:"
+
+#: comicsdb/templates/comicsdb/series_detail.html:286
+msgid "Ended:"
+msgstr "Terminata:"
+
+#: comicsdb/templates/comicsdb/series_detail.html:300
+msgid "Alternative Names:"
+msgstr "Nomi Alternativi:"
+
+#: comicsdb/templates/comicsdb/series_detail.html:302
+msgid "Alternative Name:"
+msgstr "Nome Alternativo:"
+
+#: comicsdb/templates/comicsdb/series_detail.html:315
+msgid "Genres"
+msgstr "Generi"
+
+#: comicsdb/templates/comicsdb/series_detail.html:317
+msgid "Genre"
+msgstr "Genere"
+
+#: comicsdb/templates/comicsdb/series_list.html:5
+msgid "Series - Metron"
+msgstr "Serie - Metron"
+
+#: comicsdb/templates/comicsdb/statistics.html:9
+msgid "Statistics - Metron"
+msgstr "Statistiche - Metron"
+
+#: comicsdb/templates/comicsdb/statistics.html:14
+msgid "Metron Database Statistics"
+msgstr "Statistiche del Database Metron"
+
+#: comicsdb/templates/comicsdb/statistics.html:16
+#, python-format
+msgid ""
+"Last Updated: <time "
+"datetime=\"%(update_time_value|date:'c')s\">%(update_time_value)s</time>"
+msgstr ""
+"Ultimo Aggiornamento: <time "
+"datetime=\"%(update_time_value|date:'c')s\">%(update_time_value)s</time>"
+
+#: comicsdb/templates/comicsdb/statistics.html:22
+msgid "Database Totals"
+msgstr "Totali del Database"
+
+#: comicsdb/templates/comicsdb/statistics.html:71
+msgid "Statistical Analysis"
+msgstr "Analisi Statistica"
+
+#: comicsdb/templates/comicsdb/statistics.html:111
+msgid "About These Statistics"
+msgstr "Informazioni su Queste Statistiche"
+
+#: comicsdb/templates/comicsdb/statistics.html:113
+msgid ""
+"These statistics are automatically generated from the Metron database and are updated "
+"every 30 minutes. They represent the collective efforts of our community in building "
+"a comprehensive comic book database."
+msgstr ""
+"Queste statistiche sono generate automaticamente dal database Metron e vengono "
+"aggiornate ogni 30 minuti. Rappresentano gli sforzi collettivi della nostra community "
+"nella costruzione di un database completo di fumetti."
+
+#: comicsdb/templates/comicsdb/team_detail.html:14
+msgid "Team navigation"
+msgstr "Navigazione squadra"
+
+#: comicsdb/templates/comicsdb/team_detail.html:19
+#, python-format
+msgid "Go to %(previous_team)s"
+msgstr "Vai a %(previous_team)s"
+
+#: comicsdb/templates/comicsdb/team_detail.html:21
+#: comicsdb/templates/comicsdb/team_detail.html:26
+msgid "Previous Team"
+msgstr "Squadra Precedente"
+
+#: comicsdb/templates/comicsdb/team_detail.html:32
+#, python-format
+msgid "Go to %(next_team)s"
+msgstr "Vai a %(next_team)s"
+
+#: comicsdb/templates/comicsdb/team_detail.html:33
+#: comicsdb/templates/comicsdb/team_detail.html:38
+msgid "Next Team"
+msgstr "Squadra Successiva"
+
+#: comicsdb/templates/comicsdb/team_detail.html:48
+#: comicsdb/templates/comicsdb/team_list.html:13
+msgid "Add a new team"
+msgstr "Aggiungi una nuova squadra"
+
+#: comicsdb/templates/comicsdb/team_detail.html:113
+#, python-format
+msgid "No image for %(team.name)s"
+msgstr "Nessuna immagine per %(team.name)s"
+
+#: comicsdb/templates/comicsdb/team_detail.html:137
+#, python-format
+msgid "Member (%(counter)s)"
+msgid_plural "Members (%(counter)s)"
+msgstr[0] "Membro (%(counter)s)"
+msgstr[1] "Membri (%(counter)s)"
+
+#: comicsdb/templates/comicsdb/team_detail.html:194
+msgid "Team Details"
+msgstr "Dettagli Squadra"
+
+#: comicsdb/templates/comicsdb/team_list.html:3
+msgid "Teams - Metron"
+msgstr "Squadre - Metron"
+
+#: comicsdb/templates/comicsdb/team_list.html:6
+msgid "Teams List"
+msgstr "Elenco Squadre"
+
+#: comicsdb/templates/comicsdb/team_list.html:10
+msgid "Find a team"
+msgstr "Cerca una squadra"
+
+#: comicsdb/templates/comicsdb/universe_detail.html:14
+msgid "Universe navigation"
+msgstr "Navigazione universo"
+
+#: comicsdb/templates/comicsdb/universe_detail.html:19
+#, python-format
+msgid "Go to %(previous_universe)s"
+msgstr "Vai a %(previous_universe)s"
+
+#: comicsdb/templates/comicsdb/universe_detail.html:21
+#: comicsdb/templates/comicsdb/universe_detail.html:26
+msgid "Previous Universe"
+msgstr "Universo Precedente"
+
+#: comicsdb/templates/comicsdb/universe_detail.html:32
+#, python-format
+msgid "Go to %(next_universe)s"
+msgstr "Vai a %(next_universe)s"
+
+#: comicsdb/templates/comicsdb/universe_detail.html:33
+#: comicsdb/templates/comicsdb/universe_detail.html:38
+msgid "Next Universe"
+msgstr "Universo Successivo"
+
+#: comicsdb/templates/comicsdb/universe_detail.html:48
+#: comicsdb/templates/comicsdb/universe_list.html:13
+msgid "Add a new universe"
+msgstr "Aggiungi un nuovo universo"
+
+#: comicsdb/templates/comicsdb/universe_detail.html:290
+msgid "Universe Details"
+msgstr "Dettagli Universo"
+
+#: comicsdb/templates/comicsdb/universe_list.html:3
+msgid "Universes - Metron"
+msgstr "Universi - Metron"
+
+#: comicsdb/templates/comicsdb/universe_list.html:6
+msgid "Universes List"
+msgstr "Elenco Universi"
+
+#: comicsdb/templates/comicsdb/universe_list.html:10
+msgid "Find a universe"
+msgstr "Cerca un universo"
+
+#: comicsdb/templates/comicsdb/week_list.html:5
+msgid "Future Releases - Metron"
+msgstr "Prossime Uscite - Metron"
+
+#: comicsdb/templates/comicsdb/week_list.html:7
+#, python-format
+msgid "New Comics - %(release_date)s - Metron"
+msgstr "Nuovi Fumetti - %(release_date)s - Metron"
+
+#: comicsdb/templates/comicsdb/week_list.html:14
+#, python-format
+msgid "Comics Released the Week of %(release_date)s"
+msgstr "Fumetti Usciti la Settimana del %(release_date)s"
+
+#: comicsdb/templates/comicsdb/week_list.html:16
+msgid "Future Releases"
+msgstr "Prossime Uscite"
+
+#: comicsdb/templates/comicsdb/week_list.html:32
+msgid "Weekly releases navigation"
+msgstr "Navigazione uscite settimanali"
+
+#: comicsdb/templates/comicsdb/week_list.html:37
+#: comicsdb/templates/comicsdb/week_list.html:39
+#, python-format
+msgid "<strong>%(counter)s</strong> Issue"
+msgid_plural "<strong>%(counter)s</strong> Issues"
+msgstr[0] "<strong>%(counter)s</strong> Albo"
+msgstr[1] "<strong>%(counter)s</strong> Albi"
+
+#: comicsdb/templates/comicsdb/week_list.html:82
+msgid "No Releases Found"
+msgstr "Nessuna Uscita Trovata"
+
+#: comicsdb/templates/comicsdb/week_list.html:85
+msgid "No future releases have been scheduled yet."
+msgstr "Non è ancora stata programmata nessuna futura uscita."
+
+#: comicsdb/templates/comicsdb/week_list.html:87
+msgid "No issues were released this week."
+msgstr "Nessun albo è stato pubblicato questa settimana."
+
+#: comicsdb/templates/comicsdb/week_list.html:98
+#: user_collection/templates/user_collection/collection_list.html:44
+msgid "Add Issue"
+msgstr "Aggiungi Albo"
 
 #: comicsdb/views/issue.py:451
 #, python-format
@@ -266,6 +3508,96 @@ msgstr "%(first)s e %(last)s"
 msgid "Successfully added %(parts)s from reprinted issues."
 msgstr "Aggiunti con successo %(parts)s dagli albi ristampati."
 
+#: comicsdb/views/issue_list_helpers.py:23
+msgid "Series A–Z"
+msgstr "Serie A–Z"
+
+#: comicsdb/views/issue_list_helpers.py:27
+msgid "Cover date (newest)"
+msgstr "Data di copertina (più recente)"
+
+#: comicsdb/views/issue_list_helpers.py:31
+msgid "Cover date (oldest)"
+msgstr "Data di copertina (meno recente)"
+
+#: comicsdb/views/issue_list_helpers.py:60 comicsdb/views/series_list_helpers.py:19
+#: pull_list/templates/pull_list/pulllist_detail.html:49
+#: user_collection/templates/user_collection/missing_issues_list.html:42
+msgid "Type"
+msgstr "Tipo"
+
+#: comicsdb/views/issue_list_helpers.py:63
+msgid "Number"
+msgstr "Numero"
+
+#: comicsdb/views/issue_list_helpers.py:64
+msgid "Alt number"
+msgstr "Numero alternativo"
+
+#: comicsdb/views/issue_list_helpers.py:65
+msgid "Cover year"
+msgstr "Anno di copertina"
+
+#: comicsdb/views/issue_list_helpers.py:66
+msgid "Cover month"
+msgstr "Mese di copertina"
+
+#: comicsdb/views/issue_list_helpers.py:67
+msgid "Store date from"
+msgstr "Data di uscita da"
+
+#: comicsdb/views/issue_list_helpers.py:68
+msgid "Store date to"
+msgstr "Data di uscita a"
+
+#: comicsdb/views/issue_list_helpers.py:69
+msgid "FOC date from"
+msgstr "Data FOC da"
+
+#: comicsdb/views/issue_list_helpers.py:70
+msgid "FOC date to"
+msgstr "Data FOC a"
+
+#: comicsdb/views/series_list_helpers.py:21
+msgid "Publisher ID"
+msgstr "ID Editore"
+
+#: comicsdb/views/series_list_helpers.py:23
+msgid "Imprint ID"
+msgstr "ID Etichetta"
+
+#: comicsdb/views/series_list_helpers.py:25
+msgid "Year Began (from)"
+msgstr "Anno di Inizio (da)"
+
+#: comicsdb/views/series_list_helpers.py:26
+msgid "Year Began (to)"
+msgstr "Anno di Inizio (a)"
+
+#: comicsdb/views/statistics.py:136
+msgid "Percentage of Issues by Publisher"
+msgstr "Percentuale di Albi per Editore"
+
+#: comicsdb/views/statistics.py:141
+msgid "Number of Issues Added per Year"
+msgstr "Numero di Albi Aggiunti per Anno"
+
+#: comicsdb/views/statistics.py:145
+msgid "Number of Issues for the last 30 days"
+msgstr "Numero di Albi negli ultimi 30 giorni"
+
+#: comicsdb/views/statistics.py:149
+msgid "Number of Issues Added by Month"
+msgstr "Numero di Albi Aggiunti per Mese"
+
+#: comicsdb/views/statistics.py:153
+msgid "Number of Creators Added by Month"
+msgstr "Numero di Autori Aggiunti per Mese"
+
+#: comicsdb/views/statistics.py:158
+msgid "Number of Characters Added by Month"
+msgstr "Numero di Personaggi Aggiunti per Mese"
+
 #: polls/templates/polls/partials/poll_results.html:3
 msgid "Results"
 msgstr "Risultati"
@@ -305,35 +3637,6 @@ msgid ""
 msgstr ""
 "Sei sicuro di voler eliminare <strong>%(title)s</strong>? Questo eliminerà anche "
 "tutti i voti espressi in questo sondaggio e non può essere annullato."
-
-#: polls/templates/polls/poll_confirm_delete.html:20
-#: polls/templates/polls/poll_detail.html:38
-#: reading_lists/templates/reading_lists/readinglist_confirm_delete.html:32
-#: reading_lists/templates/reading_lists/readinglist_detail.html:177
-msgid "Delete"
-msgstr "Elimina"
-
-#: polls/templates/polls/poll_confirm_delete.html:25
-#: pull_list/templates/pull_list/remove_series_confirm.html:27
-#: reading_lists/templates/reading_lists/add_issue_autocomplete.html:42
-#: reading_lists/templates/reading_lists/add_issues_from_arc.html:43
-#: reading_lists/templates/reading_lists/add_issues_from_series.html:76
-#: reading_lists/templates/reading_lists/partials/readinglist_item_edit.html:68
-#: reading_lists/templates/reading_lists/readinglist_confirm_assign_metron.html:29
-#: reading_lists/templates/reading_lists/readinglist_confirm_delete.html:29
-#: reading_lists/templates/reading_lists/readinglist_form.html:114
-#: reading_lists/templates/reading_lists/remove_issue_confirm.html:25
-#: user_collection/templates/user_collection/add_issues_from_series.html:82
-#: user_collection/templates/user_collection/collection_confirm_delete.html:31
-#: user_collection/templates/user_collection/collection_form.html:72
-#: user_collection/templates/user_collection/partials/read_dates_list.html:38
-#: users/templates/users/change_profile.html:120
-#: users/templates/users/delete_account.html:44
-#: wish_list/templates/wish_list/wishlist_acquire_form.html:37
-#: wish_list/templates/wish_list/wishlist_item_confirm_delete.html:26
-#: wish_list/templates/wish_list/wishlist_item_form.html:50
-msgid "Cancel"
-msgstr "Annulla"
 
 #: polls/templates/polls/poll_detail.html:3
 #: reading_lists/templates/reading_lists/readinglist_form.html:3
@@ -388,10 +3691,6 @@ msgstr "per esprimere il tuo voto."
 #: polls/templates/polls/poll_detail.html:100
 msgid "Poll Details"
 msgstr "Dettagli Sondaggio"
-
-#: polls/templates/polls/poll_detail.html:102
-msgid "Status:"
-msgstr "Stato:"
 
 #: polls/templates/polls/poll_detail.html:106
 msgid "Voting Opens:"
@@ -450,25 +3749,9 @@ msgstr "Nessuna scelta selezionata."
 msgid "Search for a series..."
 msgstr "Cerca una serie..."
 
-#: pull_list/forms.py:20 pull_list/templates/pull_list/pulllist_detail.html:47
-#: reading_lists/forms.py:137
-#: reading_lists/templates/reading_lists/readinglist_detail.html:100
-#: templates/partials/navbar.html:74 user_collection/forms.py:132
-#: user_collection/templates/user_collection/collection_stats.html:226
-#: user_collection/templates/user_collection/missing_issues_list.html:40
-#: users/templates/users/customuser_detail.html:230
-#: wish_list/templates/wish_list/wishlist_detail.html:83
-msgid "Series"
-msgstr "Serie"
-
 #: pull_list/forms.py:21
 msgid "Select a series to add to your pull list"
 msgstr "Seleziona una serie da aggiungere alla tua pull list"
-
-#: pull_list/models.py:27
-#: pull_list/templates/pull_list/partials/pull_list_button.html:11
-msgid "Pull List"
-msgstr "Pull List"
 
 #: pull_list/models.py:28
 msgid "Pull Lists"
@@ -506,19 +3789,6 @@ msgstr "Aggiungi"
 msgid "Series on Pull List (%(count)s)"
 msgstr "Serie nella Pull List (%(count)s)"
 
-#: pull_list/templates/pull_list/pulllist_detail.html:48
-#: reading_lists/templates/reading_lists/partials/readinglist_filter.html:89
-#: reading_lists/views.py:46
-#: user_collection/templates/user_collection/missing_issues_list.html:41
-#: user_collection/templates/user_collection/partials/collection_filter.html:94
-msgid "Publisher"
-msgstr "Editore"
-
-#: pull_list/templates/pull_list/pulllist_detail.html:49
-#: user_collection/templates/user_collection/missing_issues_list.html:42
-msgid "Type"
-msgstr "Tipo"
-
 #: pull_list/templates/pull_list/pulllist_detail.html:68
 #: pull_list/templates/pull_list/remove_series_confirm.html:30
 #: reading_lists/templates/reading_lists/remove_issue_confirm.html:28
@@ -536,13 +3806,6 @@ msgstr "Nessuna serie ancora in questa pull list."
 #: pull_list/templates/pull_list/pulllist_detail.html:85
 msgid "Upcoming Issues"
 msgstr "Prossimi Albi"
-
-#: pull_list/templates/pull_list/pulllist_detail.html:91
-#: user_collection/templates/user_collection/collection_list.html:62
-#: user_collection/templates/user_collection/missing_issues_detail.html:79
-#: wish_list/templates/wish_list/wishlist_detail.html:82
-msgid "Issue"
-msgstr "Albo"
 
 #: pull_list/templates/pull_list/pulllist_detail.html:92
 #: user_collection/templates/user_collection/missing_issues_detail.html:82
@@ -613,11 +3876,6 @@ msgstr "Inserisci un nome per la tua lista di lettura"
 msgid "Describe the reading list (optional)"
 msgstr "Descrivi la lista di lettura (opzionale)"
 
-#: reading_lists/forms.py:69
-#: user_collection/templates/user_collection/collection_detail.html:84
-msgid "Description"
-msgstr "Descrizione"
-
 #: reading_lists/forms.py:70
 msgid "Private List"
 msgstr "Lista Privata"
@@ -627,10 +3885,6 @@ msgstr "Lista Privata"
 #: reading_lists/views.py:47
 msgid "List Type"
 msgstr "Tipo di Lista"
-
-#: reading_lists/forms.py:72
-msgid "Source"
-msgstr "Fonte"
 
 #: reading_lists/forms.py:73
 msgid "Source URL"
@@ -718,19 +3972,9 @@ msgstr "Specifica almeno un numero di albo iniziale o finale per l'intervallo."
 msgid "Search for a story arc..."
 msgstr "Cerca un arco narrativo..."
 
-#: reading_lists/forms.py:204
-msgid "Story Arc"
-msgstr "Arco Narrativo"
-
 #: reading_lists/forms.py:205
 msgid "Select the story arc to add issues from"
 msgstr "Seleziona l'arco narrativo da cui aggiungere gli albi"
-
-#: reading_lists/models.py:62
-#: reading_lists/templates/reading_lists/partials/readinglist_filter.html:71
-#: reading_lists/views.py:45
-msgid "Creator"
-msgstr "Autore"
 
 #: reading_lists/models.py:63
 msgid "Event"
@@ -739,16 +3983,6 @@ msgstr "Evento"
 #: reading_lists/models.py:64
 msgid "Story"
 msgstr "Storia"
-
-#: reading_lists/models.py:65 templates/partials/navbar.html:93
-#: users/templates/users/customuser_detail.html:252
-msgid "Characters"
-msgstr "Personaggi"
-
-#: reading_lists/models.py:66 templates/partials/navbar.html:99
-#: users/templates/users/customuser_detail.html:274
-msgid "Teams"
-msgstr "Squadre"
 
 #: reading_lists/models.py:67
 msgid "Master"
@@ -857,6 +4091,7 @@ msgid "Optional categorization of this issue's role in the reading list"
 msgstr "Categorizzazione opzionale del ruolo di questo albo nella lista di lettura"
 
 #: reading_lists/templates/reading_lists/add_issue_autocomplete.html:3
+#, python-format
 msgid "Manage Issues - %(name)s - Metron"
 msgstr "Gestisci Albi - %(name)s - Metron"
 
@@ -919,11 +4154,8 @@ msgstr "Albo #"
 msgid "Current"
 msgstr "Attuale"
 
-#: reading_lists/templates/reading_lists/add_issue_autocomplete.html:195
-msgid "New"
-msgstr "Nuovo"
-
 #: reading_lists/templates/reading_lists/add_issues_from_arc.html:3
+#, python-format
 msgid "Add from Story Arc - %(name)s - Metron"
 msgstr "Aggiungi da Arco Narrativo - %(name)s - Metron"
 
@@ -987,6 +4219,7 @@ msgstr ""
 "ordine! Puoi combinare più archi per costruire ordini di lettura completi."
 
 #: reading_lists/templates/reading_lists/add_issues_from_series.html:3
+#, python-format
 msgid "Add from Series - %(name)s - Metron"
 msgstr "Aggiungi dalla Serie - %(name)s - Metron"
 
@@ -1047,15 +4280,8 @@ msgstr ""
 msgid "Private"
 msgstr "Privato"
 
-#: reading_lists/templates/reading_lists/partials/readinglist_card.html:25
-#: reading_lists/templates/reading_lists/readinglist_detail.html:333
-#: reading_lists/templates/reading_lists/readinglist_detail.html:381
-msgid "%(counter)s issue"
-msgid_plural "%(counter)s issues"
-msgstr[0] "%(counter)s albo"
-msgstr[1] "%(counter)s albi"
-
 #: reading_lists/templates/reading_lists/partials/readinglist_card.html:48
+#, python-format
 msgid "By <strong>%(username)s</strong>"
 msgstr "Di <strong>%(username)s</strong>"
 
@@ -1064,6 +4290,7 @@ msgid "No description"
 msgstr "Nessuna descrizione"
 
 #: reading_lists/templates/reading_lists/partials/readinglist_card.html:64
+#, python-format
 msgid "Updated %(timesince)s ago"
 msgstr "Aggiornato %(timesince)s fa"
 
@@ -1071,33 +4298,13 @@ msgstr "Aggiornato %(timesince)s fa"
 msgid "Search Reading Lists"
 msgstr "Cerca Liste di Lettura"
 
-#: reading_lists/templates/reading_lists/partials/readinglist_filter.html:18
-#: user_collection/templates/user_collection/partials/collection_filter.html:18
-msgid "Filters Active"
-msgstr "Filtri Attivi"
-
-#: reading_lists/templates/reading_lists/partials/readinglist_filter.html:24
-#: user_collection/templates/user_collection/partials/collection_filter.html:24
-msgid "Quick Search"
-msgstr "Ricerca Rapida"
-
 #: reading_lists/templates/reading_lists/partials/readinglist_filter.html:31
 msgid "Search by list name..."
 msgstr "Cerca per nome lista..."
 
-#: reading_lists/templates/reading_lists/partials/readinglist_filter.html:32
-#: user_collection/templates/user_collection/partials/collection_filter.html:32
-msgid "Quick search"
-msgstr "Ricerca rapida"
-
 #: reading_lists/templates/reading_lists/partials/readinglist_filter.html:37
 msgid "Search by reading list name"
 msgstr "Cerca per nome della lista di lettura"
-
-#: reading_lists/templates/reading_lists/partials/readinglist_filter.html:46
-#: user_collection/templates/user_collection/partials/collection_filter.html:46
-msgid "Advanced Filters"
-msgstr "Filtri Avanzati"
 
 #: reading_lists/templates/reading_lists/partials/readinglist_filter.html:53
 msgid "List Name"
@@ -1119,24 +4326,9 @@ msgstr "es. Metron"
 msgid "Filter by creator username"
 msgstr "Filtra per nome utente autore"
 
-#: reading_lists/templates/reading_lists/partials/readinglist_filter.html:96
-#: user_collection/templates/user_collection/partials/collection_filter.html:101
-msgid "e.g., Marvel"
-msgstr "es. Marvel"
-
-#: reading_lists/templates/reading_lists/partials/readinglist_filter.html:97
-#: user_collection/templates/user_collection/partials/collection_filter.html:102
-msgid "Filter by publisher"
-msgstr "Filtra per editore"
-
 #: reading_lists/templates/reading_lists/partials/readinglist_filter.html:110
 msgid "Filter by list type"
 msgstr "Filtra per tipo di lista"
-
-#: reading_lists/templates/reading_lists/partials/readinglist_filter.html:111
-#: user_collection/templates/user_collection/partials/collection_filter.html:76
-msgid "All Types"
-msgstr "Tutti i Tipi"
 
 #: reading_lists/templates/reading_lists/partials/readinglist_filter.html:129
 msgid "Attribution Source"
@@ -1208,26 +4400,6 @@ msgstr "Tutte le Liste"
 msgid "Public"
 msgstr "Pubblico"
 
-#: reading_lists/templates/reading_lists/partials/readinglist_filter.html:223
-#: user_collection/templates/user_collection/partials/collection_filter.html:246
-msgid "Apply Filters"
-msgstr "Applica Filtri"
-
-#: reading_lists/templates/reading_lists/partials/readinglist_filter.html:229
-#: user_collection/templates/user_collection/partials/collection_filter.html:252
-msgid "Clear all filters"
-msgstr "Cancella tutti i filtri"
-
-#: reading_lists/templates/reading_lists/partials/readinglist_filter.html:233
-#: user_collection/templates/user_collection/partials/collection_filter.html:256
-msgid "Clear Filters"
-msgstr "Cancella Filtri"
-
-#: reading_lists/templates/reading_lists/partials/readinglist_item.html:22
-#: reading_lists/templates/reading_lists/partials/readinglist_item_edit.html:22
-msgid "No image for %(issue)s"
-msgstr "Nessuna immagine per %(issue)s"
-
 #: reading_lists/templates/reading_lists/partials/readinglist_item.html:52
 msgid "Edit issue type"
 msgstr "Modifica tipo di albo"
@@ -1245,16 +4417,8 @@ msgstr "-- Nessun Tipo --"
 msgid "Core"
 msgstr "Principale"
 
-#: reading_lists/templates/reading_lists/partials/readinglist_item_edit.html:58
-msgid "Save"
-msgstr "Salva"
-
-#: reading_lists/templates/reading_lists/partials/readinglist_item_list.html:14
-#: reading_lists/templates/reading_lists/readinglist_detail.html:232
-msgid "Load More Issues"
-msgstr "Carica Altri Albi"
-
 #: reading_lists/templates/reading_lists/readinglist_confirm_assign_metron.html:3
+#, python-format
 msgid "Assign %(name)s to Metron - Metron"
 msgstr "Assegna %(name)s a Metron - Metron"
 
@@ -1286,6 +4450,7 @@ msgid "Assign to Metron"
 msgstr "Assegna a Metron"
 
 #: reading_lists/templates/reading_lists/readinglist_confirm_delete.html:3
+#, python-format
 msgid "Delete %(name)s - Metron"
 msgstr "Elimina %(name)s - Metron"
 
@@ -1293,13 +4458,8 @@ msgstr "Elimina %(name)s - Metron"
 msgid "Delete Reading List"
 msgstr "Elimina Lista di Lettura"
 
-#: reading_lists/templates/reading_lists/readinglist_confirm_delete.html:15
-#: user_collection/templates/user_collection/collection_confirm_delete.html:15
-#: wish_list/templates/wish_list/wishlist_item_confirm_delete.html:15
-msgid "Warning"
-msgstr "Attenzione"
-
 #: reading_lists/templates/reading_lists/readinglist_confirm_delete.html:19
+#, python-format
 msgid "Are you sure you want to delete the reading list <strong>\"%(name)s\"</strong>?"
 msgstr ""
 "Sei sicuro di voler eliminare la lista di lettura <strong>\"%(name)s\"</strong>?"
@@ -1321,12 +4481,14 @@ msgid "Curated by"
 msgstr "Curata da"
 
 #: reading_lists/templates/reading_lists/readinglist_detail.html:48
+#, python-format
 msgid "%(avg)s &middot; %(counter)s rating"
 msgid_plural "%(avg)s &middot; %(counter)s ratings"
 msgstr[0] "%(avg)s &middot; %(counter)s valutazione"
 msgstr[1] "%(avg)s &middot; %(counter)s valutazioni"
 
 #: reading_lists/templates/reading_lists/readinglist_detail.html:51
+#: templates/partials/rating_widget.html:31
 msgid "No ratings yet"
 msgstr "Nessuna valutazione ancora"
 
@@ -1342,31 +4504,13 @@ msgstr "Condividi"
 msgid "Rate this list"
 msgstr "Valuta questa lista"
 
-#: reading_lists/templates/reading_lists/readinglist_detail.html:84
-#: templates/partials/navbar.html:80
-#: user_collection/templates/user_collection/collection_stats.html:227
-#: users/templates/users/customuser_detail.html:241
-msgid "Issues"
-msgstr "Albi"
-
 #: reading_lists/templates/reading_lists/readinglist_detail.html:88
 msgid "Reading span"
 msgstr "Periodo di lettura"
 
-#: reading_lists/templates/reading_lists/readinglist_detail.html:96
-#: reading_lists/templates/reading_lists/readinglist_detail.html:327
-#: reading_lists/templates/reading_lists/readinglist_detail.html:344
-#: templates/partials/navbar.html:62 users/templates/users/customuser_detail.html:219
-msgid "Publishers"
-msgstr "Editori"
-
 #: reading_lists/templates/reading_lists/readinglist_detail.html:105
 msgid "Composition"
 msgstr "Composizione"
-
-#: reading_lists/templates/reading_lists/readinglist_detail.html:132
-msgid "Previous"
-msgstr "Precedente"
 
 #: reading_lists/templates/reading_lists/readinglist_detail.html:142
 msgid "Next"
@@ -1383,18 +4527,12 @@ msgstr "Aggiungi dalla Serie"
 msgid "Add from Arc"
 msgstr "Aggiungi da Arco"
 
-#: reading_lists/templates/reading_lists/readinglist_detail.html:173
-#: user_collection/templates/user_collection/collection_detail.html:27
-#: user_collection/templates/user_collection/collection_list.html:132
-#: wish_list/templates/wish_list/wishlist_detail.html:123
-msgid "Edit"
-msgstr "Modifica"
-
 #: reading_lists/templates/reading_lists/readinglist_detail.html:197
 msgid "About this list"
 msgstr "Informazioni su questa lista"
 
 #: reading_lists/templates/reading_lists/readinglist_detail.html:203
+#, python-format
 msgid "Issues (%(count)s)"
 msgstr "Albi (%(count)s)"
 
@@ -1414,10 +4552,6 @@ msgstr "Dettagli Lista"
 #: reading_lists/templates/reading_lists/readinglist_detail.html:266
 msgid "Owner:"
 msgstr "Proprietario:"
-
-#: reading_lists/templates/reading_lists/readinglist_detail.html:270
-msgid "Type:"
-msgstr "Tipo:"
 
 #: reading_lists/templates/reading_lists/readinglist_detail.html:272
 msgid "Visibility:"
@@ -1462,17 +4596,12 @@ msgstr "Cancella selezione"
 msgid "My Reading Lists"
 msgstr "Le Mie Liste di Lettura"
 
-#: reading_lists/templates/reading_lists/readinglist_list.html:3
-#: reading_lists/templates/reading_lists/readinglist_list.html:6
-#: templates/partials/navbar.html:119
-msgid "Reading Lists"
-msgstr "Liste di Lettura"
-
 #: reading_lists/templates/reading_lists/readinglist_list.html:21
 msgid "Reading list navigation"
 msgstr "Navigazione lista di lettura"
 
 #: reading_lists/templates/reading_lists/readinglist_list.html:25
+#, python-format
 msgid "<strong>%(formatted_count)s</strong> reading list"
 msgid_plural "<strong>%(formatted_count)s</strong> reading lists"
 msgstr[0] "<strong>%(formatted_count)s</strong> lista di lettura"
@@ -1498,21 +4627,6 @@ msgstr "Non hai ancora nessuna lista di lettura"
 msgid "Create your first reading list!"
 msgstr "Crea la tua prima lista di lettura!"
 
-#: reading_lists/templates/reading_lists/readinglist_list.html:72
-#: user_collection/templates/user_collection/collection_list.html:157
-msgid "No results found"
-msgstr "Nessun risultato trovato"
-
-#: reading_lists/templates/reading_lists/readinglist_list.html:73
-#: user_collection/templates/user_collection/collection_list.html:158
-msgid "Try adjusting your search filters"
-msgstr "Prova a modificare i filtri di ricerca"
-
-#: reading_lists/templates/reading_lists/readinglist_list.html:76
-#: user_collection/templates/user_collection/collection_list.html:162
-msgid "Clear All Filters"
-msgstr "Cancella Tutti i Filtri"
-
 #: reading_lists/templates/reading_lists/readinglist_list.html:79
 msgid "No reading lists found"
 msgstr "Nessuna lista di lettura trovata"
@@ -1530,21 +4644,9 @@ msgid "Remove Issue from Reading List"
 msgstr "Rimuovi Albo dalla Lista di Lettura"
 
 #: reading_lists/templates/reading_lists/remove_issue_confirm.html:16
+#, python-format
 msgid "Remove <strong>%(issue)s</strong> from <strong>%(name)s</strong>?"
 msgstr "Rimuovere <strong>%(issue)s</strong> da <strong>%(name)s</strong>?"
-
-#: reading_lists/views.py:43 users/templates/users/customuser_list.html:37
-#: users/templates/users/customuser_list.html:41
-msgid "Search"
-msgstr "Cerca"
-
-#: reading_lists/views.py:44 users/templates/users/api_token.html:85
-msgid "Name"
-msgstr "Nome"
-
-#: reading_lists/views.py:48
-msgid "Attribution"
-msgstr "Attribuzione"
 
 #: reading_lists/views.py:49
 msgid "Min Rating"
@@ -1597,14 +4699,17 @@ msgid "Ownership of '%(name)s' has been reassigned to Metron."
 msgstr "La proprietà di '%(name)s' è stata riassegnata a Metron."
 
 #: reading_lists/views.py:620
+#, python-format
 msgid "Removed %(issue)s from '%(name)s'!"
 msgstr "Rimosso %(issue)s da '%(name)s'!"
 
 #: reading_lists/views.py:695
+#, python-format
 msgid "Added %(issue)s"
 msgstr "Aggiunto %(issue)s"
 
 #: reading_lists/views.py:698
+#, python-format
 msgid "Added %(count)d issue"
 msgid_plural "Added %(count)d issues"
 msgstr[0] "Aggiunto %(count)d albo"
@@ -1618,6 +4723,7 @@ msgstr[0] "riordinato %(count)d albo esistente"
 msgstr[1] "riordinati %(count)d albi esistenti"
 
 #: reading_lists/views.py:714
+#, python-format
 msgid "%(first)s and %(second)s"
 msgstr "%(first)s e %(second)s"
 
@@ -1627,6 +4733,7 @@ msgid "%(summary)s in '%(name)s'!"
 msgstr "%(summary)s in '%(name)s'!"
 
 #: reading_lists/views.py:730
+#, python-format
 msgid "Skipped %(count)d duplicate issue."
 msgid_plural "Skipped %(count)d duplicate issues."
 msgstr[0] "Saltato %(count)d albo duplicato."
@@ -1637,6 +4744,7 @@ msgid "No changes were made."
 msgstr "Nessuna modifica effettuata."
 
 #: reading_lists/views.py:778
+#, python-format
 msgid "No new issues to add. All issues from %(series)s are already in the list."
 msgstr ""
 "Nessun nuovo albo da aggiungere. Tutti gli albi di %(series)s sono già nella lista."
@@ -1675,10 +4783,75 @@ msgid_plural "Added %(count)d issues from %(arc)s at the end of '%(name)s'!"
 msgstr[0] "Aggiunto %(count)d albo da %(arc)s alla fine di '%(name)s'!"
 msgstr[1] "Aggiunti %(count)d albi da %(arc)s alla fine di '%(name)s'!"
 
-#: templates/base.html:9 users/templates/registration/account_activation_email.html:210
-#: users/templates/registration/account_activation_email.txt:21
-msgid "Metron Comic Book Database"
-msgstr "Database Fumetti Metron"
+#: templates/404.html:4 templates/500.html:4
+msgid "Page Not Found - Metron"
+msgstr "Pagina Non Trovata - Metron"
+
+#: templates/404.html:16 templates/500.html:16
+msgid "Page Not Found"
+msgstr "Pagina Non Trovata"
+
+#: templates/404.html:24 templates/500.html:24
+msgid ""
+"Sorry, we couldn't find the page you're looking for. It might have been moved, "
+"deleted, or never existed."
+msgstr ""
+"Siamo spiacenti, non siamo riusciti a trovare la pagina che stai cercando. Potrebbe "
+"essere stata spostata, eliminata o non essere mai esistita."
+
+#: templates/404.html:32 templates/500.html:32
+#: users/templates/registration/account_activation_invalid.html:35
+#: users/templates/registration/account_activation_sent.html:32
+#: users/templates/registration/password_change_done.html:30
+#: users/templates/registration/signup_rate_limited.html:30
+#: users/templates/registration/signups_disabled.html:28
+msgid "Go to Home"
+msgstr "Vai alla Home"
+
+#: templates/404.html:38 templates/500.html:38
+msgid "Go Back"
+msgstr "Torna Indietro"
+
+#: templates/404.html:45 templates/500.html:45
+msgid "You might want to:"
+msgstr "Potresti voler:"
+
+#: templates/404.html:48 templates/500.html:48
+msgid "Check the URL for typos"
+msgstr "Controlla l'URL per errori di battitura"
+
+#: templates/404.html:49 templates/500.html:49
+msgid "Use the search feature to find what you're looking for"
+msgstr "Usa la funzione di ricerca per trovare quello che stai cercando"
+
+#: templates/404.html:54 templates/500.html:54
+#, python-format
+msgid ""
+"Browse our <a href=\"%(issue_list_url)s\">issues</a>, <a "
+"href=\"%(series_list_url)s\">series</a>, or <a "
+"href=\"%(character_list_url)s\">characters</a>"
+msgstr ""
+"Sfoglia i nostri <a href=\"%(issue_list_url)s\">albi</a>, <a "
+"href=\"%(series_list_url)s\">serie</a> o <a "
+"href=\"%(character_list_url)s\">personaggi</a>"
+
+#: templates/404.html:58 templates/500.html:58
+#, python-format
+msgid "Return to the <a href=\"%(home_url)s\">homepage</a>"
+msgstr "Torna alla <a href=\"%(home_url)s\">homepage</a>"
+
+#: templates/404.html:65 templates/500.html:65
+msgid "Still need help?"
+msgstr "Hai ancora bisogno di aiuto?"
+
+#: templates/404.html:66 templates/500.html:66
+msgid "If you believe this is an error, please let us know:"
+msgstr "Se ritieni che questo sia un errore, faccelo sapere:"
+
+#: templates/404.html:75 templates/500.html:75
+#: users/templates/registration/account_activation_invalid.html:87
+msgid "Report Issue"
+msgstr "Segnala un Problema"
 
 #: templates/base.html:13
 msgid ""
@@ -1692,10 +4865,20 @@ msgstr ""
 msgid "comics, comic books, database, Marvel, DC, creators, characters"
 msgstr "fumetti, albi, database, Marvel, DC, autori, personaggi"
 
-#: templates/partials/footer.html:10
-#: users/templates/registration/account_activation_email.html:229
-msgid "Contact Us"
-msgstr "Contattaci"
+#: templates/django/forms/widgets/clearable_file_input.html:65
+#: templates/django/forms/widgets/clearable_file_input.html:72
+#: templates/django/forms/widgets/clearable_file_input.html:85
+#: templates/django/forms/widgets/clearable_file_input.html:92
+msgid "No file selected"
+msgstr "Nessun file selezionato"
+
+#: templates/django/forms/widgets/clearable_file_input.html:70
+msgid "Choose new file…"
+msgstr "Scegli un nuovo file…"
+
+#: templates/django/forms/widgets/clearable_file_input.html:90
+msgid "Choose a file…"
+msgstr "Scegli un file…"
 
 #: templates/partials/footer.html:11
 msgid "Contact links"
@@ -1713,18 +4896,9 @@ msgstr "Email all'Amministratore"
 msgid "Join our Matrix chat"
 msgstr "Unisciti alla nostra chat Matrix"
 
-#: templates/partials/footer.html:32
-msgid "Matrix Chat"
-msgstr "Chat Matrix"
-
 #: templates/partials/footer.html:40
 msgid "Join GitHub discussions"
 msgstr "Partecipa alle discussioni su GitHub"
-
-#: templates/partials/footer.html:44
-#: users/templates/registration/account_activation_sent.html:73
-msgid "GitHub Discussions"
-msgstr "Discussioni GitHub"
 
 #: templates/partials/footer.html:55
 msgid "Built with"
@@ -1751,12 +4925,6 @@ msgstr ", salvo dove diversamente indicato."
 msgid "Creative Commons License"
 msgstr "Licenza Creative Commons"
 
-#: templates/partials/footer.html:95
-#: users/templates/registration/account_activation_email.html:236
-#, python-format
-msgid "&copy; %(current_year)s Metron Project. All rights reserved."
-msgstr "&copy; %(current_year)s Metron Project. Tutti i diritti riservati."
-
 #: templates/partials/messages.html:13
 msgid "close notification"
 msgstr "chiudi notifica"
@@ -1768,10 +4936,6 @@ msgstr "navigazione principale"
 #: templates/partials/navbar.html:10
 msgid "Metron home"
 msgstr "Home di Metron"
-
-#: templates/partials/navbar.html:12
-msgid "Metron logo"
-msgstr "Logo Metron"
 
 #: templates/partials/navbar.html:18
 msgid "menu"
@@ -1796,22 +4960,6 @@ msgstr "Future"
 #: templates/partials/navbar.html:56
 msgid "Browse"
 msgstr "Esplora"
-
-#: templates/partials/navbar.html:68 users/templates/users/customuser_detail.html:285
-msgid "Imprints"
-msgstr "Etichette"
-
-#: templates/partials/navbar.html:87 users/templates/users/customuser_detail.html:263
-msgid "Creators"
-msgstr "Autori"
-
-#: templates/partials/navbar.html:106
-msgid "Story Arcs"
-msgstr "Archi Narrativi"
-
-#: templates/partials/navbar.html:112 users/templates/users/customuser_detail.html:307
-msgid "Universes"
-msgstr "Universi"
 
 #: templates/partials/navbar.html:126
 msgid "My Library"
@@ -1893,6 +5041,264 @@ msgstr "Registrati"
 #: templates/partials/navbar.html:273
 msgid "Log in to your account"
 msgstr "Accedi al tuo account"
+
+#: templates/partials/rating_summary.html:25 templates/partials/rating_widget.html:28
+#, python-format
+msgid "%(avg)s (%(counter)s rating)"
+msgid_plural "%(avg)s (%(counter)s ratings)"
+msgstr[0] "%(avg)s (%(counter)s recensione)"
+msgstr[1] "%(avg)s (%(counter)s recensioni)"
+
+#: templates/partials/rating_widget.html:19
+msgid "Average Rating:"
+msgstr "Valutazione Media:"
+
+#: templates/partials/rating_widget.html:37
+msgid "Your Rating:"
+msgstr "La Tua Valutazione:"
+
+#: templates/partials/rating_widget.html:46
+#: user_collection/templates/user_collection/partials/star_rating.html:10
+#, python-format
+msgid "Rate %(counter)s star"
+msgid_plural "Rate %(counter)s stars"
+msgstr[0] "Vota %(counter)s stella"
+msgstr[1] "Vota %(counter)s stelle"
+
+#: templates/partials/rating_widget.html:57
+#: user_collection/templates/user_collection/partials/star_rating.html:21
+msgid "Clear rating"
+msgstr "Cancella valutazione"
+
+#: templates/partials/social_meta.html:12 templates/partials/social_meta.html:23
+msgid "A community-based comic book database."
+msgstr "Un database di fumetti gestito dalla community."
+
+#: templates/partials/social_meta.html:16
+msgid "An image of the New God Metron seated and pondering the universe."
+msgstr "Un'immagine del Nuovo Dio Metron seduto a riflettere sull'universo."
+
+#: templates/registration/login.html:5
+msgid "Login - Metron"
+msgstr "Accedi - Metron"
+
+#: templates/registration/login.html:13
+msgid "Login to Metron"
+msgstr "Accedi a Metron"
+
+#: templates/registration/login.html:14
+msgid "Access your account to contribute to the database"
+msgstr "Accedi al tuo account per contribuire al database"
+
+#: templates/registration/login.html:57
+msgid "Login"
+msgstr "Accedi"
+
+#: templates/registration/login.html:68
+msgid "Forgot your password?"
+msgstr "Hai dimenticato la password?"
+
+#: templates/registration/login.html:77
+msgid "Don't have an account?"
+msgstr "Non hai un account?"
+
+#: templates/registration/login.html:78
+msgid "Sign up here"
+msgstr "Registrati qui"
+
+#: templates/registration/password_reset_complete.html:4
+msgid "Password Reset Complete - Metron"
+msgstr "Reimpostazione Password Completata - Metron"
+
+#: templates/registration/password_reset_complete.html:12
+msgid "Password Reset Complete"
+msgstr "Reimpostazione Password Completata"
+
+#: templates/registration/password_reset_complete.html:20
+#: users/templates/registration/password_change_done.html:20
+msgid "Your password has been successfully changed!"
+msgstr "La tua password è stata modificata con successo!"
+
+#: templates/registration/password_reset_complete.html:21
+msgid "You can now log in with your new password."
+msgstr "Ora puoi accedere con la tua nuova password."
+
+#: templates/registration/password_reset_complete.html:30
+msgid "Go to Login Page"
+msgstr "Vai alla Pagina di Accesso"
+
+#: templates/registration/password_reset_complete.html:41
+#: users/templates/registration/password_change_done.html:48
+msgid "Security Tip"
+msgstr "Suggerimento di Sicurezza"
+
+#: templates/registration/password_reset_complete.html:45
+#: users/templates/registration/password_change_done.html:52
+msgid "Keep your password secure and don't share it with anyone"
+msgstr "Mantieni la tua password sicura e non condividerla con nessuno"
+
+#: templates/registration/password_reset_complete.html:46
+#: users/templates/registration/password_change_done.html:53
+msgid "Use a unique password for Metron"
+msgstr "Usa una password unica per Metron"
+
+#: templates/registration/password_reset_complete.html:47
+#: users/templates/registration/password_change_done.html:54
+msgid "Consider using a password manager"
+msgstr "Considera l'uso di un gestore di password"
+
+#: templates/registration/password_reset_complete.html:48
+#: users/templates/registration/password_change_done.html:55
+msgid "Change your password periodically for better security"
+msgstr "Cambia la tua password periodicamente per una maggiore sicurezza"
+
+#: templates/registration/password_reset_confirm.html:5
+msgid "Set New Password - Metron"
+msgstr "Imposta Nuova Password - Metron"
+
+#: templates/registration/password_reset_confirm.html:13
+msgid "Set Your New Password"
+msgstr "Imposta la Tua Nuova Password"
+
+#: templates/registration/password_reset_confirm.html:14
+msgid "Choose a strong password for your account"
+msgstr "Scegli una password sicura per il tuo account"
+
+#: templates/registration/password_reset_confirm.html:53
+#: users/templates/registration/password_change_form.html:53
+#: users/templates/users/customuser_detail.html:31
+msgid "Change Password"
+msgstr "Cambia Password"
+
+#: templates/registration/password_reset_confirm.html:61
+#: users/templates/registration/password_change_form.html:65
+msgid "Password Requirements:"
+msgstr "Requisiti della Password:"
+
+#: templates/registration/password_reset_confirm.html:63
+#: users/templates/registration/password_change_form.html:69
+msgid "Your password can't be too similar to your other personal information"
+msgstr ""
+"La tua password non può essere troppo simile alle tue altre informazioni personali"
+
+#: templates/registration/password_reset_confirm.html:64
+#: users/templates/registration/password_change_form.html:70
+msgid "Your password must contain at least 8 characters"
+msgstr "La tua password deve contenere almeno 8 caratteri"
+
+#: templates/registration/password_reset_confirm.html:65
+#: users/templates/registration/password_change_form.html:71
+msgid "Your password can't be a commonly used password"
+msgstr "La tua password non può essere una password comunemente usata"
+
+#: templates/registration/password_reset_confirm.html:66
+#: users/templates/registration/password_change_form.html:72
+msgid "Your password can't be entirely numeric"
+msgstr "La tua password non può essere interamente numerica"
+
+#: templates/registration/password_reset_done.html:4
+msgid "Reset Email Sent - Metron"
+msgstr "Email di Reimpostazione Inviata - Metron"
+
+#: templates/registration/password_reset_done.html:12
+msgid "Check Your Inbox"
+msgstr "Controlla la Tua Casella di Posta"
+
+#: templates/registration/password_reset_done.html:20
+msgid "We've sent password reset instructions to your email address."
+msgstr ""
+"Abbiamo inviato le istruzioni per la reimpostazione della password al tuo indirizzo "
+"email."
+
+#: templates/registration/password_reset_done.html:21
+msgid "You should receive the email within a few minutes."
+msgstr "Dovresti ricevere l'email entro pochi minuti."
+
+#: templates/registration/password_reset_done.html:30
+#: templates/registration/password_reset_form.html:52
+msgid "Back to Login"
+msgstr "Torna al Login"
+
+#: templates/registration/password_reset_done.html:37
+#: users/templates/registration/account_activation_sent.html:43
+msgid "Didn't receive the email?"
+msgstr "Non hai ricevuto l'email?"
+
+#: templates/registration/password_reset_done.html:39
+#: users/templates/registration/account_activation_sent.html:47
+msgid "Check your spam or junk folder"
+msgstr "Controlla la cartella spam o posta indesiderata"
+
+#: templates/registration/password_reset_done.html:40
+#: users/templates/registration/account_activation_sent.html:48
+msgid "Make sure you entered the correct email address"
+msgstr "Assicurati di aver inserito l'indirizzo email corretto"
+
+#: templates/registration/password_reset_done.html:41
+#: users/templates/registration/account_activation_sent.html:49
+msgid "Wait a few minutes - emails can be delayed"
+msgstr "Attendi qualche minuto - le email possono essere in ritardo"
+
+#: templates/registration/password_reset_done.html:44
+#, python-format
+msgid "Try the <a href=\"%(password_reset_url)s\">password reset</a> again"
+msgstr "Riprova la <a href=\"%(password_reset_url)s\">reimpostazione della password</a>"
+
+#: templates/registration/password_reset_done.html:50
+#: users/templates/registration/account_activation_invalid.html:70
+msgid "Still having trouble?"
+msgstr "Hai ancora problemi?"
+
+#: templates/registration/password_reset_done.html:51
+msgid "Contact us for assistance"
+msgstr "Contattaci per assistenza"
+
+#: templates/registration/password_reset_done.html:58
+#: users/templates/registration/account_activation_invalid.html:78
+#: users/templates/registration/account_activation_sent.html:64
+msgid "Contact Support"
+msgstr "Contatta il Supporto"
+
+#: templates/registration/password_reset_form.html:5
+msgid "Password Reset - Metron"
+msgstr "Reimpostazione Password - Metron"
+
+#: templates/registration/password_reset_form.html:13
+msgid "Reset Your Password"
+msgstr "Reimposta la Tua Password"
+
+#: templates/registration/password_reset_form.html:14
+msgid "Enter your email address and we'll send you reset instructions"
+msgstr ""
+"Inserisci il tuo indirizzo email e ti invieremo le istruzioni per la reimpostazione"
+
+#: templates/registration/password_reset_form.html:24
+msgid "Email Address"
+msgstr "Indirizzo Email"
+
+#: templates/registration/password_reset_form.html:41
+msgid "Send Reset Instructions"
+msgstr "Invia Istruzioni di Reimpostazione"
+
+#: templates/registration/password_reset_form.html:60
+msgid "What happens next?"
+msgstr "Cosa succede dopo?"
+
+#: templates/registration/password_reset_form.html:62
+msgid "We'll send an email to the address you provided"
+msgstr "Invieremo un'email all'indirizzo che hai fornito"
+
+#: templates/registration/password_reset_form.html:63
+msgid "Check your inbox (and spam folder)"
+msgstr "Controlla la tua casella di posta (e la cartella spam)"
+
+#: templates/registration/password_reset_form.html:64
+msgid "Follow the link in the email to reset your password"
+msgstr "Segui il link nell'email per reimpostare la tua password"
+
+#: templates/registration/password_reset_form.html:65
+msgid "The link expires in 24 hours"
+msgstr "Il link scade tra 24 ore"
 
 #: timeline/templates/timeline.html:4
 msgid "Timeline"
@@ -2151,11 +5557,6 @@ msgstr "0.5 (PR - Scadente)"
 msgid "Print"
 msgstr "Cartaceo"
 
-#: user_collection/models.py:48
-#: user_collection/templates/user_collection/collection_stats.html:201
-msgid "Digital"
-msgstr "Digitale"
-
 #: user_collection/models.py:49
 #: user_collection/templates/user_collection/collection_stats.html:203
 msgid "Both"
@@ -2340,19 +5741,6 @@ msgstr "Informazioni Albo"
 msgid "Issue:"
 msgstr "Albo:"
 
-#: user_collection/templates/user_collection/collection_detail.html:67
-msgid "Series:"
-msgstr "Serie:"
-
-#: user_collection/templates/user_collection/collection_detail.html:71
-#: user_collection/templates/user_collection/missing_issues_detail.html:35
-msgid "Publisher:"
-msgstr "Editore:"
-
-#: user_collection/templates/user_collection/collection_detail.html:75
-msgid "Cover Date:"
-msgstr "Data di Copertina:"
-
 #: user_collection/templates/user_collection/collection_detail.html:90
 msgid "Grading Information"
 msgstr "Informazioni sulla Valutazione"
@@ -2424,10 +5812,6 @@ msgstr "Letto"
 msgid "Unread"
 msgstr "Non Letto"
 
-#: user_collection/templates/user_collection/collection_detail.html:177
-msgid "Rating:"
-msgstr "Valutazione:"
-
 #: user_collection/templates/user_collection/collection_detail.html:181
 msgid "Read History:"
 msgstr "Cronologia Letture:"
@@ -2489,10 +5873,6 @@ msgstr "Cronologia Letture"
 msgid "Missing Issues"
 msgstr "Albi Mancanti"
 
-#: user_collection/templates/user_collection/collection_list.html:44
-msgid "Add Issue"
-msgstr "Aggiungi Albo"
-
 #: user_collection/templates/user_collection/collection_list.html:67
 #: user_collection/templates/user_collection/partials/collection_filter.html:218
 msgid "Rating"
@@ -2501,11 +5881,6 @@ msgstr "Valutazione"
 #: user_collection/templates/user_collection/collection_list.html:68
 msgid "Quantity"
 msgstr "Quantità"
-
-#: user_collection/templates/user_collection/collection_list.html:70
-#: user_collection/templates/user_collection/missing_issues_list.html:45
-msgid "Actions"
-msgstr "Azioni"
 
 #: user_collection/templates/user_collection/collection_list.html:88
 msgid "User-assessed"
@@ -2606,10 +5981,6 @@ msgstr "Informazioni Serie"
 msgid "Series Type:"
 msgstr "Tipo di Serie:"
 
-#: user_collection/templates/user_collection/missing_issues_detail.html:44
-msgid "Volume:"
-msgstr "Volume:"
-
 #: user_collection/templates/user_collection/missing_issues_detail.html:52
 msgid "Collection Progress"
 msgstr "Progresso della Collezione"
@@ -2690,38 +6061,6 @@ msgstr "Cerca tra serie e note..."
 msgid "Search across series names and notes"
 msgstr "Cerca tra i nomi delle serie e le note"
 
-#: user_collection/templates/user_collection/partials/collection_filter.html:53
-msgid "Series Name"
-msgstr "Nome Serie"
-
-#: user_collection/templates/user_collection/partials/collection_filter.html:60
-msgid "e.g., Amazing Spider-Man"
-msgstr "es. Amazing Spider-Man"
-
-#: user_collection/templates/user_collection/partials/collection_filter.html:61
-msgid "Filter by series name"
-msgstr "Filtra per nome serie"
-
-#: user_collection/templates/user_collection/partials/collection_filter.html:70
-msgid "Series Type"
-msgstr "Tipo di Serie"
-
-#: user_collection/templates/user_collection/partials/collection_filter.html:75
-msgid "Filter by series type"
-msgstr "Filtra per tipo di serie"
-
-#: user_collection/templates/user_collection/partials/collection_filter.html:112
-msgid "Issue Number"
-msgstr "Numero Albo"
-
-#: user_collection/templates/user_collection/partials/collection_filter.html:119
-msgid "e.g., 1"
-msgstr "es. 1"
-
-#: user_collection/templates/user_collection/partials/collection_filter.html:120
-msgid "Filter by issue number"
-msgstr "Filtra per numero albo"
-
 #: user_collection/templates/user_collection/partials/collection_filter.html:133
 msgid "Filter by format"
 msgstr "Filtra per formato"
@@ -2773,14 +6112,6 @@ msgstr "Rimuovi data di lettura"
 msgid "Confirm Delete"
 msgstr "Conferma Eliminazione"
 
-#: user_collection/templates/user_collection/partials/read_dates_list.html:22
-#: users/templates/registration/password_change_form.html:26
-#: users/templates/registration/signup.html:30
-#: users/templates/users/change_profile.html:26
-#: users/templates/users/customuser_detail.html:486
-msgid "close"
-msgstr "chiudi"
-
 #: user_collection/templates/user_collection/partials/read_dates_list.html:28
 #, python-format
 msgid "Are you sure you want to remove the read date <strong>%(read_date)s</strong>?"
@@ -2814,17 +6145,6 @@ msgstr "Lascia vuoto per usare la data/ora corrente"
 #: user_collection/templates/user_collection/partials/read_dates_list.html:73
 msgid "Add Read Date"
 msgstr "Aggiungi Data di Lettura"
-
-#: user_collection/templates/user_collection/partials/star_rating.html:10
-#, python-format
-msgid "Rate %(counter)s star"
-msgid_plural "Rate %(counter)s stars"
-msgstr[0] "Vota %(counter)s stella"
-msgstr[1] "Vota %(counter)s stelle"
-
-#: user_collection/templates/user_collection/partials/star_rating.html:21
-msgid "Clear rating"
-msgstr "Cancella valutazione"
 
 #: user_collection/templates/user_collection/reading_history.html:4
 msgid "Reading History - Metron"
@@ -2879,11 +6199,6 @@ msgstr "Elemento della collezione aggiornato!"
 #: user_collection/views.py:168
 msgid "Item removed from your collection."
 msgstr "Elemento rimosso dalla tua collezione."
-
-#: user_collection/views.py:212 user_collection/views.py:229
-#: user_collection/views.py:243
-msgid "Unknown"
-msgstr "Sconosciuto"
 
 #: user_collection/views.py:217
 msgid "Issues by Publisher"
@@ -3102,15 +6417,6 @@ msgid "If you didn't create an account with Metron, you can safely ignore this e
 msgstr ""
 "Se non hai creato un account con Metron, puoi tranquillamente ignorare questa email."
 
-#: users/templates/registration/account_activation_email.html:216
-#: users/templates/registration/account_activation_email.txt:22
-msgid "A community-driven project for comic book enthusiasts"
-msgstr "Un progetto guidato dalla community per appassionati di fumetti"
-
-#: users/templates/registration/account_activation_email.html:223
-msgid "Visit Website"
-msgstr "Visita il Sito"
-
 #: users/templates/registration/account_activation_email.txt:6
 msgid "To complete your registration and activate your account, please visit:"
 msgstr "Per completare la registrazione e attivare il tuo account, visita:"
@@ -3122,11 +6428,6 @@ msgid ""
 msgstr ""
 "IMPORTANTE: Questo link scade tra 24 ore. Se non attivi il tuo account entro questo "
 "tempo, dovrai registrarti di nuovo."
-
-#: users/templates/registration/account_activation_email.txt:29
-#, python-format
-msgid "(c) %(current_year)s Metron Project. All rights reserved."
-msgstr "(c) %(current_year)s Metron Project. Tutti i diritti riservati."
 
 #: users/templates/registration/account_activation_invalid.html:4
 msgid "Invalid Confirmation Link - Metron"
@@ -3155,14 +6456,6 @@ msgstr "Il link è scaduto (i link sono validi per 24 ore)"
 #: users/templates/registration/account_activation_invalid.html:25
 msgid "The link was copied incorrectly"
 msgstr "Il link è stato copiato in modo errato"
-
-#: users/templates/registration/account_activation_invalid.html:35
-#: users/templates/registration/account_activation_sent.html:32
-#: users/templates/registration/password_change_done.html:30
-#: users/templates/registration/signup_rate_limited.html:30
-#: users/templates/registration/signups_disabled.html:28
-msgid "Go to Home"
-msgstr "Vai alla Home"
 
 #: users/templates/registration/account_activation_invalid.html:41
 msgid "Try Logging In"
@@ -3193,22 +6486,9 @@ msgstr ""
 msgid "Make sure you're using the most recent confirmation email"
 msgstr "Assicurati di utilizzare l'email di conferma più recente"
 
-#: users/templates/registration/account_activation_invalid.html:70
-msgid "Still having trouble?"
-msgstr "Hai ancora problemi?"
-
 #: users/templates/registration/account_activation_invalid.html:71
 msgid "Our support team is here to help"
 msgstr "Il nostro team di supporto è qui per aiutarti"
-
-#: users/templates/registration/account_activation_invalid.html:78
-#: users/templates/registration/account_activation_sent.html:64
-msgid "Contact Support"
-msgstr "Contatta il Supporto"
-
-#: users/templates/registration/account_activation_invalid.html:87
-msgid "Report Issue"
-msgstr "Segnala un Problema"
 
 #: users/templates/registration/account_activation_sent.html:4
 msgid "Confirmation Email Sent - Metron"
@@ -3235,22 +6515,6 @@ msgstr ""
 "Clicca il link nell'email per attivare il tuo account e completare il processo di "
 "registrazione."
 
-#: users/templates/registration/account_activation_sent.html:43
-msgid "Didn't receive the email?"
-msgstr "Non hai ricevuto l'email?"
-
-#: users/templates/registration/account_activation_sent.html:47
-msgid "Check your spam or junk folder"
-msgstr "Controlla la cartella spam o posta indesiderata"
-
-#: users/templates/registration/account_activation_sent.html:48
-msgid "Make sure you entered the correct email address"
-msgstr "Assicurati di aver inserito l'indirizzo email corretto"
-
-#: users/templates/registration/account_activation_sent.html:49
-msgid "Wait a few minutes - emails can be delayed"
-msgstr "Attendi qualche minuto - le email possono essere in ritardo"
-
 #: users/templates/registration/account_activation_sent.html:50
 msgid "The confirmation link is valid for 24 hours"
 msgstr "Il link di conferma è valido per 24 ore"
@@ -3271,10 +6535,6 @@ msgstr "Password Modificata - Metron"
 msgid "Password Changed Successfully"
 msgstr "Password Modificata con Successo"
 
-#: users/templates/registration/password_change_done.html:20
-msgid "Your password has been successfully changed!"
-msgstr "La tua password è stata modificata con successo!"
-
 #: users/templates/registration/password_change_done.html:21
 msgid "You can now continue using your account with the new password."
 msgstr "Ora puoi continuare a usare il tuo account con la nuova password."
@@ -3282,26 +6542,6 @@ msgstr "Ora puoi continuare a usare il tuo account con la nuova password."
 #: users/templates/registration/password_change_done.html:37
 msgid "View Profile"
 msgstr "Visualizza Profilo"
-
-#: users/templates/registration/password_change_done.html:48
-msgid "Security Tip"
-msgstr "Suggerimento di Sicurezza"
-
-#: users/templates/registration/password_change_done.html:52
-msgid "Keep your password secure and don't share it with anyone"
-msgstr "Mantieni la tua password sicura e non condividerla con nessuno"
-
-#: users/templates/registration/password_change_done.html:53
-msgid "Use a unique password for Metron"
-msgstr "Usa una password unica per Metron"
-
-#: users/templates/registration/password_change_done.html:54
-msgid "Consider using a password manager"
-msgstr "Considera l'uso di un gestore di password"
-
-#: users/templates/registration/password_change_done.html:55
-msgid "Change your password periodically for better security"
-msgstr "Cambia la tua password periodicamente per una maggiore sicurezza"
 
 #: users/templates/registration/password_change_form.html:5
 msgid "Change Password - Metron"
@@ -3315,32 +6555,6 @@ msgstr "Cambia la Tua Password"
 msgid "Update your account password"
 msgstr "Aggiorna la password del tuo account"
 
-#: users/templates/registration/password_change_form.html:53
-#: users/templates/users/customuser_detail.html:31
-msgid "Change Password"
-msgstr "Cambia Password"
-
-#: users/templates/registration/password_change_form.html:65
-msgid "Password Requirements:"
-msgstr "Requisiti della Password:"
-
-#: users/templates/registration/password_change_form.html:69
-msgid "Your password can't be too similar to your other personal information"
-msgstr ""
-"La tua password non può essere troppo simile alle tue altre informazioni personali"
-
-#: users/templates/registration/password_change_form.html:70
-msgid "Your password must contain at least 8 characters"
-msgstr "La tua password deve contenere almeno 8 caratteri"
-
-#: users/templates/registration/password_change_form.html:71
-msgid "Your password can't be a commonly used password"
-msgstr "La tua password non può essere una password comunemente usata"
-
-#: users/templates/registration/password_change_form.html:72
-msgid "Your password can't be entirely numeric"
-msgstr "La tua password non può essere interamente numerica"
-
 #: users/templates/registration/signup.html:5
 msgid "Sign Up - Metron"
 msgstr "Registrati - Metron"
@@ -3352,10 +6566,6 @@ msgstr "Unisciti a Metron"
 #: users/templates/registration/signup.html:17
 msgid "Create an account to contribute to the comic book database"
 msgstr "Crea un account per contribuire al database dei fumetti"
-
-#: users/templates/registration/signup.html:69
-msgid "Create Account"
-msgstr "Crea Account"
 
 #: users/templates/registration/signup.html:76
 msgid "Already have an account?"
@@ -3465,10 +6675,6 @@ msgstr "I Tuoi Token"
 #: users/templates/users/api_token.html:81
 msgid "Never"
 msgstr "Mai"
-
-#: users/templates/users/api_token.html:86
-msgid "Created"
-msgstr "Creato"
 
 #: users/templates/users/api_token.html:87
 msgid "Expires"
@@ -3730,10 +6936,6 @@ msgstr "Unisciti alla conversazione"
 msgid "Users - Metron"
 msgstr "Utenti - Metron"
 
-#: users/templates/users/customuser_list.html:13
-msgid "List navigation and actions"
-msgstr "Navigazione ed azioni elenco"
-
 #: users/templates/users/customuser_list.html:17
 #, python-format
 msgid "<strong>%(formatted_count)s</strong> User"
@@ -3868,11 +7070,6 @@ msgstr "Data di Acquisto"
 msgid "Additional notes"
 msgstr "Note aggiuntive"
 
-#: wish_list/models.py:23
-#: wish_list/templates/wish_list/partials/wish_list_button.html:11
-msgid "Wish List"
-msgstr "Lista dei Desideri"
-
 #: wish_list/models.py:24
 msgid "Wish Lists"
 msgstr "Liste dei Desideri"
@@ -3950,10 +7147,6 @@ msgstr "Elementi (%(count)s)"
 msgid "Priority"
 msgstr "Priorità"
 
-#: wish_list/templates/wish_list/wishlist_detail.html:84
-msgid "Status"
-msgstr "Stato"
-
 #: wish_list/templates/wish_list/wishlist_detail.html:85
 msgid "Min Grade"
 msgstr "Grado Min"
@@ -4021,3 +7214,15 @@ msgstr "%(issue)s segnato come acquisito! Aggiunto alla tua collezione."
 #, python-format
 msgid "%(issue)s marked as acquired! Already in your collection."
 msgstr "%(issue)s segnato come acquisito! Già nella tua collezione."
+
+#, python-format
+#~ msgid "<strong>%(counter|intcomma)s</strong> Issue"
+#~ msgid_plural "<strong>%(counter|intcomma)s</strong> Issues"
+#~ msgstr[0] "<strong>%(counter)s</strong> Albo"
+#~ msgstr[1] "<strong>%(counter)s</strong> Albi"
+
+#, python-format
+#~ msgid "%(counter|intcomma)s issue"
+#~ msgid_plural "%(counter|intcomma)s issues"
+#~ msgstr[0] "%(counter)s albo"
+#~ msgstr[1] "%(counter)s albi"

--- a/locale/it/LC_MESSAGES/django.po
+++ b/locale/it/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: metron\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-13 13:54-0400\n"
+"POT-Creation-Date: 2026-08-13 15:00-0400\n"
 "PO-Revision-Date: 2026-08-13 11:23-0400\n"
 "Last-Translator: Metron Project\n"
 "Language-Team: Italian\n"
@@ -317,6 +317,8 @@ msgstr "Elimina"
 #: user_collection/templates/user_collection/collection_confirm_delete.html:31
 #: user_collection/templates/user_collection/collection_form.html:72
 #: user_collection/templates/user_collection/partials/read_dates_list.html:38
+#: users/templates/users/change_profile.html:120
+#: users/templates/users/delete_account.html:44
 #: wish_list/templates/wish_list/wishlist_acquire_form.html:37
 #: wish_list/templates/wish_list/wishlist_item_confirm_delete.html:26
 #: wish_list/templates/wish_list/wishlist_item_form.html:50
@@ -441,6 +443,7 @@ msgstr "Cerca una serie..."
 #: templates/partials/navbar.html:74 user_collection/forms.py:132
 #: user_collection/templates/user_collection/collection_stats.html:226
 #: user_collection/templates/user_collection/missing_issues_list.html:40
+#: users/templates/users/customuser_detail.html:230
 #: wish_list/templates/wish_list/wishlist_detail.html:83
 msgid "Series"
 msgstr "Serie"
@@ -565,7 +568,8 @@ msgstr "%(series)s è già nella tua pull list."
 msgid "Removed %(series)s from your pull list."
 msgstr "Rimosso %(series)s dalla tua pull list."
 
-#: templates/base.html:9
+#: templates/base.html:9 users/templates/registration/account_activation_email.html:210
+#: users/templates/registration/account_activation_email.txt:21
 msgid "Metron Comic Book Database"
 msgstr "Database Fumetti Metron"
 
@@ -582,6 +586,7 @@ msgid "comics, comic books, database, Marvel, DC, creators, characters"
 msgstr "fumetti, albi, database, Marvel, DC, autori, personaggi"
 
 #: templates/partials/footer.html:10
+#: users/templates/registration/account_activation_email.html:229
 msgid "Contact Us"
 msgstr "Contattaci"
 
@@ -610,6 +615,7 @@ msgid "Join GitHub discussions"
 msgstr "Partecipa alle discussioni su GitHub"
 
 #: templates/partials/footer.html:44
+#: users/templates/registration/account_activation_sent.html:73
 msgid "GitHub Discussions"
 msgstr "Discussioni GitHub"
 
@@ -639,6 +645,7 @@ msgid "Creative Commons License"
 msgstr "Licenza Creative Commons"
 
 #: templates/partials/footer.html:95
+#: users/templates/registration/account_activation_email.html:236
 #, python-format
 msgid "&copy; %(current_year)s Metron Project. All rights reserved."
 msgstr "&copy; %(current_year)s Metron Project. Tutti i diritti riservati."
@@ -683,28 +690,29 @@ msgstr "Future"
 msgid "Browse"
 msgstr "Esplora"
 
-#: templates/partials/navbar.html:62
+#: templates/partials/navbar.html:62 users/templates/users/customuser_detail.html:219
 msgid "Publishers"
 msgstr "Editori"
 
-#: templates/partials/navbar.html:68
+#: templates/partials/navbar.html:68 users/templates/users/customuser_detail.html:285
 msgid "Imprints"
 msgstr "Etichette"
 
 #: templates/partials/navbar.html:80
 #: user_collection/templates/user_collection/collection_stats.html:227
+#: users/templates/users/customuser_detail.html:241
 msgid "Issues"
 msgstr "Albi"
 
-#: templates/partials/navbar.html:87
+#: templates/partials/navbar.html:87 users/templates/users/customuser_detail.html:263
 msgid "Creators"
 msgstr "Autori"
 
-#: templates/partials/navbar.html:93
+#: templates/partials/navbar.html:93 users/templates/users/customuser_detail.html:252
 msgid "Characters"
 msgstr "Personaggi"
 
-#: templates/partials/navbar.html:99
+#: templates/partials/navbar.html:99 users/templates/users/customuser_detail.html:274
 msgid "Teams"
 msgstr "Squadre"
 
@@ -712,7 +720,7 @@ msgstr "Squadre"
 msgid "Story Arcs"
 msgstr "Archi Narrativi"
 
-#: templates/partials/navbar.html:112
+#: templates/partials/navbar.html:112 users/templates/users/customuser_detail.html:307
 msgid "Universes"
 msgstr "Universi"
 
@@ -745,7 +753,7 @@ msgstr "La Mia Lista dei Desideri"
 msgid "More"
 msgstr "Altro"
 
-#: templates/partials/navbar.html:163
+#: templates/partials/navbar.html:163 users/templates/users/customuser_detail.html:498
 msgid "Wiki"
 msgstr "Wiki"
 
@@ -757,7 +765,7 @@ msgstr "Documentazione API"
 msgid "Statistics"
 msgstr "Statistiche"
 
-#: templates/partials/navbar.html:189
+#: templates/partials/navbar.html:189 users/templates/users/customuser_list.html:10
 msgid "Users"
 msgstr "Utenti"
 
@@ -1267,6 +1275,7 @@ msgstr ""
 "formato e note!"
 
 #: user_collection/templates/user_collection/collection_confirm_delete.html:3
+#, python-format
 msgid "Remove %(issue)s - Metron"
 msgstr "Rimuovi %(issue)s - Metron"
 
@@ -1281,6 +1290,7 @@ msgid "Warning"
 msgstr "Attenzione"
 
 #: user_collection/templates/user_collection/collection_confirm_delete.html:19
+#, python-format
 msgid "Are you sure you want to remove <strong>%(issue)s</strong> from your collection?"
 msgstr "Sei sicuro di voler rimuovere <strong>%(issue)s</strong> dalla tua collezione?"
 
@@ -1460,6 +1470,7 @@ msgid "My Comic Collection"
 msgstr "La Mia Collezione di Fumetti"
 
 #: user_collection/templates/user_collection/collection_list.html:14
+#, python-format
 msgid "<strong>%(counter)s</strong> item in your collection"
 msgid_plural "<strong>%(counter)s</strong> items in your collection"
 msgstr[0] "<strong>%(counter)s</strong> elemento nella tua collezione"
@@ -1592,6 +1603,7 @@ msgid "No series data available"
 msgstr "Nessun dato sulla serie disponibile"
 
 #: user_collection/templates/user_collection/missing_issues_detail.html:3
+#, python-format
 msgid "Missing Issues - %(name)s - Metron"
 msgstr "Albi Mancanti - %(name)s - Metron"
 
@@ -1625,6 +1637,7 @@ msgid "%(pct)s%% Complete"
 msgstr "%(pct)s%% Completato"
 
 #: user_collection/templates/user_collection/missing_issues_detail.html:64
+#, python-format
 msgid "%(counter)s issue missing"
 msgid_plural "%(counter)s issues missing"
 msgstr[0] "%(counter)s albo mancante"
@@ -1652,6 +1665,7 @@ msgid "Find gaps in your collection"
 msgstr "Trova le lacune nella tua collezione"
 
 #: user_collection/templates/user_collection/missing_issues_list.html:21
+#, python-format
 msgid "<strong>%(counter)s</strong> series with missing issues"
 msgid_plural "<strong>%(counter)s</strong> series with missing issues"
 msgstr[0] "<strong>%(counter)s</strong> serie con albi mancanti"
@@ -1798,6 +1812,7 @@ msgid "All Ratings"
 msgstr "Tutte le Valutazioni"
 
 #: user_collection/templates/user_collection/partials/collection_filter.html:226
+#, python-format
 msgid "%(counter)s Star"
 msgid_plural "%(counter)s Stars"
 msgstr[0] "%(counter)s Stella"
@@ -1824,10 +1839,15 @@ msgid "Confirm Delete"
 msgstr "Conferma Eliminazione"
 
 #: user_collection/templates/user_collection/partials/read_dates_list.html:22
+#: users/templates/registration/password_change_form.html:26
+#: users/templates/registration/signup.html:30
+#: users/templates/users/change_profile.html:26
+#: users/templates/users/customuser_detail.html:486
 msgid "close"
 msgstr "chiudi"
 
 #: user_collection/templates/user_collection/partials/read_dates_list.html:28
+#, python-format
 msgid "Are you sure you want to remove the read date <strong>%(read_date)s</strong>?"
 msgstr ""
 "Sei sicuro di voler rimuovere la data di lettura <strong>%(read_date)s</strong>?"
@@ -1838,6 +1858,7 @@ msgstr "Rimuovi Data di Lettura"
 
 #: user_collection/templates/user_collection/partials/read_dates_list.html:46
 #: user_collection/templates/user_collection/reading_history.html:83
+#, python-format
 msgid "Read %(counter)s time"
 msgid_plural "Read %(counter)s times"
 msgstr[0] "Letto %(counter)s volta"
@@ -1860,6 +1881,7 @@ msgid "Add Read Date"
 msgstr "Aggiungi Data di Lettura"
 
 #: user_collection/templates/user_collection/partials/star_rating.html:10
+#, python-format
 msgid "Rate %(counter)s star"
 msgid_plural "Rate %(counter)s stars"
 msgstr[0] "Vota %(counter)s stella"
@@ -1878,6 +1900,7 @@ msgid "My Reading History"
 msgstr "La Mia Cronologia di Lettura"
 
 #: user_collection/templates/user_collection/reading_history.html:15
+#, python-format
 msgid "<strong>%(counter)s</strong> issue read"
 msgid_plural "<strong>%(counter)s</strong> issues read"
 msgstr[0] "<strong>%(counter)s</strong> albo letto"
@@ -1888,6 +1911,7 @@ msgid "Date Unknown"
 msgstr "Data Sconosciuta"
 
 #: user_collection/templates/user_collection/reading_history.html:73
+#: users/templates/users/customuser_detail.html:442
 msgid "No cover available"
 msgstr "Copertina non disponibile"
 
@@ -1955,6 +1979,7 @@ msgid "Top Artists"
 msgstr "Migliori Disegnatori"
 
 #: user_collection/views.py:454
+#, python-format
 msgid "Added %(count)d issue to your collection"
 msgid_plural "Added %(count)d issues to your collection"
 msgstr[0] "Aggiunto %(count)d albo alla tua collezione"
@@ -1985,6 +2010,905 @@ msgstr "%(added)s!"
 #: user_collection/views.py:477
 msgid "All issues from this series are already in your collection."
 msgstr "Tutti gli albi di questa serie sono già nella tua collezione."
+
+#: users/forms.py:19
+msgid ""
+"Required. Enter a valid email address. Temporary email addresses are not allowed."
+msgstr ""
+"Obbligatorio. Inserisci un indirizzo email valido. Gli indirizzi email temporanei non "
+"sono ammessi."
+
+#: users/forms.py:42 users/forms.py:52 users/forms.py:67
+msgid "Email address is not valid."
+msgstr "L'indirizzo email non è valido."
+
+#: users/forms.py:46
+msgid "Email already exists"
+msgstr "L'email esiste già"
+
+#: users/forms.py:56 users/forms.py:65
+msgid "Temporary email addresses are not allowed."
+msgstr "Gli indirizzi email temporanei non sono ammessi."
+
+#: users/forms.py:61
+msgid "Error creating account. Contact the site administrator."
+msgstr "Errore nella creazione dell'account. Contatta l'amministratore del sito."
+
+#: users/forms.py:78
+msgid "Required. Enter a valid email address."
+msgstr "Obbligatorio. Inserisci un indirizzo email valido."
+
+#: users/forms.py:81
+msgid "Please provide valid email."
+msgstr "Fornisci un'email valida."
+
+#: users/models.py:13
+msgid "Mega Sponsor"
+msgstr "Mega Sponsor"
+
+#: users/models.py:14
+msgid "Sponsor"
+msgstr "Sponsor"
+
+#: users/models.py:15
+msgid "Backer"
+msgstr "Sostenitore"
+
+#: users/models.py:16
+msgid "Friend"
+msgstr "Amico"
+
+#: users/models.py:103
+msgid "New account signups are temporarily disabled. Please check back later."
+msgstr ""
+"Le registrazioni di nuovi account sono temporaneamente disabilitate. Riprova più "
+"tardi."
+
+#: users/models.py:107 users/models.py:108
+msgid "Signup settings"
+msgstr "Impostazioni di registrazione"
+
+#: users/models.py:148
+msgid "Donation amount in cents."
+msgstr "Importo della donazione in centesimi."
+
+#: users/models.py:154
+msgid "Monthly"
+msgstr "Mensile"
+
+#: users/models.py:155
+msgid "Yearly"
+msgstr "Annuale"
+
+#: users/models.py:156
+msgid "One-time"
+msgstr "Una tantum"
+
+#: users/models.py:158
+msgid "The underlying OpenCollective order's frequency."
+msgstr "La frequenza dell'ordine OpenCollective sottostante."
+
+#: users/templates/registration/account_activation_email.html:7 users/views.py:166
+msgid "Activate Your Metron Account"
+msgstr "Attiva il Tuo Account Metron"
+
+#: users/templates/registration/account_activation_email.html:48
+#: users/templates/registration/account_activation_email.txt:2
+#, python-format
+msgid "Welcome to Metron, %(username)s!"
+msgstr "Benvenuto su Metron, %(username)s!"
+
+#: users/templates/registration/account_activation_email.html:54
+#: users/templates/registration/account_activation_email.txt:4
+msgid ""
+"Thank you for joining the Metron Comic Book Database community! We're excited to have "
+"you as part of our growing community of comic book enthusiasts."
+msgstr ""
+"Grazie per esserti unito alla community di Metron Comic Book Database! Siamo felici "
+"di averti come parte della nostra crescente community di appassionati di fumetti."
+
+#: users/templates/registration/account_activation_email.html:60
+msgid ""
+"To complete your registration and activate your account, please click the button "
+"below:"
+msgstr ""
+"Per completare la registrazione e attivare il tuo account, clicca il pulsante qui "
+"sotto:"
+
+#: users/templates/registration/account_activation_email.html:77
+msgid "Activate My Account"
+msgstr "Attiva il Mio Account"
+
+#: users/templates/registration/account_activation_email.html:97
+msgid "Button not working?"
+msgstr "Il pulsante non funziona?"
+
+#: users/templates/registration/account_activation_email.html:97
+msgid "Copy and paste this link into your browser:"
+msgstr "Copia e incolla questo link nel tuo browser:"
+
+#: users/templates/registration/account_activation_email.html:123
+#: users/templates/registration/account_activation_email.txt:10
+msgid "What you can do with your Metron account:"
+msgstr "Cosa puoi fare con il tuo account Metron:"
+
+#: users/templates/registration/account_activation_email.html:134
+#: users/templates/registration/account_activation_email.txt:11
+msgid "Contribute to the comic book database by adding and editing information"
+msgstr "Contribuisci al database dei fumetti aggiungendo e modificando informazioni"
+
+#: users/templates/registration/account_activation_email.html:142
+#: users/templates/registration/account_activation_email.txt:12
+msgid "Access our comprehensive API for developers"
+msgstr "Accedi alla nostra API completa per sviluppatori"
+
+#: users/templates/registration/account_activation_email.html:150
+#: users/templates/registration/account_activation_email.txt:13
+msgid "Join discussions with fellow comic book fans"
+msgstr "Partecipa alle discussioni con altri appassionati di fumetti"
+
+#: users/templates/registration/account_activation_email.html:158
+#: users/templates/registration/account_activation_email.txt:14
+msgid "Help build the most accurate comic book database"
+msgstr "Aiuta a costruire il database di fumetti più accurato"
+
+#: users/templates/registration/account_activation_email.html:190
+msgid "This link expires in 24 hours."
+msgstr "Questo link scade tra 24 ore."
+
+#: users/templates/registration/account_activation_email.html:190
+msgid ""
+"If you don't activate your account within this time, you'll need to sign up again."
+msgstr "Se non attivi il tuo account entro questo tempo, dovrai registrarti di nuovo."
+
+#: users/templates/registration/account_activation_email.html:199
+#: users/templates/registration/account_activation_email.txt:18
+msgid "If you didn't create an account with Metron, you can safely ignore this email."
+msgstr ""
+"Se non hai creato un account con Metron, puoi tranquillamente ignorare questa email."
+
+#: users/templates/registration/account_activation_email.html:216
+#: users/templates/registration/account_activation_email.txt:22
+msgid "A community-driven project for comic book enthusiasts"
+msgstr "Un progetto guidato dalla community per appassionati di fumetti"
+
+#: users/templates/registration/account_activation_email.html:223
+msgid "Visit Website"
+msgstr "Visita il Sito"
+
+#: users/templates/registration/account_activation_email.txt:6
+msgid "To complete your registration and activate your account, please visit:"
+msgstr "Per completare la registrazione e attivare il tuo account, visita:"
+
+#: users/templates/registration/account_activation_email.txt:16
+msgid ""
+"IMPORTANT: This link expires in 24 hours. If you don't activate your account within "
+"this time, you'll need to sign up again."
+msgstr ""
+"IMPORTANTE: Questo link scade tra 24 ore. Se non attivi il tuo account entro questo "
+"tempo, dovrai registrarti di nuovo."
+
+#: users/templates/registration/account_activation_email.txt:29
+msgid "(c) %(current_year)s Metron Project. All rights reserved."
+msgstr "(c) %(current_year)s Metron Project. Tutti i diritti riservati."
+
+#: users/templates/registration/account_activation_invalid.html:4
+msgid "Invalid Confirmation Link - Metron"
+msgstr "Link di Conferma Non Valido - Metron"
+
+#: users/templates/registration/account_activation_invalid.html:12
+msgid "Invalid Confirmation Link"
+msgstr "Link di Conferma Non Valido"
+
+#: users/templates/registration/account_activation_invalid.html:20
+msgid "The confirmation link is invalid or has expired."
+msgstr "Il link di conferma non è valido o è scaduto."
+
+#: users/templates/registration/account_activation_invalid.html:21
+msgid "This may have happened because:"
+msgstr "Questo potrebbe essere successo perché:"
+
+#: users/templates/registration/account_activation_invalid.html:23
+msgid "The link has already been used"
+msgstr "Il link è già stato utilizzato"
+
+#: users/templates/registration/account_activation_invalid.html:24
+msgid "The link has expired (links are valid for 24 hours)"
+msgstr "Il link è scaduto (i link sono validi per 24 ore)"
+
+#: users/templates/registration/account_activation_invalid.html:25
+msgid "The link was copied incorrectly"
+msgstr "Il link è stato copiato in modo errato"
+
+#: users/templates/registration/account_activation_invalid.html:35
+#: users/templates/registration/account_activation_sent.html:32
+#: users/templates/registration/password_change_done.html:30
+#: users/templates/registration/signup_rate_limited.html:30
+#: users/templates/registration/signups_disabled.html:28
+msgid "Go to Home"
+msgstr "Vai alla Home"
+
+#: users/templates/registration/account_activation_invalid.html:41
+msgid "Try Logging In"
+msgstr "Prova ad Accedere"
+
+#: users/templates/registration/account_activation_invalid.html:52
+msgid "What should you do?"
+msgstr "Cosa dovresti fare?"
+
+#: users/templates/registration/account_activation_invalid.html:58
+#, python-format
+msgid ""
+"If your account was already activated, try <a href=\"%(login_url)s\">logging in</a>"
+msgstr ""
+"Se il tuo account era già stato attivato, prova ad <a "
+"href=\"%(login_url)s\">accedere</a>"
+
+#: users/templates/registration/account_activation_invalid.html:62
+#, python-format
+msgid ""
+"If you need a new confirmation link, please <a href=\"%(signup_url)s\">sign up again</"
+"a> or contact support"
+msgstr ""
+"Se hai bisogno di un nuovo link di conferma, <a href=\"%(signup_url)s\">registrati di "
+"nuovo</a> o contatta il supporto"
+
+#: users/templates/registration/account_activation_invalid.html:64
+msgid "Make sure you're using the most recent confirmation email"
+msgstr "Assicurati di utilizzare l'email di conferma più recente"
+
+#: users/templates/registration/account_activation_invalid.html:70
+msgid "Still having trouble?"
+msgstr "Hai ancora problemi?"
+
+#: users/templates/registration/account_activation_invalid.html:71
+msgid "Our support team is here to help"
+msgstr "Il nostro team di supporto è qui per aiutarti"
+
+#: users/templates/registration/account_activation_invalid.html:78
+#: users/templates/registration/account_activation_sent.html:64
+msgid "Contact Support"
+msgstr "Contatta il Supporto"
+
+#: users/templates/registration/account_activation_invalid.html:87
+msgid "Report Issue"
+msgstr "Segnala un Problema"
+
+#: users/templates/registration/account_activation_sent.html:4
+msgid "Confirmation Email Sent - Metron"
+msgstr "Email di Conferma Inviata - Metron"
+
+#: users/templates/registration/account_activation_sent.html:12
+msgid "Check Your Email"
+msgstr "Controlla la Tua Email"
+
+#: users/templates/registration/account_activation_sent.html:21
+#: users/templates/users/customuser_detail.html:492
+msgid "Welcome to Metron!"
+msgstr "Benvenuto su Metron!"
+
+#: users/templates/registration/account_activation_sent.html:21
+msgid "We've sent a confirmation link to your email address."
+msgstr "Abbiamo inviato un link di conferma al tuo indirizzo email."
+
+#: users/templates/registration/account_activation_sent.html:23
+msgid ""
+"Please click the link in the email to activate your account and complete the "
+"registration process."
+msgstr ""
+"Clicca il link nell'email per attivare il tuo account e completare il processo di "
+"registrazione."
+
+#: users/templates/registration/account_activation_sent.html:43
+msgid "Didn't receive the email?"
+msgstr "Non hai ricevuto l'email?"
+
+#: users/templates/registration/account_activation_sent.html:47
+msgid "Check your spam or junk folder"
+msgstr "Controlla la cartella spam o posta indesiderata"
+
+#: users/templates/registration/account_activation_sent.html:48
+msgid "Make sure you entered the correct email address"
+msgstr "Assicurati di aver inserito l'indirizzo email corretto"
+
+#: users/templates/registration/account_activation_sent.html:49
+msgid "Wait a few minutes - emails can be delayed"
+msgstr "Attendi qualche minuto - le email possono essere in ritardo"
+
+#: users/templates/registration/account_activation_sent.html:50
+msgid "The confirmation link is valid for 24 hours"
+msgstr "Il link di conferma è valido per 24 ore"
+
+#: users/templates/registration/account_activation_sent.html:56
+msgid "Need help?"
+msgstr "Hai bisogno di aiuto?"
+
+#: users/templates/registration/account_activation_sent.html:57
+msgid "If you continue to have issues, please contact us"
+msgstr "Se continui ad avere problemi, contattaci"
+
+#: users/templates/registration/password_change_done.html:4
+msgid "Password Changed - Metron"
+msgstr "Password Modificata - Metron"
+
+#: users/templates/registration/password_change_done.html:12
+msgid "Password Changed Successfully"
+msgstr "Password Modificata con Successo"
+
+#: users/templates/registration/password_change_done.html:20
+msgid "Your password has been successfully changed!"
+msgstr "La tua password è stata modificata con successo!"
+
+#: users/templates/registration/password_change_done.html:21
+msgid "You can now continue using your account with the new password."
+msgstr "Ora puoi continuare a usare il tuo account con la nuova password."
+
+#: users/templates/registration/password_change_done.html:37
+msgid "View Profile"
+msgstr "Visualizza Profilo"
+
+#: users/templates/registration/password_change_done.html:48
+msgid "Security Tip"
+msgstr "Suggerimento di Sicurezza"
+
+#: users/templates/registration/password_change_done.html:52
+msgid "Keep your password secure and don't share it with anyone"
+msgstr "Mantieni la tua password sicura e non condividerla con nessuno"
+
+#: users/templates/registration/password_change_done.html:53
+msgid "Use a unique password for Metron"
+msgstr "Usa una password unica per Metron"
+
+#: users/templates/registration/password_change_done.html:54
+msgid "Consider using a password manager"
+msgstr "Considera l'uso di un gestore di password"
+
+#: users/templates/registration/password_change_done.html:55
+msgid "Change your password periodically for better security"
+msgstr "Cambia la tua password periodicamente per una maggiore sicurezza"
+
+#: users/templates/registration/password_change_form.html:5
+msgid "Change Password - Metron"
+msgstr "Cambia Password - Metron"
+
+#: users/templates/registration/password_change_form.html:13
+msgid "Change Your Password"
+msgstr "Cambia la Tua Password"
+
+#: users/templates/registration/password_change_form.html:14
+msgid "Update your account password"
+msgstr "Aggiorna la password del tuo account"
+
+#: users/templates/registration/password_change_form.html:53
+#: users/templates/users/customuser_detail.html:31
+msgid "Change Password"
+msgstr "Cambia Password"
+
+#: users/templates/registration/password_change_form.html:65
+msgid "Password Requirements:"
+msgstr "Requisiti della Password:"
+
+#: users/templates/registration/password_change_form.html:69
+msgid "Your password can't be too similar to your other personal information"
+msgstr ""
+"La tua password non può essere troppo simile alle tue altre informazioni personali"
+
+#: users/templates/registration/password_change_form.html:70
+msgid "Your password must contain at least 8 characters"
+msgstr "La tua password deve contenere almeno 8 caratteri"
+
+#: users/templates/registration/password_change_form.html:71
+msgid "Your password can't be a commonly used password"
+msgstr "La tua password non può essere una password comunemente usata"
+
+#: users/templates/registration/password_change_form.html:72
+msgid "Your password can't be entirely numeric"
+msgstr "La tua password non può essere interamente numerica"
+
+#: users/templates/registration/signup.html:5
+msgid "Sign Up - Metron"
+msgstr "Registrati - Metron"
+
+#: users/templates/registration/signup.html:16
+msgid "Join Metron"
+msgstr "Unisciti a Metron"
+
+#: users/templates/registration/signup.html:17
+msgid "Create an account to contribute to the comic book database"
+msgstr "Crea un account per contribuire al database dei fumetti"
+
+#: users/templates/registration/signup.html:69
+msgid "Create Account"
+msgstr "Crea Account"
+
+#: users/templates/registration/signup.html:76
+msgid "Already have an account?"
+msgstr "Hai già un account?"
+
+#: users/templates/registration/signup.html:77
+msgid "Log in here"
+msgstr "Accedi qui"
+
+#: users/templates/registration/signup.html:84
+msgid "Why create an account?"
+msgstr "Perché creare un account?"
+
+#: users/templates/registration/signup.html:87
+msgid "Contribute to the comic book database"
+msgstr "Contribuisci al database dei fumetti"
+
+#: users/templates/registration/signup.html:88
+msgid "Add and edit comic information"
+msgstr "Aggiungi e modifica informazioni sui fumetti"
+
+#: users/templates/registration/signup.html:89
+msgid "Access the API for developers"
+msgstr "Accedi all'API per sviluppatori"
+
+#: users/templates/registration/signup.html:90
+msgid "Join our community of comic enthusiasts"
+msgstr "Unisciti alla nostra community di appassionati di fumetti"
+
+#: users/templates/registration/signup_rate_limited.html:4
+msgid "Too Many Signups - Metron"
+msgstr "Troppe Registrazioni - Metron"
+
+#: users/templates/registration/signup_rate_limited.html:11
+msgid "Too Many Signups"
+msgstr "Troppe Registrazioni"
+
+#: users/templates/registration/signup_rate_limited.html:19
+msgid ""
+"Too many accounts have recently been created from your network. Please try again "
+"later."
+msgstr "Troppi account sono stati creati di recente dalla tua rete. Riprova più tardi."
+
+#: users/templates/registration/signup_rate_limited.html:25
+#: users/templates/registration/signups_disabled.html:23
+msgid "Log In"
+msgstr "Accedi"
+
+#: users/templates/registration/signups_disabled.html:4
+msgid "Signups Disabled - Metron"
+msgstr "Registrazioni Disabilitate - Metron"
+
+#: users/templates/registration/signups_disabled.html:11
+msgid "Signups Disabled"
+msgstr "Registrazioni Disabilitate"
+
+#: users/templates/users/api_token.html:4
+msgid "API Tokens - Metron"
+msgstr "Token API - Metron"
+
+#: users/templates/users/api_token.html:12
+#: users/templates/users/customuser_detail.html:39
+msgid "API Tokens"
+msgstr "Token API"
+
+#: users/templates/users/api_token.html:13
+msgid "Manage the tokens used to authenticate scripts and apps against the Metron API"
+msgstr ""
+"Gestisci i token utilizzati per autenticare script e app rispetto all'API di Metron"
+
+#: users/templates/users/api_token.html:24
+msgid "Copy your new token now — it won't be shown again"
+msgstr "Copia subito il tuo nuovo token — non verrà mostrato di nuovo"
+
+#: users/templates/users/api_token.html:39 users/templates/users/api_token.html:40
+msgid "Copy token"
+msgstr "Copia token"
+
+#: users/templates/users/api_token.html:44
+msgid "Copy"
+msgstr "Copia"
+
+#: users/templates/users/api_token.html:52
+msgid "Generate a New Token"
+msgstr "Genera un Nuovo Token"
+
+#: users/templates/users/api_token.html:61
+msgid "Optional label, e.g. &quot;Mokkari script&quot;"
+msgstr "Etichetta opzionale, es. &quot;Script Mokkari&quot;"
+
+#: users/templates/users/api_token.html:68
+msgid "Generate Token"
+msgstr "Genera Token"
+
+#: users/templates/users/api_token.html:74
+msgid ""
+"Send it as <code>Authorization: Bearer &lt;token&gt;</code>. Tokens don't expire by "
+"default — revoke one below if you no longer need it."
+msgstr ""
+"Invialo come <code>Authorization: Bearer &lt;token&gt;</code>. I token non scadono "
+"per impostazione predefinita — revocane uno qui sotto se non ne hai più bisogno."
+
+#: users/templates/users/api_token.html:79
+msgid "Your Tokens"
+msgstr "I Tuoi Token"
+
+#: users/templates/users/api_token.html:81
+msgid "Never"
+msgstr "Mai"
+
+#: users/templates/users/api_token.html:85
+msgid "Name"
+msgstr "Nome"
+
+#: users/templates/users/api_token.html:86
+msgid "Created"
+msgstr "Creato"
+
+#: users/templates/users/api_token.html:87
+msgid "Expires"
+msgstr "Scade"
+
+#: users/templates/users/api_token.html:100
+msgid "Revoke this token? Any application using it will stop working immediately."
+msgstr ""
+"Revocare questo token? Qualsiasi applicazione che lo utilizza smetterà immediatamente "
+"di funzionare."
+
+#: users/templates/users/api_token.html:106
+msgid "Revoke"
+msgstr "Revoca"
+
+#: users/templates/users/api_token.html:115
+msgid "You don't have any API tokens yet."
+msgstr "Non hai ancora nessun token API."
+
+#: users/templates/users/api_token.html:125
+msgid "Back to Profile"
+msgstr "Torna al Profilo"
+
+#: users/templates/users/api_token.html:140
+msgid "Copied"
+msgstr "Copiato"
+
+#: users/templates/users/change_profile.html:5
+msgid "Edit Profile - Metron"
+msgstr "Modifica Profilo - Metron"
+
+#: users/templates/users/change_profile.html:13
+msgid "Edit Your Profile"
+msgstr "Modifica il Tuo Profilo"
+
+#: users/templates/users/change_profile.html:14
+msgid "Update your account information and preferences"
+msgstr "Aggiorna le informazioni e le preferenze del tuo account"
+
+#: users/templates/users/change_profile.html:92
+msgid "Password"
+msgstr "Password"
+
+#: users/templates/users/change_profile.html:98
+msgid "To change your password, please use the"
+msgstr "Per cambiare la tua password, utilizza il"
+
+#: users/templates/users/change_profile.html:99
+msgid "password change form"
+msgstr "modulo di cambio password"
+
+#: users/templates/users/change_profile.html:111
+#: wish_list/templates/wish_list/wishlist_item_form.html:53
+msgid "Save Changes"
+msgstr "Salva Modifiche"
+
+#: users/templates/users/change_profile.html:132
+msgid "Profile Tips:"
+msgstr "Suggerimenti per il Profilo:"
+
+#: users/templates/users/change_profile.html:136
+msgid "Your username is visible to other users in the community"
+msgstr "Il tuo nome utente è visibile agli altri utenti della community"
+
+#: users/templates/users/change_profile.html:137
+msgid "Adding a profile image helps others recognize you"
+msgstr "Aggiungere un'immagine del profilo aiuta gli altri a riconoscerti"
+
+#: users/templates/users/change_profile.html:138
+msgid "Your bio is displayed on your public profile page"
+msgstr "La tua biografia viene visualizzata nella tua pagina del profilo pubblico"
+
+#: users/templates/users/change_profile.html:139
+msgid "Email address is used for notifications and account recovery"
+msgstr "L'indirizzo email viene utilizzato per notifiche e recupero dell'account"
+
+#: users/templates/users/customuser_detail.html:7
+msgid "%(username)s - Metron"
+msgstr "%(username)s - Metron"
+
+#: users/templates/users/customuser_detail.html:11
+msgid "Profile page for %(username)s on Metron Comic Book Database."
+msgstr "Pagina del profilo di %(username)s su Metron Comic Book Database."
+
+#: users/templates/users/customuser_detail.html:19
+msgid "Edit your profile"
+msgstr "Modifica il tuo profilo"
+
+#: users/templates/users/customuser_detail.html:23
+msgid "Edit Profile"
+msgstr "Modifica Profilo"
+
+#: users/templates/users/customuser_detail.html:27
+msgid "Change your password"
+msgstr "Cambia la tua password"
+
+#: users/templates/users/customuser_detail.html:35
+msgid "Manage your API tokens"
+msgstr "Gestisci i tuoi token API"
+
+#: users/templates/users/customuser_detail.html:43
+msgid "Delete your account"
+msgstr "Elimina il tuo account"
+
+#: users/templates/users/customuser_detail.html:47
+msgid "Delete Account"
+msgstr "Elimina Account"
+
+#: users/templates/users/customuser_detail.html:63
+#: users/templates/users/customuser_list.html:64
+#, python-format
+msgid "Profile picture of %(username)s"
+msgstr "Immagine del profilo di %(username)s"
+
+#: users/templates/users/customuser_detail.html:69
+#, python-format
+msgid "Default profile picture for %(username)s"
+msgstr "Immagine del profilo predefinita per %(username)s"
+
+#: users/templates/users/customuser_detail.html:83
+#: users/templates/users/customuser_detail.html:115
+msgid "Site Administrator"
+msgstr "Amministratore del Sito"
+
+#: users/templates/users/customuser_detail.html:87
+#: users/templates/users/customuser_detail.html:119
+msgid "Admin"
+msgstr "Admin"
+
+#: users/templates/users/customuser_detail.html:92
+#: users/templates/users/customuser_detail.html:124
+msgid "Database Editor"
+msgstr "Editor del Database"
+
+#: users/templates/users/customuser_detail.html:96
+#: users/templates/users/customuser_detail.html:128
+msgid "Editor"
+msgstr "Editor"
+
+#: users/templates/users/customuser_detail.html:99
+#: users/templates/users/customuser_detail.html:131
+msgid "Reading List Editor"
+msgstr "Editor delle Liste di Lettura"
+
+#: users/templates/users/customuser_detail.html:103
+#: users/templates/users/customuser_detail.html:135
+msgid "List Editor"
+msgstr "Editor Liste"
+
+#: users/templates/users/customuser_detail.html:146
+msgid "Member Since"
+msgstr "Membro Dal"
+
+#: users/templates/users/customuser_detail.html:159
+msgid "Last Active"
+msgstr "Ultima Attività"
+
+#: users/templates/users/customuser_detail.html:178
+msgid "About"
+msgstr "Informazioni"
+
+#: users/templates/users/customuser_detail.html:189
+msgid "You haven't added a bio yet."
+msgstr "Non hai ancora aggiunto una biografia."
+
+#: users/templates/users/customuser_detail.html:190
+msgid "Add one now"
+msgstr "Aggiungine una ora"
+
+#: users/templates/users/customuser_detail.html:190
+msgid "to tell others about yourself!"
+msgstr "per parlare di te agli altri!"
+
+#: users/templates/users/customuser_detail.html:207
+msgid "Database Contributions"
+msgstr "Contributi al Database"
+
+#: users/templates/users/customuser_detail.html:209
+msgid "Items created by this user"
+msgstr "Elementi creati da questo utente"
+
+#: users/templates/users/customuser_detail.html:296
+msgid "Arcs"
+msgstr "Archi"
+
+#: users/templates/users/customuser_detail.html:323
+msgid "No contribution statistics available."
+msgstr "Nessuna statistica sui contributi disponibile."
+
+#: users/templates/users/customuser_detail.html:335
+msgid "Account Settings"
+msgstr "Impostazioni Account"
+
+#: users/templates/users/customuser_detail.html:342
+msgid "Email:"
+msgstr "Email:"
+
+#: users/templates/users/customuser_detail.html:352
+msgid "Email Status:"
+msgstr "Stato Email:"
+
+#: users/templates/users/customuser_detail.html:354
+msgid "Confirmed"
+msgstr "Confermata"
+
+#: users/templates/users/customuser_detail.html:356
+msgid "Not Confirmed"
+msgstr "Non Confermata"
+
+#: users/templates/users/customuser_detail.html:365
+msgid "Daily API Usage:"
+msgstr "Utilizzo Giornaliero API:"
+
+#: users/templates/users/customuser_detail.html:367
+#, python-format
+msgid "(%(remaining)s remaining)"
+msgstr "(%(remaining)s rimanenti)"
+
+#: users/templates/users/customuser_detail.html:372
+msgid "%(pct)s%% used"
+msgstr "%(pct)s%% utilizzato"
+
+#: users/templates/users/customuser_detail.html:382
+msgid "Supporter Status:"
+msgstr "Stato Sostenitore:"
+
+#: users/templates/users/customuser_detail.html:384
+#, python-format
+msgid "(elevated rate limit until %(until)s)"
+msgstr "(limite di velocità elevato fino al %(until)s)"
+
+#: users/templates/users/customuser_detail.html:393
+msgid "Manage Settings"
+msgstr "Gestisci Impostazioni"
+
+#: users/templates/users/customuser_detail.html:411
+msgid "Recent Reading Activity"
+msgstr "Attività di Lettura Recente"
+
+#: users/templates/users/customuser_detail.html:423
+msgid "View Full History"
+msgstr "Visualizza Cronologia Completa"
+
+#: users/templates/users/customuser_detail.html:495
+msgid "Here are some helpful resources to get you started:"
+msgstr "Ecco alcune risorse utili per iniziare:"
+
+#: users/templates/users/customuser_detail.html:498
+msgid "Learn how to contribute to the database and explore our developer API"
+msgstr "Scopri come contribuire al database ed esplora la nostra API per sviluppatori"
+
+#: users/templates/users/customuser_detail.html:503
+msgid "Community Discussions"
+msgstr "Discussioni della Community"
+
+#: users/templates/users/customuser_detail.html:503
+msgid "Join the conversation"
+msgstr "Unisciti alla conversazione"
+
+#: users/templates/users/customuser_list.html:6
+msgid "Users - Metron"
+msgstr "Utenti - Metron"
+
+#: users/templates/users/customuser_list.html:13
+msgid "List navigation and actions"
+msgstr "Navigazione ed azioni elenco"
+
+#: users/templates/users/customuser_list.html:17
+msgid "<strong>%(formatted_count)s</strong> User"
+msgid_plural "<strong>%(formatted_count)s</strong> Users"
+msgstr[0] "<strong>%(formatted_count)s</strong> Utente"
+msgstr[1] "<strong>%(formatted_count)s</strong> Utenti"
+
+#: users/templates/users/customuser_list.html:25
+msgid "Search users"
+msgstr "Cerca utenti"
+
+#: users/templates/users/customuser_list.html:28
+msgid "Search Users"
+msgstr "Cerca Utenti"
+
+#: users/templates/users/customuser_list.html:33
+#: users/templates/users/customuser_list.html:34
+msgid "Find a user"
+msgstr "Trova un utente"
+
+#: users/templates/users/customuser_list.html:37
+#: users/templates/users/customuser_list.html:41
+msgid "Search"
+msgstr "Cerca"
+
+#: users/templates/users/customuser_list.html:70
+msgid "Default profile picture"
+msgstr "Immagine del profilo predefinita"
+
+#: users/templates/users/customuser_list.html:82
+#, python-format
+msgid "Joined %(joined)s"
+msgstr "Iscritto dal %(joined)s"
+
+#: users/templates/users/customuser_list.html:97
+msgid "No users found."
+msgstr "Nessun utente trovato."
+
+#: users/templates/users/delete_account.html:4
+msgid "Delete Account - Metron"
+msgstr "Elimina Account - Metron"
+
+#: users/templates/users/delete_account.html:14
+msgid "Delete Your Account"
+msgstr "Elimina il Tuo Account"
+
+#: users/templates/users/delete_account.html:15
+msgid "This action cannot be undone"
+msgstr "Questa azione non può essere annullata"
+
+#: users/templates/users/delete_account.html:18
+msgid "Warning: Permanent deletion"
+msgstr "Attenzione: eliminazione permanente"
+
+#: users/templates/users/delete_account.html:21
+msgid "Your account and all personal data will be permanently deleted"
+msgstr "Il tuo account e tutti i dati personali verranno eliminati permanentemente"
+
+#: users/templates/users/delete_account.html:22
+msgid "Your reading list and collection data will be removed"
+msgstr "I dati della tua lista di lettura e della collezione verranno rimossi"
+
+#: users/templates/users/delete_account.html:23
+msgid ""
+"Database contributions (issues, creators, etc.) will remain but will no longer be "
+"attributed to you"
+msgstr ""
+"I contributi al database (albi, autori, ecc.) rimarranno ma non saranno più "
+"attribuiti a te"
+
+#: users/templates/users/delete_account.html:35
+msgid "Delete My Account"
+msgstr "Elimina il Mio Account"
+
+#: users/views.py:128
+msgid "Editing Guidelines"
+msgstr "Linee Guida per la Modifica"
+
+#: users/views.py:132
+#, python-format
+msgid ""
+"If you are planning on adding new information to the database, please refer to the "
+"%(link)s."
+msgstr ""
+"Se hai intenzione di aggiungere nuove informazioni al database, fai riferimento a "
+"%(link)s."
+
+#: users/views.py:216
+msgid "Your profile was successfully updated!"
+msgstr "Il tuo profilo è stato aggiornato con successo!"
+
+#: users/views.py:218
+msgid "Please correct the error below."
+msgstr "Correggi l'errore qui sotto."
+
+#: users/views.py:231
+msgid "Your account has been deleted."
+msgstr "Il tuo account è stato eliminato."
+
+#: users/views.py:246
+msgid "New API token created. Copy it now — you won't be able to see it again."
+msgstr "Nuovo token API creato. Copialo ora — non potrai vederlo di nuovo."
+
+#: users/views.py:262
+msgid "API token revoked."
+msgstr "Token API revocato."
 
 #: wish_list/forms.py:41
 msgid "Notes about this item (optional)"
@@ -2056,6 +2980,7 @@ msgid "Add to wish list"
 msgstr "Aggiungi alla lista dei desideri"
 
 #: wish_list/templates/wish_list/wishlist_acquire_form.html:3
+#, python-format
 msgid "Acquire %(issue)s - Metron"
 msgstr "Acquisisci %(issue)s - Metron"
 
@@ -2064,6 +2989,7 @@ msgid "Acquire Item"
 msgstr "Acquisisci Elemento"
 
 #: wish_list/templates/wish_list/wishlist_acquire_form.html:7
+#, python-format
 msgid "Mark <strong>%(issue)s</strong> as acquired"
 msgstr "Segna <strong>%(issue)s</strong> come acquisito"
 
@@ -2127,6 +3053,7 @@ msgid "Remove from Wish List"
 msgstr "Rimuovi dalla Lista dei Desideri"
 
 #: wish_list/templates/wish_list/wishlist_item_confirm_delete.html:18
+#, python-format
 msgid "Are you sure you want to remove <strong>%(issue)s</strong> from your wish list?"
 msgstr ""
 "Sei sicuro di voler rimuovere <strong>%(issue)s</strong> dalla tua lista dei desideri?"
@@ -2139,15 +3066,13 @@ msgstr "Modifica Elemento della Lista dei Desideri - Metron"
 msgid "Edit Wish List Item"
 msgstr "Modifica Elemento della Lista dei Desideri"
 
-#: wish_list/templates/wish_list/wishlist_item_form.html:53
-msgid "Save Changes"
-msgstr "Salva Modifiche"
-
 #: wish_list/views.py:35
+#, python-format
 msgid "%(issue)s is already on your wish list."
 msgstr "%(issue)s è già nella tua lista dei desideri."
 
 #: wish_list/views.py:41
+#, python-format
 msgid "Added %(issue)s to your wish list."
 msgstr "Aggiunto %(issue)s alla tua lista dei desideri."
 
@@ -2157,6 +3082,7 @@ msgid "Updated %(issue)s."
 msgstr "%(issue)s aggiornato."
 
 #: wish_list/views.py:84
+#, python-format
 msgid "Removed %(issue)s from your wish list."
 msgstr "Rimosso %(issue)s dalla tua lista dei desideri."
 

--- a/locale/it/LC_MESSAGES/django.po
+++ b/locale/it/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: metron\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-13 15:00-0400\n"
+"POT-Creation-Date: 2026-08-13 16:05-0400\n"
 "PO-Revision-Date: 2026-08-13 11:23-0400\n"
 "Last-Translator: Metron Project\n"
 "Language-Team: Italian\n"
@@ -308,11 +308,21 @@ msgstr ""
 
 #: polls/templates/polls/poll_confirm_delete.html:20
 #: polls/templates/polls/poll_detail.html:38
+#: reading_lists/templates/reading_lists/readinglist_confirm_delete.html:32
+#: reading_lists/templates/reading_lists/readinglist_detail.html:177
 msgid "Delete"
 msgstr "Elimina"
 
 #: polls/templates/polls/poll_confirm_delete.html:25
 #: pull_list/templates/pull_list/remove_series_confirm.html:27
+#: reading_lists/templates/reading_lists/add_issue_autocomplete.html:42
+#: reading_lists/templates/reading_lists/add_issues_from_arc.html:43
+#: reading_lists/templates/reading_lists/add_issues_from_series.html:76
+#: reading_lists/templates/reading_lists/partials/readinglist_item_edit.html:68
+#: reading_lists/templates/reading_lists/readinglist_confirm_assign_metron.html:29
+#: reading_lists/templates/reading_lists/readinglist_confirm_delete.html:29
+#: reading_lists/templates/reading_lists/readinglist_form.html:114
+#: reading_lists/templates/reading_lists/remove_issue_confirm.html:25
 #: user_collection/templates/user_collection/add_issues_from_series.html:82
 #: user_collection/templates/user_collection/collection_confirm_delete.html:31
 #: user_collection/templates/user_collection/collection_form.html:72
@@ -326,6 +336,7 @@ msgid "Cancel"
 msgstr "Annulla"
 
 #: polls/templates/polls/poll_detail.html:3
+#: reading_lists/templates/reading_lists/readinglist_form.html:3
 #, python-format
 msgid "%(title)s - Metron"
 msgstr "%(title)s - Metron"
@@ -435,11 +446,13 @@ msgstr "Hai già votato in questo sondaggio."
 msgid "No choice selected."
 msgstr "Nessuna scelta selezionata."
 
-#: pull_list/forms.py:16 user_collection/forms.py:128
+#: pull_list/forms.py:16 reading_lists/forms.py:133 user_collection/forms.py:128
 msgid "Search for a series..."
 msgstr "Cerca una serie..."
 
 #: pull_list/forms.py:20 pull_list/templates/pull_list/pulllist_detail.html:47
+#: reading_lists/forms.py:137
+#: reading_lists/templates/reading_lists/readinglist_detail.html:100
 #: templates/partials/navbar.html:74 user_collection/forms.py:132
 #: user_collection/templates/user_collection/collection_stats.html:226
 #: user_collection/templates/user_collection/missing_issues_list.html:40
@@ -474,6 +487,7 @@ msgid "Add to pull list"
 msgstr "Aggiungi alla pull list"
 
 #: pull_list/templates/pull_list/pulllist_detail.html:3
+#: reading_lists/templates/reading_lists/readinglist_detail.html:3
 #: wish_list/templates/wish_list/wishlist_detail.html:3
 #, python-format
 msgid "%(name)s - Metron"
@@ -493,6 +507,8 @@ msgid "Series on Pull List (%(count)s)"
 msgstr "Serie nella Pull List (%(count)s)"
 
 #: pull_list/templates/pull_list/pulllist_detail.html:48
+#: reading_lists/templates/reading_lists/partials/readinglist_filter.html:89
+#: reading_lists/views.py:46
 #: user_collection/templates/user_collection/missing_issues_list.html:41
 #: user_collection/templates/user_collection/partials/collection_filter.html:94
 msgid "Publisher"
@@ -505,6 +521,7 @@ msgstr "Tipo"
 
 #: pull_list/templates/pull_list/pulllist_detail.html:68
 #: pull_list/templates/pull_list/remove_series_confirm.html:30
+#: reading_lists/templates/reading_lists/remove_issue_confirm.html:28
 #: user_collection/templates/user_collection/collection_detail.html:32
 #: user_collection/templates/user_collection/collection_list.html:139
 #: wish_list/templates/wish_list/wishlist_detail.html:128
@@ -567,6 +584,1096 @@ msgstr "%(series)s è già nella tua pull list."
 #, python-format
 msgid "Removed %(series)s from your pull list."
 msgstr "Rimosso %(series)s dalla tua pull list."
+
+#: reading_lists/forms.py:19
+msgid "Previous List"
+msgstr "Lista Precedente"
+
+#: reading_lists/forms.py:20
+msgid "The reading list that comes before this one in a reading order (optional)"
+msgstr "La lista di lettura che precede questa nell'ordine di lettura (opzionale)"
+
+#: reading_lists/forms.py:23 reading_lists/forms.py:33
+msgid "Search for a reading list..."
+msgstr "Cerca una lista di lettura..."
+
+#: reading_lists/forms.py:29
+msgid "Next List"
+msgstr "Lista Successiva"
+
+#: reading_lists/forms.py:30
+msgid "The reading list that comes after this one in a reading order (optional)"
+msgstr "La lista di lettura che segue questa nell'ordine di lettura (opzionale)"
+
+#: reading_lists/forms.py:51
+msgid "Enter a name for your reading list"
+msgstr "Inserisci un nome per la tua lista di lettura"
+
+#: reading_lists/forms.py:55
+msgid "Describe the reading list (optional)"
+msgstr "Descrivi la lista di lettura (opzionale)"
+
+#: reading_lists/forms.py:69
+#: user_collection/templates/user_collection/collection_detail.html:84
+msgid "Description"
+msgstr "Descrizione"
+
+#: reading_lists/forms.py:70
+msgid "Private List"
+msgstr "Lista Privata"
+
+#: reading_lists/forms.py:71
+#: reading_lists/templates/reading_lists/partials/readinglist_filter.html:107
+#: reading_lists/views.py:47
+msgid "List Type"
+msgstr "Tipo di Lista"
+
+#: reading_lists/forms.py:72
+msgid "Source"
+msgstr "Fonte"
+
+#: reading_lists/forms.py:73
+msgid "Source URL"
+msgstr "URL della Fonte"
+
+#: reading_lists/forms.py:77
+msgid "Private lists are only visible to you. Public lists can be viewed by anyone."
+msgstr ""
+"Le liste private sono visibili solo a te. Le liste pubbliche possono essere viste da "
+"chiunque."
+
+#: reading_lists/forms.py:79
+msgid "Where did you get this reading list from? (optional)"
+msgstr "Da dove hai preso questa lista di lettura? (opzionale)"
+
+#: reading_lists/forms.py:80
+msgid "URL of the specific page for this reading list (optional)"
+msgstr "URL della pagina specifica per questa lista di lettura (opzionale)"
+
+#: reading_lists/forms.py:102
+msgid "Search for issues..."
+msgstr "Cerca albi..."
+
+#: reading_lists/forms.py:109
+msgid "Search for Issues (Optional)"
+msgstr "Cerca Albi (Opzionale)"
+
+#: reading_lists/forms.py:110
+msgid "Add new issues and/or reorder existing issues by dragging"
+msgstr "Aggiungi nuovi albi e/o riordina gli albi esistenti trascinandoli"
+
+#: reading_lists/forms.py:115
+msgid "Stores the order of selected issues after drag-and-drop"
+msgstr "Memorizza l'ordine degli albi selezionati dopo il trascinamento"
+
+#: reading_lists/forms.py:123 user_collection/forms.py:118
+msgid "All issues"
+msgstr "Tutti gli albi"
+
+#: reading_lists/forms.py:124 user_collection/forms.py:119
+msgid "Issue range"
+msgstr "Intervallo di albi"
+
+#: reading_lists/forms.py:138 user_collection/forms.py:133
+msgid "Select the series to add issues from"
+msgstr "Seleziona la serie da cui aggiungere gli albi"
+
+#: reading_lists/forms.py:145
+msgid "What to add"
+msgstr "Cosa aggiungere"
+
+#: reading_lists/forms.py:153
+msgid "Start Issue #"
+msgstr "Albo Iniziale #"
+
+#: reading_lists/forms.py:154
+msgid "Leave blank to start from the first issue"
+msgstr "Lascia vuoto per iniziare dal primo albo"
+
+#: reading_lists/forms.py:161
+msgid "End Issue #"
+msgstr "Albo Finale #"
+
+#: reading_lists/forms.py:162
+msgid "Leave blank to go to the last issue"
+msgstr "Lascia vuoto per arrivare all'ultimo albo"
+
+#: reading_lists/forms.py:167 reading_lists/forms.py:210
+msgid "At the end"
+msgstr "Alla fine"
+
+#: reading_lists/forms.py:168 reading_lists/forms.py:211
+msgid "At the beginning"
+msgstr "All'inizio"
+
+#: reading_lists/forms.py:172 reading_lists/forms.py:215
+msgid "Add issues"
+msgstr "Aggiungi albi"
+
+#: reading_lists/forms.py:185
+msgid "Please specify at least a start or end issue number for the range."
+msgstr "Specifica almeno un numero di albo iniziale o finale per l'intervallo."
+
+#: reading_lists/forms.py:200
+msgid "Search for a story arc..."
+msgstr "Cerca un arco narrativo..."
+
+#: reading_lists/forms.py:204
+msgid "Story Arc"
+msgstr "Arco Narrativo"
+
+#: reading_lists/forms.py:205
+msgid "Select the story arc to add issues from"
+msgstr "Seleziona l'arco narrativo da cui aggiungere gli albi"
+
+#: reading_lists/models.py:62
+#: reading_lists/templates/reading_lists/partials/readinglist_filter.html:71
+#: reading_lists/views.py:45
+msgid "Creator"
+msgstr "Autore"
+
+#: reading_lists/models.py:63
+msgid "Event"
+msgstr "Evento"
+
+#: reading_lists/models.py:64
+msgid "Story"
+msgstr "Storia"
+
+#: reading_lists/models.py:65 templates/partials/navbar.html:93
+#: users/templates/users/customuser_detail.html:252
+msgid "Characters"
+msgstr "Personaggi"
+
+#: reading_lists/models.py:66 templates/partials/navbar.html:99
+#: users/templates/users/customuser_detail.html:274
+msgid "Teams"
+msgstr "Squadre"
+
+#: reading_lists/models.py:67
+msgid "Master"
+msgstr "Principale"
+
+#: reading_lists/models.py:72
+msgid "Comic Book Reading Orders"
+msgstr "Comic Book Reading Orders"
+
+#: reading_lists/models.py:73
+msgid "Complete Marvel Reading Orders"
+msgstr "Complete Marvel Reading Orders"
+
+#: reading_lists/models.py:74
+msgid "Comic Book Herald"
+msgstr "Comic Book Herald"
+
+#: reading_lists/models.py:75
+msgid "Comic Book Treasury"
+msgstr "Comic Book Treasury"
+
+#: reading_lists/models.py:76
+msgid "Marvel Guides"
+msgstr "Marvel Guides"
+
+#: reading_lists/models.py:77
+msgid "How To Love Comics"
+msgstr "How To Love Comics"
+
+#: reading_lists/models.py:78
+msgid "League of ComicGeeks"
+msgstr "League of ComicGeeks"
+
+#: reading_lists/models.py:79
+msgid "Other"
+msgstr "Altro"
+
+#: reading_lists/models.py:85
+msgid "The user who owns this reading list"
+msgstr "L'utente proprietario di questa lista di lettura"
+
+#: reading_lists/models.py:89
+msgid "Whether this list is private (only visible to the owner)"
+msgstr "Se questa lista è privata (visibile solo al proprietario)"
+
+#: reading_lists/models.py:95
+msgid "The type of reading list"
+msgstr "Il tipo di lista di lettura"
+
+#: reading_lists/models.py:101
+msgid "Source where this reading list information was obtained"
+msgstr "Fonte da cui sono state ottenute le informazioni di questa lista di lettura"
+
+#: reading_lists/models.py:105
+msgid "URL of the specific page where this reading list was obtained"
+msgstr "URL della pagina specifica da cui è stata ottenuta questa lista di lettura"
+
+#: reading_lists/models.py:120
+msgid "The reading list that comes before this one in a reading order"
+msgstr "La lista di lettura che precede questa nell'ordine di lettura"
+
+#: reading_lists/models.py:128
+msgid "The reading list that comes after this one in a reading order"
+msgstr "La lista di lettura che segue questa nell'ordine di lettura"
+
+#: reading_lists/models.py:145
+msgid "A reading list cannot be its own previous list."
+msgstr "Una lista di lettura non può essere la lista precedente di se stessa."
+
+#: reading_lists/models.py:148
+msgid "A reading list cannot be its own next list."
+msgstr "Una lista di lettura non può essere la lista successiva di se stessa."
+
+#: reading_lists/models.py:150
+msgid "The previous and next reading lists must be different."
+msgstr "Le liste di lettura precedente e successiva devono essere diverse."
+
+#: reading_lists/models.py:217
+#: reading_lists/templates/reading_lists/partials/readinglist_item_edit.html:50
+#: reading_lists/views.py:66
+msgid "Prologue"
+msgstr "Prologo"
+
+#: reading_lists/models.py:218
+msgid "Core Issue"
+msgstr "Albo Principale"
+
+#: reading_lists/models.py:219
+#: reading_lists/templates/reading_lists/partials/readinglist_item_edit.html:52
+#: reading_lists/views.py:65
+msgid "Tie-In"
+msgstr "Tie-In"
+
+#: reading_lists/models.py:220
+#: reading_lists/templates/reading_lists/partials/readinglist_item_edit.html:53
+#: reading_lists/views.py:67
+msgid "Epilogue"
+msgstr "Epilogo"
+
+#: reading_lists/models.py:234
+msgid "Position of this issue in the reading list"
+msgstr "Posizione di questo albo nella lista di lettura"
+
+#: reading_lists/models.py:240
+msgid "Optional categorization of this issue's role in the reading list"
+msgstr "Categorizzazione opzionale del ruolo di questo albo nella lista di lettura"
+
+#: reading_lists/templates/reading_lists/add_issue_autocomplete.html:3
+msgid "Manage Issues - %(name)s - Metron"
+msgstr "Gestisci Albi - %(name)s - Metron"
+
+#: reading_lists/templates/reading_lists/add_issue_autocomplete.html:10
+msgid "Manage Reading List"
+msgstr "Gestisci Lista di Lettura"
+
+#: reading_lists/templates/reading_lists/add_issue_autocomplete.html:30
+msgid "Selected Issues"
+msgstr "Albi Selezionati"
+
+#: reading_lists/templates/reading_lists/add_issue_autocomplete.html:31
+msgid "Drag to reorder"
+msgstr "Trascina per riordinare"
+
+#: reading_lists/templates/reading_lists/add_issue_autocomplete.html:45
+#: users/templates/users/change_profile.html:111
+#: wish_list/templates/wish_list/wishlist_item_form.html:53
+msgid "Save Changes"
+msgstr "Salva Modifiche"
+
+#: reading_lists/templates/reading_lists/add_issue_autocomplete.html:51
+#: reading_lists/templates/reading_lists/add_issues_from_arc.html:52
+#: reading_lists/templates/reading_lists/add_issues_from_series.html:85
+#: user_collection/templates/user_collection/add_issues_from_series.html:91
+msgid "How to use:"
+msgstr "Come si usa:"
+
+#: reading_lists/templates/reading_lists/add_issue_autocomplete.html:53
+msgid ""
+"To add new issues: Start typing in the search box to find issues by series name, "
+"issue number, or story title"
+msgstr ""
+"Per aggiungere nuovi albi: inizia a digitare nella casella di ricerca per trovare "
+"albi per nome serie, numero albo o titolo della storia"
+
+#: reading_lists/templates/reading_lists/add_issue_autocomplete.html:54
+msgid "Select multiple issues from the dropdown (they will appear as chips)"
+msgstr "Seleziona più albi dal menu a tendina (appariranno come chip)"
+
+#: reading_lists/templates/reading_lists/add_issue_autocomplete.html:55
+msgid "All issues (existing and new) will appear below in a draggable list"
+msgstr ""
+"Tutti gli albi (esistenti e nuovi) appariranno qui sotto in un elenco trascinabile"
+
+#: reading_lists/templates/reading_lists/add_issue_autocomplete.html:56
+msgid "Drag and drop the issues to set your preferred reading order"
+msgstr "Trascina gli albi per impostare il tuo ordine di lettura preferito"
+
+#: reading_lists/templates/reading_lists/add_issue_autocomplete.html:57
+msgid "Click \"Save Changes\" to add new issues and/or save the reordered list"
+msgstr ""
+"Clicca \"Salva Modifiche\" per aggiungere nuovi albi e/o salvare l'elenco riordinato"
+
+#: reading_lists/templates/reading_lists/add_issue_autocomplete.html:189
+msgid "Issue #"
+msgstr "Albo #"
+
+#: reading_lists/templates/reading_lists/add_issue_autocomplete.html:195
+msgid "Current"
+msgstr "Attuale"
+
+#: reading_lists/templates/reading_lists/add_issue_autocomplete.html:195
+msgid "New"
+msgstr "Nuovo"
+
+#: reading_lists/templates/reading_lists/add_issues_from_arc.html:3
+msgid "Add from Story Arc - %(name)s - Metron"
+msgstr "Aggiungi da Arco Narrativo - %(name)s - Metron"
+
+#: reading_lists/templates/reading_lists/add_issues_from_arc.html:9
+msgid "Add Issues from Story Arc"
+msgstr "Aggiungi Albi da Arco Narrativo"
+
+#: reading_lists/templates/reading_lists/add_issues_from_arc.html:46
+#: reading_lists/templates/reading_lists/add_issues_from_series.html:79
+#: reading_lists/templates/reading_lists/readinglist_detail.html:161
+#: reading_lists/templates/reading_lists/readinglist_detail.html:245
+#: user_collection/templates/user_collection/add_issues_from_series.html:85
+msgid "Add Issues"
+msgstr "Aggiungi Albi"
+
+#: reading_lists/templates/reading_lists/add_issues_from_arc.html:55
+msgid "Select a story arc:"
+msgstr "Seleziona un arco narrativo:"
+
+#: reading_lists/templates/reading_lists/add_issues_from_arc.html:55
+msgid "Start typing in the search box to find a story arc by name"
+msgstr ""
+"Inizia a digitare nella casella di ricerca per trovare un arco narrativo per nome"
+
+#: reading_lists/templates/reading_lists/add_issues_from_arc.html:58
+msgid "All issues from the arc will be added:"
+msgstr "Tutti gli albi dell'arco narrativo verranno aggiunti:"
+
+#: reading_lists/templates/reading_lists/add_issues_from_arc.html:58
+msgid "Issues are added in chronological order by cover date"
+msgstr "Gli albi vengono aggiunti in ordine cronologico per data di copertina"
+
+#: reading_lists/templates/reading_lists/add_issues_from_arc.html:61
+#: reading_lists/templates/reading_lists/add_issues_from_series.html:102
+msgid "Choose position:"
+msgstr "Scegli la posizione:"
+
+#: reading_lists/templates/reading_lists/add_issues_from_arc.html:61
+#: reading_lists/templates/reading_lists/add_issues_from_series.html:102
+msgid "Add issues at the beginning or end of your reading list"
+msgstr "Aggiungi albi all'inizio o alla fine della tua lista di lettura"
+
+#: reading_lists/templates/reading_lists/add_issues_from_arc.html:63
+#: reading_lists/templates/reading_lists/add_issues_from_series.html:104
+msgid "Issues already in your reading list will be automatically skipped"
+msgstr ""
+"Gli albi già presenti nella tua lista di lettura verranno automaticamente saltati"
+
+#: reading_lists/templates/reading_lists/add_issues_from_arc.html:66
+#: reading_lists/templates/reading_lists/add_issues_from_series.html:107
+#: user_collection/templates/user_collection/add_issues_from_series.html:115
+msgid "Tip:"
+msgstr "Suggerimento:"
+
+#: reading_lists/templates/reading_lists/add_issues_from_arc.html:66
+msgid ""
+"Story arcs are perfect for reading major crossover events in order! You can combine "
+"multiple arcs to build comprehensive reading orders."
+msgstr ""
+"Gli archi narrativi sono perfetti per leggere i principali eventi crossover in "
+"ordine! Puoi combinare più archi per costruire ordini di lettura completi."
+
+#: reading_lists/templates/reading_lists/add_issues_from_series.html:3
+msgid "Add from Series - %(name)s - Metron"
+msgstr "Aggiungi dalla Serie - %(name)s - Metron"
+
+#: reading_lists/templates/reading_lists/add_issues_from_series.html:9
+#: user_collection/templates/user_collection/add_issues_from_series.html:9
+msgid "Add Issues from Series"
+msgstr "Aggiungi Albi dalla Serie"
+
+#: reading_lists/templates/reading_lists/add_issues_from_series.html:88
+#: user_collection/templates/user_collection/add_issues_from_series.html:94
+msgid "Select a series:"
+msgstr "Seleziona una serie:"
+
+#: reading_lists/templates/reading_lists/add_issues_from_series.html:88
+#: user_collection/templates/user_collection/add_issues_from_series.html:94
+msgid "Start typing in the search box to find a series by name"
+msgstr "Inizia a digitare nella casella di ricerca per trovare una serie per nome"
+
+#: reading_lists/templates/reading_lists/add_issues_from_series.html:91
+#: user_collection/templates/user_collection/add_issues_from_series.html:97
+msgid "Choose what to add:"
+msgstr "Scegli cosa aggiungere:"
+
+#: reading_lists/templates/reading_lists/add_issues_from_series.html:94
+#: user_collection/templates/user_collection/add_issues_from_series.html:100
+msgid "All issues:"
+msgstr "Tutti gli albi:"
+
+#: reading_lists/templates/reading_lists/add_issues_from_series.html:94
+#: user_collection/templates/user_collection/add_issues_from_series.html:100
+msgid "Adds every issue from the series"
+msgstr "Aggiunge tutti gli albi della serie"
+
+#: reading_lists/templates/reading_lists/add_issues_from_series.html:97
+#: user_collection/templates/user_collection/add_issues_from_series.html:103
+msgid "Issue range:"
+msgstr "Intervallo di albi:"
+
+#: reading_lists/templates/reading_lists/add_issues_from_series.html:97
+#: user_collection/templates/user_collection/add_issues_from_series.html:103
+msgid "Specify a start and/or end issue number (e.g., start at #1, end at #50)"
+msgstr ""
+"Specifica un numero di albo iniziale e/o finale (es. inizia da #1, termina a #50)"
+
+#: reading_lists/templates/reading_lists/add_issues_from_series.html:107
+msgid ""
+"For large reading orders spanning multiple series, you can use this tool repeatedly "
+"to add different series or ranges, building your list quickly!"
+msgstr ""
+"Per ordini di lettura estesi su più serie, puoi usare questo strumento più volte per "
+"aggiungere serie o intervalli diversi, costruendo rapidamente la tua lista!"
+
+#: reading_lists/templates/reading_lists/partials/readinglist_card.html:14
+#: reading_lists/templates/reading_lists/partials/readinglist_filter.html:203
+#: reading_lists/templates/reading_lists/readinglist_detail.html:27
+#: reading_lists/templates/reading_lists/readinglist_detail.html:275
+#: reading_lists/views.py:61
+msgid "Private"
+msgstr "Privato"
+
+#: reading_lists/templates/reading_lists/partials/readinglist_card.html:25
+#: reading_lists/templates/reading_lists/readinglist_detail.html:333
+#: reading_lists/templates/reading_lists/readinglist_detail.html:381
+msgid "%(counter)s issue"
+msgid_plural "%(counter)s issues"
+msgstr[0] "%(counter)s albo"
+msgstr[1] "%(counter)s albi"
+
+#: reading_lists/templates/reading_lists/partials/readinglist_card.html:48
+msgid "By <strong>%(username)s</strong>"
+msgstr "Di <strong>%(username)s</strong>"
+
+#: reading_lists/templates/reading_lists/partials/readinglist_card.html:62
+msgid "No description"
+msgstr "Nessuna descrizione"
+
+#: reading_lists/templates/reading_lists/partials/readinglist_card.html:64
+msgid "Updated %(timesince)s ago"
+msgstr "Aggiornato %(timesince)s fa"
+
+#: reading_lists/templates/reading_lists/partials/readinglist_filter.html:10
+msgid "Search Reading Lists"
+msgstr "Cerca Liste di Lettura"
+
+#: reading_lists/templates/reading_lists/partials/readinglist_filter.html:18
+#: user_collection/templates/user_collection/partials/collection_filter.html:18
+msgid "Filters Active"
+msgstr "Filtri Attivi"
+
+#: reading_lists/templates/reading_lists/partials/readinglist_filter.html:24
+#: user_collection/templates/user_collection/partials/collection_filter.html:24
+msgid "Quick Search"
+msgstr "Ricerca Rapida"
+
+#: reading_lists/templates/reading_lists/partials/readinglist_filter.html:31
+msgid "Search by list name..."
+msgstr "Cerca per nome lista..."
+
+#: reading_lists/templates/reading_lists/partials/readinglist_filter.html:32
+#: user_collection/templates/user_collection/partials/collection_filter.html:32
+msgid "Quick search"
+msgstr "Ricerca rapida"
+
+#: reading_lists/templates/reading_lists/partials/readinglist_filter.html:37
+msgid "Search by reading list name"
+msgstr "Cerca per nome della lista di lettura"
+
+#: reading_lists/templates/reading_lists/partials/readinglist_filter.html:46
+#: user_collection/templates/user_collection/partials/collection_filter.html:46
+msgid "Advanced Filters"
+msgstr "Filtri Avanzati"
+
+#: reading_lists/templates/reading_lists/partials/readinglist_filter.html:53
+msgid "List Name"
+msgstr "Nome Lista"
+
+#: reading_lists/templates/reading_lists/partials/readinglist_filter.html:60
+msgid "e.g., Marvel Reading Order"
+msgstr "es. Marvel Reading Order"
+
+#: reading_lists/templates/reading_lists/partials/readinglist_filter.html:61
+msgid "Filter by list name"
+msgstr "Filtra per nome lista"
+
+#: reading_lists/templates/reading_lists/partials/readinglist_filter.html:78
+msgid "e.g., Metron"
+msgstr "es. Metron"
+
+#: reading_lists/templates/reading_lists/partials/readinglist_filter.html:79
+msgid "Filter by creator username"
+msgstr "Filtra per nome utente autore"
+
+#: reading_lists/templates/reading_lists/partials/readinglist_filter.html:96
+#: user_collection/templates/user_collection/partials/collection_filter.html:101
+msgid "e.g., Marvel"
+msgstr "es. Marvel"
+
+#: reading_lists/templates/reading_lists/partials/readinglist_filter.html:97
+#: user_collection/templates/user_collection/partials/collection_filter.html:102
+msgid "Filter by publisher"
+msgstr "Filtra per editore"
+
+#: reading_lists/templates/reading_lists/partials/readinglist_filter.html:110
+msgid "Filter by list type"
+msgstr "Filtra per tipo di lista"
+
+#: reading_lists/templates/reading_lists/partials/readinglist_filter.html:111
+#: user_collection/templates/user_collection/partials/collection_filter.html:76
+msgid "All Types"
+msgstr "Tutti i Tipi"
+
+#: reading_lists/templates/reading_lists/partials/readinglist_filter.html:129
+msgid "Attribution Source"
+msgstr "Fonte di Attribuzione"
+
+#: reading_lists/templates/reading_lists/partials/readinglist_filter.html:134
+msgid "Filter by attribution source"
+msgstr "Filtra per fonte di attribuzione"
+
+#: reading_lists/templates/reading_lists/partials/readinglist_filter.html:135
+msgid "All Sources"
+msgstr "Tutte le Fonti"
+
+#: reading_lists/templates/reading_lists/partials/readinglist_filter.html:153
+msgid "Minimum Rating"
+msgstr "Valutazione Minima"
+
+#: reading_lists/templates/reading_lists/partials/readinglist_filter.html:158
+msgid "Filter by minimum rating"
+msgstr "Filtra per valutazione minima"
+
+#: reading_lists/templates/reading_lists/partials/readinglist_filter.html:159
+#: user_collection/templates/user_collection/partials/collection_filter.html:222
+msgid "All Ratings"
+msgstr "Tutte le Valutazioni"
+
+#: reading_lists/templates/reading_lists/partials/readinglist_filter.html:162
+#: reading_lists/views.py:54
+msgid "1+ Stars"
+msgstr "1+ Stelle"
+
+#: reading_lists/templates/reading_lists/partials/readinglist_filter.html:166
+#: reading_lists/views.py:55
+msgid "2+ Stars"
+msgstr "2+ Stelle"
+
+#: reading_lists/templates/reading_lists/partials/readinglist_filter.html:170
+#: reading_lists/views.py:56
+msgid "3+ Stars"
+msgstr "3+ Stelle"
+
+#: reading_lists/templates/reading_lists/partials/readinglist_filter.html:174
+#: reading_lists/views.py:57
+msgid "4+ Stars"
+msgstr "4+ Stelle"
+
+#: reading_lists/templates/reading_lists/partials/readinglist_filter.html:178
+#: reading_lists/views.py:58
+msgid "5 Stars"
+msgstr "5 Stelle"
+
+#: reading_lists/templates/reading_lists/partials/readinglist_filter.html:192
+#: reading_lists/views.py:50
+msgid "Privacy"
+msgstr "Privacy"
+
+#: reading_lists/templates/reading_lists/partials/readinglist_filter.html:195
+msgid "Filter by privacy"
+msgstr "Filtra per privacy"
+
+#: reading_lists/templates/reading_lists/partials/readinglist_filter.html:196
+msgid "All Lists"
+msgstr "Tutte le Liste"
+
+#: reading_lists/templates/reading_lists/partials/readinglist_filter.html:199
+#: reading_lists/templates/reading_lists/readinglist_detail.html:57
+#: reading_lists/templates/reading_lists/readinglist_detail.html:277
+#: reading_lists/views.py:61
+msgid "Public"
+msgstr "Pubblico"
+
+#: reading_lists/templates/reading_lists/partials/readinglist_filter.html:223
+#: user_collection/templates/user_collection/partials/collection_filter.html:246
+msgid "Apply Filters"
+msgstr "Applica Filtri"
+
+#: reading_lists/templates/reading_lists/partials/readinglist_filter.html:229
+#: user_collection/templates/user_collection/partials/collection_filter.html:252
+msgid "Clear all filters"
+msgstr "Cancella tutti i filtri"
+
+#: reading_lists/templates/reading_lists/partials/readinglist_filter.html:233
+#: user_collection/templates/user_collection/partials/collection_filter.html:256
+msgid "Clear Filters"
+msgstr "Cancella Filtri"
+
+#: reading_lists/templates/reading_lists/partials/readinglist_item.html:22
+#: reading_lists/templates/reading_lists/partials/readinglist_item_edit.html:22
+msgid "No image for %(issue)s"
+msgstr "Nessuna immagine per %(issue)s"
+
+#: reading_lists/templates/reading_lists/partials/readinglist_item.html:52
+msgid "Edit issue type"
+msgstr "Modifica tipo di albo"
+
+#: reading_lists/templates/reading_lists/partials/readinglist_item.html:57
+msgid "Remove from list"
+msgstr "Rimuovi dalla lista"
+
+#: reading_lists/templates/reading_lists/partials/readinglist_item_edit.html:49
+msgid "-- No Type --"
+msgstr "-- Nessun Tipo --"
+
+#: reading_lists/templates/reading_lists/partials/readinglist_item_edit.html:51
+#: reading_lists/views.py:64
+msgid "Core"
+msgstr "Principale"
+
+#: reading_lists/templates/reading_lists/partials/readinglist_item_edit.html:58
+msgid "Save"
+msgstr "Salva"
+
+#: reading_lists/templates/reading_lists/partials/readinglist_item_list.html:14
+#: reading_lists/templates/reading_lists/readinglist_detail.html:232
+msgid "Load More Issues"
+msgstr "Carica Altri Albi"
+
+#: reading_lists/templates/reading_lists/readinglist_confirm_assign_metron.html:3
+msgid "Assign %(name)s to Metron - Metron"
+msgstr "Assegna %(name)s a Metron - Metron"
+
+#: reading_lists/templates/reading_lists/readinglist_confirm_assign_metron.html:6
+msgid "Assign Reading List to Metron"
+msgstr "Assegna Lista di Lettura a Metron"
+
+#: reading_lists/templates/reading_lists/readinglist_confirm_assign_metron.html:15
+msgid "Confirm ownership change"
+msgstr "Conferma cambio di proprietà"
+
+#: reading_lists/templates/reading_lists/readinglist_confirm_assign_metron.html:19
+#, python-format
+msgid ""
+"Are you sure you want to reassign ownership of the reading list <strong>\"%(name)s\"</"
+"strong> from <strong>%(username)s</strong> to the <strong>Metron</strong> account?"
+msgstr ""
+"Sei sicuro di voler riassegnare la proprietà della lista di lettura "
+"<strong>\"%(name)s\"</strong> da <strong>%(username)s</strong> all'account "
+"<strong>Metron</strong>?"
+
+#: reading_lists/templates/reading_lists/readinglist_confirm_assign_metron.html:21
+msgid "This action cannot be undone from this page."
+msgstr "Questa azione non può essere annullata da questa pagina."
+
+#: reading_lists/templates/reading_lists/readinglist_confirm_assign_metron.html:32
+#: reading_lists/templates/reading_lists/readinglist_detail.html:184
+msgid "Assign to Metron"
+msgstr "Assegna a Metron"
+
+#: reading_lists/templates/reading_lists/readinglist_confirm_delete.html:3
+msgid "Delete %(name)s - Metron"
+msgstr "Elimina %(name)s - Metron"
+
+#: reading_lists/templates/reading_lists/readinglist_confirm_delete.html:6
+msgid "Delete Reading List"
+msgstr "Elimina Lista di Lettura"
+
+#: reading_lists/templates/reading_lists/readinglist_confirm_delete.html:15
+#: user_collection/templates/user_collection/collection_confirm_delete.html:15
+#: wish_list/templates/wish_list/wishlist_item_confirm_delete.html:15
+msgid "Warning"
+msgstr "Attenzione"
+
+#: reading_lists/templates/reading_lists/readinglist_confirm_delete.html:19
+msgid "Are you sure you want to delete the reading list <strong>\"%(name)s\"</strong>?"
+msgstr ""
+"Sei sicuro di voler eliminare la lista di lettura <strong>\"%(name)s\"</strong>?"
+
+#: reading_lists/templates/reading_lists/readinglist_confirm_delete.html:21
+#: user_collection/templates/user_collection/collection_confirm_delete.html:24
+#: user_collection/templates/user_collection/partials/read_dates_list.html:30
+#: wish_list/templates/wish_list/wishlist_item_confirm_delete.html:19
+msgid "This action cannot be undone."
+msgstr "Questa azione non può essere annullata."
+
+#: reading_lists/templates/reading_lists/readinglist_detail.html:21
+#, python-format
+msgid "Reading List &middot; %(list_type)s"
+msgstr "Lista di Lettura &middot; %(list_type)s"
+
+#: reading_lists/templates/reading_lists/readinglist_detail.html:33
+msgid "Curated by"
+msgstr "Curata da"
+
+#: reading_lists/templates/reading_lists/readinglist_detail.html:48
+msgid "%(avg)s &middot; %(counter)s rating"
+msgid_plural "%(avg)s &middot; %(counter)s ratings"
+msgstr[0] "%(avg)s &middot; %(counter)s valutazione"
+msgstr[1] "%(avg)s &middot; %(counter)s valutazioni"
+
+#: reading_lists/templates/reading_lists/readinglist_detail.html:51
+msgid "No ratings yet"
+msgstr "Nessuna valutazione ancora"
+
+#: reading_lists/templates/reading_lists/readinglist_detail.html:64
+msgid "Link copied!"
+msgstr "Link copiato!"
+
+#: reading_lists/templates/reading_lists/readinglist_detail.html:66
+msgid "Share"
+msgstr "Condividi"
+
+#: reading_lists/templates/reading_lists/readinglist_detail.html:73
+msgid "Rate this list"
+msgstr "Valuta questa lista"
+
+#: reading_lists/templates/reading_lists/readinglist_detail.html:84
+#: templates/partials/navbar.html:80
+#: user_collection/templates/user_collection/collection_stats.html:227
+#: users/templates/users/customuser_detail.html:241
+msgid "Issues"
+msgstr "Albi"
+
+#: reading_lists/templates/reading_lists/readinglist_detail.html:88
+msgid "Reading span"
+msgstr "Periodo di lettura"
+
+#: reading_lists/templates/reading_lists/readinglist_detail.html:96
+#: reading_lists/templates/reading_lists/readinglist_detail.html:327
+#: reading_lists/templates/reading_lists/readinglist_detail.html:344
+#: templates/partials/navbar.html:62 users/templates/users/customuser_detail.html:219
+msgid "Publishers"
+msgstr "Editori"
+
+#: reading_lists/templates/reading_lists/readinglist_detail.html:105
+msgid "Composition"
+msgstr "Composizione"
+
+#: reading_lists/templates/reading_lists/readinglist_detail.html:132
+msgid "Previous"
+msgstr "Precedente"
+
+#: reading_lists/templates/reading_lists/readinglist_detail.html:142
+msgid "Next"
+msgstr "Successivo"
+
+#: reading_lists/templates/reading_lists/readinglist_detail.html:165
+#: reading_lists/templates/reading_lists/readinglist_detail.html:249
+#: user_collection/templates/user_collection/collection_list.html:39
+msgid "Add from Series"
+msgstr "Aggiungi dalla Serie"
+
+#: reading_lists/templates/reading_lists/readinglist_detail.html:169
+#: reading_lists/templates/reading_lists/readinglist_detail.html:253
+msgid "Add from Arc"
+msgstr "Aggiungi da Arco"
+
+#: reading_lists/templates/reading_lists/readinglist_detail.html:173
+#: user_collection/templates/user_collection/collection_detail.html:27
+#: user_collection/templates/user_collection/collection_list.html:132
+#: wish_list/templates/wish_list/wishlist_detail.html:123
+msgid "Edit"
+msgstr "Modifica"
+
+#: reading_lists/templates/reading_lists/readinglist_detail.html:197
+msgid "About this list"
+msgstr "Informazioni su questa lista"
+
+#: reading_lists/templates/reading_lists/readinglist_detail.html:203
+msgid "Issues (%(count)s)"
+msgstr "Albi (%(count)s)"
+
+#: reading_lists/templates/reading_lists/readinglist_detail.html:209
+#: user_collection/templates/user_collection/partials/collection_filter.html:156
+msgid "All"
+msgstr "Tutti"
+
+#: reading_lists/templates/reading_lists/readinglist_detail.html:240
+msgid "No issues in this list yet."
+msgstr "Nessun albo ancora in questa lista."
+
+#: reading_lists/templates/reading_lists/readinglist_detail.html:264
+msgid "List details"
+msgstr "Dettagli Lista"
+
+#: reading_lists/templates/reading_lists/readinglist_detail.html:266
+msgid "Owner:"
+msgstr "Proprietario:"
+
+#: reading_lists/templates/reading_lists/readinglist_detail.html:270
+msgid "Type:"
+msgstr "Tipo:"
+
+#: reading_lists/templates/reading_lists/readinglist_detail.html:272
+msgid "Visibility:"
+msgstr "Visibilità:"
+
+#: reading_lists/templates/reading_lists/readinglist_detail.html:281
+msgid "Reading span:"
+msgstr "Periodo di lettura:"
+
+#: reading_lists/templates/reading_lists/readinglist_detail.html:287
+msgid "Source:"
+msgstr "Fonte:"
+
+#: reading_lists/templates/reading_lists/readinglist_detail.html:299
+msgid "Created:"
+msgstr "Creata:"
+
+#: reading_lists/templates/reading_lists/readinglist_detail.html:301
+msgid "Last modified:"
+msgstr "Ultima modifica:"
+
+#: reading_lists/templates/reading_lists/readinglist_detail.html:310
+msgid "Series in this list"
+msgstr "Serie in questa lista"
+
+#: reading_lists/templates/reading_lists/readinglist_detail.html:355
+msgid "Top Characters"
+msgstr "Personaggi Principali"
+
+#: reading_lists/templates/reading_lists/readinglist_detail.html:391
+msgid "Featured Creators"
+msgstr "Autori in Evidenza"
+
+#: reading_lists/templates/reading_lists/readinglist_form.html:101
+msgid "Clear selection"
+msgstr "Cancella selezione"
+
+#: reading_lists/templates/reading_lists/readinglist_list.html:3
+#: reading_lists/templates/reading_lists/readinglist_list.html:6
+#: reading_lists/templates/reading_lists/readinglist_list.html:41
+#: templates/partials/navbar.html:132
+msgid "My Reading Lists"
+msgstr "Le Mie Liste di Lettura"
+
+#: reading_lists/templates/reading_lists/readinglist_list.html:3
+#: reading_lists/templates/reading_lists/readinglist_list.html:6
+#: templates/partials/navbar.html:119
+msgid "Reading Lists"
+msgstr "Liste di Lettura"
+
+#: reading_lists/templates/reading_lists/readinglist_list.html:21
+msgid "Reading list navigation"
+msgstr "Navigazione lista di lettura"
+
+#: reading_lists/templates/reading_lists/readinglist_list.html:25
+msgid "<strong>%(formatted_count)s</strong> reading list"
+msgid_plural "<strong>%(formatted_count)s</strong> reading lists"
+msgstr[0] "<strong>%(formatted_count)s</strong> lista di lettura"
+msgstr[1] "<strong>%(formatted_count)s</strong> liste di lettura"
+
+#: reading_lists/templates/reading_lists/readinglist_list.html:36
+msgid "All Reading Lists"
+msgstr "Tutte le Liste di Lettura"
+
+#: reading_lists/templates/reading_lists/readinglist_list.html:46
+#: reading_lists/templates/reading_lists/readinglist_list.html:69
+#: reading_lists/templates/reading_lists/readinglist_list.html:84
+#: reading_lists/views.py:507
+msgid "Create Reading List"
+msgstr "Crea Lista di Lettura"
+
+#: reading_lists/templates/reading_lists/readinglist_list.html:65
+msgid "You don't have any reading lists yet"
+msgstr "Non hai ancora nessuna lista di lettura"
+
+#: reading_lists/templates/reading_lists/readinglist_list.html:66
+#: reading_lists/templates/reading_lists/readinglist_list.html:81
+msgid "Create your first reading list!"
+msgstr "Crea la tua prima lista di lettura!"
+
+#: reading_lists/templates/reading_lists/readinglist_list.html:72
+#: user_collection/templates/user_collection/collection_list.html:157
+msgid "No results found"
+msgstr "Nessun risultato trovato"
+
+#: reading_lists/templates/reading_lists/readinglist_list.html:73
+#: user_collection/templates/user_collection/collection_list.html:158
+msgid "Try adjusting your search filters"
+msgstr "Prova a modificare i filtri di ricerca"
+
+#: reading_lists/templates/reading_lists/readinglist_list.html:76
+#: user_collection/templates/user_collection/collection_list.html:162
+msgid "Clear All Filters"
+msgstr "Cancella Tutti i Filtri"
+
+#: reading_lists/templates/reading_lists/readinglist_list.html:79
+msgid "No reading lists found"
+msgstr "Nessuna lista di lettura trovata"
+
+#: reading_lists/templates/reading_lists/readinglist_list.html:87
+msgid "Login to create your own reading lists"
+msgstr "Accedi per creare le tue liste di lettura"
+
+#: reading_lists/templates/reading_lists/remove_issue_confirm.html:3
+msgid "Remove Issue - Metron"
+msgstr "Rimuovi Albo - Metron"
+
+#: reading_lists/templates/reading_lists/remove_issue_confirm.html:6
+msgid "Remove Issue from Reading List"
+msgstr "Rimuovi Albo dalla Lista di Lettura"
+
+#: reading_lists/templates/reading_lists/remove_issue_confirm.html:16
+msgid "Remove <strong>%(issue)s</strong> from <strong>%(name)s</strong>?"
+msgstr "Rimuovere <strong>%(issue)s</strong> da <strong>%(name)s</strong>?"
+
+#: reading_lists/views.py:43 users/templates/users/customuser_list.html:37
+#: users/templates/users/customuser_list.html:41
+msgid "Search"
+msgstr "Cerca"
+
+#: reading_lists/views.py:44 users/templates/users/api_token.html:85
+msgid "Name"
+msgstr "Nome"
+
+#: reading_lists/views.py:48
+msgid "Attribution"
+msgstr "Attribuzione"
+
+#: reading_lists/views.py:49
+msgid "Min Rating"
+msgstr "Valutazione Min"
+
+#: reading_lists/views.py:74 reading_lists/views.py:75 reading_lists/views.py:76
+#: reading_lists/views.py:77
+msgid "Artist"
+msgstr "Disegnatore"
+
+#: reading_lists/views.py:78 reading_lists/views.py:79 reading_lists/views.py:80
+msgid "Writer"
+msgstr "Sceneggiatore"
+
+#: reading_lists/views.py:501
+#, python-format
+msgid "Reading list '%(name)s' created!"
+msgstr "Lista di lettura '%(name)s' creata!"
+
+#: reading_lists/views.py:508
+msgid "Create"
+msgstr "Crea"
+
+#: reading_lists/views.py:536
+#, python-format
+msgid "Reading list '%(name)s' updated!"
+msgstr "Lista di lettura '%(name)s' aggiornata!"
+
+#: reading_lists/views.py:542
+msgid "Edit Reading List"
+msgstr "Modifica Lista di Lettura"
+
+#: reading_lists/views.py:543
+#: user_collection/templates/user_collection/collection_form.html:77
+msgid "Update"
+msgstr "Aggiorna"
+
+#: reading_lists/views.py:561
+#, python-format
+msgid "Reading list '%(name)s' deleted!"
+msgstr "Lista di lettura '%(name)s' eliminata!"
+
+#: reading_lists/views.py:588
+msgid "The 'Metron' user account does not exist."
+msgstr "L'account utente 'Metron' non esiste."
+
+#: reading_lists/views.py:596
+#, python-format
+msgid "Ownership of '%(name)s' has been reassigned to Metron."
+msgstr "La proprietà di '%(name)s' è stata riassegnata a Metron."
+
+#: reading_lists/views.py:620
+msgid "Removed %(issue)s from '%(name)s'!"
+msgstr "Rimosso %(issue)s da '%(name)s'!"
+
+#: reading_lists/views.py:695
+msgid "Added %(issue)s"
+msgstr "Aggiunto %(issue)s"
+
+#: reading_lists/views.py:698
+msgid "Added %(count)d issue"
+msgid_plural "Added %(count)d issues"
+msgstr[0] "Aggiunto %(count)d albo"
+msgstr[1] "Aggiunti %(count)d albi"
+
+#: reading_lists/views.py:705
+#, python-format
+msgid "reordered %(count)d existing issue"
+msgid_plural "reordered %(count)d existing issues"
+msgstr[0] "riordinato %(count)d albo esistente"
+msgstr[1] "riordinati %(count)d albi esistenti"
+
+#: reading_lists/views.py:714
+msgid "%(first)s and %(second)s"
+msgstr "%(first)s e %(second)s"
+
+#: reading_lists/views.py:722
+#, python-format
+msgid "%(summary)s in '%(name)s'!"
+msgstr "%(summary)s in '%(name)s'!"
+
+#: reading_lists/views.py:730
+msgid "Skipped %(count)d duplicate issue."
+msgid_plural "Skipped %(count)d duplicate issues."
+msgstr[0] "Saltato %(count)d albo duplicato."
+msgstr[1] "Saltati %(count)d albi duplicati."
+
+#: reading_lists/views.py:738
+msgid "No changes were made."
+msgstr "Nessuna modifica effettuata."
+
+#: reading_lists/views.py:778
+msgid "No new issues to add. All issues from %(series)s are already in the list."
+msgstr ""
+"Nessun nuovo albo da aggiungere. Tutti gli albi di %(series)s sono già nella lista."
+
+#: reading_lists/views.py:785
+#, python-format
+msgid "Added %(count)d issue from %(series)s at the beginning of '%(name)s'!"
+msgid_plural "Added %(count)d issues from %(series)s at the beginning of '%(name)s'!"
+msgstr[0] "Aggiunto %(count)d albo da %(series)s all'inizio di '%(name)s'!"
+msgstr[1] "Aggiunti %(count)d albi da %(series)s all'inizio di '%(name)s'!"
+
+#: reading_lists/views.py:791
+#, python-format
+msgid "Added %(count)d issue from %(series)s at the end of '%(name)s'!"
+msgid_plural "Added %(count)d issues from %(series)s at the end of '%(name)s'!"
+msgstr[0] "Aggiunto %(count)d albo da %(series)s alla fine di '%(name)s'!"
+msgstr[1] "Aggiunti %(count)d albi da %(series)s alla fine di '%(name)s'!"
+
+#: reading_lists/views.py:821
+#, python-format
+msgid "No new issues to add. All issues from %(arc)s are already in the list."
+msgstr ""
+"Nessun nuovo albo da aggiungere. Tutti gli albi di %(arc)s sono già nella lista."
+
+#: reading_lists/views.py:828
+#, python-format
+msgid "Added %(count)d issue from %(arc)s at the beginning of '%(name)s'!"
+msgid_plural "Added %(count)d issues from %(arc)s at the beginning of '%(name)s'!"
+msgstr[0] "Aggiunto %(count)d albo da %(arc)s all'inizio di '%(name)s'!"
+msgstr[1] "Aggiunti %(count)d albi da %(arc)s all'inizio di '%(name)s'!"
+
+#: reading_lists/views.py:834
+#, python-format
+msgid "Added %(count)d issue from %(arc)s at the end of '%(name)s'!"
+msgid_plural "Added %(count)d issues from %(arc)s at the end of '%(name)s'!"
+msgstr[0] "Aggiunto %(count)d albo da %(arc)s alla fine di '%(name)s'!"
+msgstr[1] "Aggiunti %(count)d albi da %(arc)s alla fine di '%(name)s'!"
 
 #: templates/base.html:9 users/templates/registration/account_activation_email.html:210
 #: users/templates/registration/account_activation_email.txt:21
@@ -690,31 +1797,13 @@ msgstr "Future"
 msgid "Browse"
 msgstr "Esplora"
 
-#: templates/partials/navbar.html:62 users/templates/users/customuser_detail.html:219
-msgid "Publishers"
-msgstr "Editori"
-
 #: templates/partials/navbar.html:68 users/templates/users/customuser_detail.html:285
 msgid "Imprints"
 msgstr "Etichette"
 
-#: templates/partials/navbar.html:80
-#: user_collection/templates/user_collection/collection_stats.html:227
-#: users/templates/users/customuser_detail.html:241
-msgid "Issues"
-msgstr "Albi"
-
 #: templates/partials/navbar.html:87 users/templates/users/customuser_detail.html:263
 msgid "Creators"
 msgstr "Autori"
-
-#: templates/partials/navbar.html:93 users/templates/users/customuser_detail.html:252
-msgid "Characters"
-msgstr "Personaggi"
-
-#: templates/partials/navbar.html:99 users/templates/users/customuser_detail.html:274
-msgid "Teams"
-msgstr "Squadre"
 
 #: templates/partials/navbar.html:106
 msgid "Story Arcs"
@@ -724,17 +1813,9 @@ msgstr "Archi Narrativi"
 msgid "Universes"
 msgstr "Universi"
 
-#: templates/partials/navbar.html:119
-msgid "Reading Lists"
-msgstr "Liste di Lettura"
-
 #: templates/partials/navbar.html:126
 msgid "My Library"
 msgstr "La Mia Libreria"
-
-#: templates/partials/navbar.html:132
-msgid "My Reading Lists"
-msgstr "Le Mie Liste di Lettura"
 
 #: templates/partials/navbar.html:138
 #: user_collection/templates/user_collection/reading_history.html:30
@@ -914,18 +1995,6 @@ msgstr ""
 #: user_collection/forms.py:109
 msgid "This issue is already in your collection."
 msgstr "Questo albo è già nella tua collezione."
-
-#: user_collection/forms.py:118
-msgid "All issues"
-msgstr "Tutti gli albi"
-
-#: user_collection/forms.py:119
-msgid "Issue range"
-msgstr "Intervallo di albi"
-
-#: user_collection/forms.py:133
-msgid "Select the series to add issues from"
-msgstr "Seleziona la serie da cui aggiungere gli albi"
 
 #: user_collection/forms.py:140
 msgid "Which issues?"
@@ -1193,50 +2262,9 @@ msgstr "Date di Lettura"
 msgid "Add from Series - My Collection - Metron"
 msgstr "Aggiungi dalla Serie - La Mia Collezione - Metron"
 
-#: user_collection/templates/user_collection/add_issues_from_series.html:9
-msgid "Add Issues from Series"
-msgstr "Aggiungi Albi dalla Serie"
-
 #: user_collection/templates/user_collection/add_issues_from_series.html:10
 msgid "Bulk add to your collection"
 msgstr "Aggiunta massiva alla tua collezione"
-
-#: user_collection/templates/user_collection/add_issues_from_series.html:85
-msgid "Add Issues"
-msgstr "Aggiungi Albi"
-
-#: user_collection/templates/user_collection/add_issues_from_series.html:91
-msgid "How to use:"
-msgstr "Come si usa:"
-
-#: user_collection/templates/user_collection/add_issues_from_series.html:94
-msgid "Select a series:"
-msgstr "Seleziona una serie:"
-
-#: user_collection/templates/user_collection/add_issues_from_series.html:94
-msgid "Start typing in the search box to find a series by name"
-msgstr "Inizia a digitare nella casella di ricerca per trovare una serie per nome"
-
-#: user_collection/templates/user_collection/add_issues_from_series.html:97
-msgid "Choose what to add:"
-msgstr "Scegli cosa aggiungere:"
-
-#: user_collection/templates/user_collection/add_issues_from_series.html:100
-msgid "All issues:"
-msgstr "Tutti gli albi:"
-
-#: user_collection/templates/user_collection/add_issues_from_series.html:100
-msgid "Adds every issue from the series"
-msgstr "Aggiunge tutti gli albi della serie"
-
-#: user_collection/templates/user_collection/add_issues_from_series.html:103
-msgid "Issue range:"
-msgstr "Intervallo di albi:"
-
-#: user_collection/templates/user_collection/add_issues_from_series.html:103
-msgid "Specify a start and/or end issue number (e.g., start at #1, end at #50)"
-msgstr ""
-"Specifica un numero di albo iniziale e/o finale (es. inizia da #1, termina a #50)"
 
 #: user_collection/templates/user_collection/add_issues_from_series.html:107
 msgid "Issues already in your collection will be automatically skipped"
@@ -1262,10 +2290,6 @@ msgstr ""
 "e aggiornare lo stato di lettura"
 
 #: user_collection/templates/user_collection/add_issues_from_series.html:115
-msgid "Tip:"
-msgstr "Suggerimento:"
-
-#: user_collection/templates/user_collection/add_issues_from_series.html:115
 msgid ""
 "This is a quick way to add an entire series to your collection. After adding, you can "
 "update individual issues with purchase details, format preferences, and notes!"
@@ -1284,11 +2308,6 @@ msgstr "Rimuovi %(issue)s - Metron"
 msgid "Remove from Collection"
 msgstr "Rimuovi dalla Collezione"
 
-#: user_collection/templates/user_collection/collection_confirm_delete.html:15
-#: wish_list/templates/wish_list/wishlist_item_confirm_delete.html:15
-msgid "Warning"
-msgstr "Attenzione"
-
 #: user_collection/templates/user_collection/collection_confirm_delete.html:19
 #, python-format
 msgid "Are you sure you want to remove <strong>%(issue)s</strong> from your collection?"
@@ -1297,12 +2316,6 @@ msgstr "Sei sicuro di voler rimuovere <strong>%(issue)s</strong> dalla tua colle
 #: user_collection/templates/user_collection/collection_confirm_delete.html:22
 msgid "This will also delete the associated purchase information and notes."
 msgstr "Questo eliminerà anche le informazioni di acquisto e le note associate."
-
-#: user_collection/templates/user_collection/collection_confirm_delete.html:24
-#: user_collection/templates/user_collection/partials/read_dates_list.html:30
-#: wish_list/templates/wish_list/wishlist_item_confirm_delete.html:19
-msgid "This action cannot be undone."
-msgstr "Questa azione non può essere annullata."
 
 #: user_collection/templates/user_collection/collection_detail.html:4
 #, python-format
@@ -1318,12 +2331,6 @@ msgstr "Dettagli Elemento della Collezione"
 #: user_collection/templates/user_collection/missing_issues_list.html:14
 msgid "Back to Collection"
 msgstr "Torna alla Collezione"
-
-#: user_collection/templates/user_collection/collection_detail.html:27
-#: user_collection/templates/user_collection/collection_list.html:132
-#: wish_list/templates/wish_list/wishlist_detail.html:123
-msgid "Edit"
-msgstr "Modifica"
 
 #: user_collection/templates/user_collection/collection_detail.html:60
 msgid "Issue Information"
@@ -1345,10 +2352,6 @@ msgstr "Editore:"
 #: user_collection/templates/user_collection/collection_detail.html:75
 msgid "Cover Date:"
 msgstr "Data di Copertina:"
-
-#: user_collection/templates/user_collection/collection_detail.html:84
-msgid "Description"
-msgstr "Descrizione"
 
 #: user_collection/templates/user_collection/collection_detail.html:90
 msgid "Grading Information"
@@ -1453,10 +2456,6 @@ msgstr "Modifica Elemento della Collezione"
 msgid "Add Collection Item"
 msgstr "Aggiungi Elemento alla Collezione"
 
-#: user_collection/templates/user_collection/collection_form.html:77
-msgid "Update"
-msgstr "Aggiorna"
-
 #: user_collection/templates/user_collection/collection_form.html:79
 msgid "Add to Collection"
 msgstr "Aggiungi alla Collezione"
@@ -1490,10 +2489,6 @@ msgstr "Cronologia Letture"
 msgid "Missing Issues"
 msgstr "Albi Mancanti"
 
-#: user_collection/templates/user_collection/collection_list.html:39
-msgid "Add from Series"
-msgstr "Aggiungi dalla Serie"
-
 #: user_collection/templates/user_collection/collection_list.html:44
 msgid "Add Issue"
 msgstr "Aggiungi Albo"
@@ -1525,18 +2520,6 @@ msgstr "Letto il %(read_date)s"
 #: user_collection/templates/user_collection/reading_history.html:121
 msgid "View Details"
 msgstr "Visualizza Dettagli"
-
-#: user_collection/templates/user_collection/collection_list.html:157
-msgid "No results found"
-msgstr "Nessun risultato trovato"
-
-#: user_collection/templates/user_collection/collection_list.html:158
-msgid "Try adjusting your search filters"
-msgstr "Prova a modificare i filtri di ricerca"
-
-#: user_collection/templates/user_collection/collection_list.html:162
-msgid "Clear All Filters"
-msgstr "Cancella Tutti i Filtri"
 
 #: user_collection/templates/user_collection/collection_list.html:165
 msgid "Your collection is empty"
@@ -1699,29 +2682,13 @@ msgstr "Possiedi collezioni complete di tutte le tue serie."
 msgid "Search Collection"
 msgstr "Cerca nella Collezione"
 
-#: user_collection/templates/user_collection/partials/collection_filter.html:18
-msgid "Filters Active"
-msgstr "Filtri Attivi"
-
-#: user_collection/templates/user_collection/partials/collection_filter.html:24
-msgid "Quick Search"
-msgstr "Ricerca Rapida"
-
 #: user_collection/templates/user_collection/partials/collection_filter.html:31
 msgid "Search across series and notes..."
 msgstr "Cerca tra serie e note..."
 
-#: user_collection/templates/user_collection/partials/collection_filter.html:32
-msgid "Quick search"
-msgstr "Ricerca rapida"
-
 #: user_collection/templates/user_collection/partials/collection_filter.html:37
 msgid "Search across series names and notes"
 msgstr "Cerca tra i nomi delle serie e le note"
-
-#: user_collection/templates/user_collection/partials/collection_filter.html:46
-msgid "Advanced Filters"
-msgstr "Filtri Avanzati"
 
 #: user_collection/templates/user_collection/partials/collection_filter.html:53
 msgid "Series Name"
@@ -1742,18 +2709,6 @@ msgstr "Tipo di Serie"
 #: user_collection/templates/user_collection/partials/collection_filter.html:75
 msgid "Filter by series type"
 msgstr "Filtra per tipo di serie"
-
-#: user_collection/templates/user_collection/partials/collection_filter.html:76
-msgid "All Types"
-msgstr "Tutti i Tipi"
-
-#: user_collection/templates/user_collection/partials/collection_filter.html:101
-msgid "e.g., Marvel"
-msgstr "es. Marvel"
-
-#: user_collection/templates/user_collection/partials/collection_filter.html:102
-msgid "Filter by publisher"
-msgstr "Filtra per editore"
 
 #: user_collection/templates/user_collection/partials/collection_filter.html:112
 msgid "Issue Number"
@@ -1783,10 +2738,6 @@ msgstr "Stato Lettura"
 msgid "Filter by read status"
 msgstr "Filtra per stato di lettura"
 
-#: user_collection/templates/user_collection/partials/collection_filter.html:156
-msgid "All"
-msgstr "Tutti"
-
 #: user_collection/templates/user_collection/partials/collection_filter.html:175
 msgid "Filter by grade"
 msgstr "Filtra per grado"
@@ -1807,28 +2758,12 @@ msgstr "Tutte le Società"
 msgid "Filter by rating"
 msgstr "Filtra per valutazione"
 
-#: user_collection/templates/user_collection/partials/collection_filter.html:222
-msgid "All Ratings"
-msgstr "Tutte le Valutazioni"
-
 #: user_collection/templates/user_collection/partials/collection_filter.html:226
 #, python-format
 msgid "%(counter)s Star"
 msgid_plural "%(counter)s Stars"
 msgstr[0] "%(counter)s Stella"
 msgstr[1] "%(counter)s Stelle"
-
-#: user_collection/templates/user_collection/partials/collection_filter.html:246
-msgid "Apply Filters"
-msgstr "Applica Filtri"
-
-#: user_collection/templates/user_collection/partials/collection_filter.html:252
-msgid "Clear all filters"
-msgstr "Cancella tutti i filtri"
-
-#: user_collection/templates/user_collection/partials/collection_filter.html:256
-msgid "Clear Filters"
-msgstr "Cancella Filtri"
 
 #: user_collection/templates/user_collection/partials/read_dates_list.html:9
 msgid "Remove read date"
@@ -2189,6 +3124,7 @@ msgstr ""
 "tempo, dovrai registrarti di nuovo."
 
 #: users/templates/registration/account_activation_email.txt:29
+#, python-format
 msgid "(c) %(current_year)s Metron Project. All rights reserved."
 msgstr "(c) %(current_year)s Metron Project. Tutti i diritti riservati."
 
@@ -2530,10 +3466,6 @@ msgstr "I Tuoi Token"
 msgid "Never"
 msgstr "Mai"
 
-#: users/templates/users/api_token.html:85
-msgid "Name"
-msgstr "Nome"
-
 #: users/templates/users/api_token.html:86
 msgid "Created"
 msgstr "Creato"
@@ -2588,11 +3520,6 @@ msgstr "Per cambiare la tua password, utilizza il"
 msgid "password change form"
 msgstr "modulo di cambio password"
 
-#: users/templates/users/change_profile.html:111
-#: wish_list/templates/wish_list/wishlist_item_form.html:53
-msgid "Save Changes"
-msgstr "Salva Modifiche"
-
 #: users/templates/users/change_profile.html:132
 msgid "Profile Tips:"
 msgstr "Suggerimenti per il Profilo:"
@@ -2614,10 +3541,12 @@ msgid "Email address is used for notifications and account recovery"
 msgstr "L'indirizzo email viene utilizzato per notifiche e recupero dell'account"
 
 #: users/templates/users/customuser_detail.html:7
+#, python-format
 msgid "%(username)s - Metron"
 msgstr "%(username)s - Metron"
 
 #: users/templates/users/customuser_detail.html:11
+#, python-format
 msgid "Profile page for %(username)s on Metron Comic Book Database."
 msgstr "Pagina del profilo di %(username)s su Metron Comic Book Database."
 
@@ -2756,6 +3685,7 @@ msgid "(%(remaining)s remaining)"
 msgstr "(%(remaining)s rimanenti)"
 
 #: users/templates/users/customuser_detail.html:372
+#, python-format
 msgid "%(pct)s%% used"
 msgstr "%(pct)s%% utilizzato"
 
@@ -2805,6 +3735,7 @@ msgid "List navigation and actions"
 msgstr "Navigazione ed azioni elenco"
 
 #: users/templates/users/customuser_list.html:17
+#, python-format
 msgid "<strong>%(formatted_count)s</strong> User"
 msgid_plural "<strong>%(formatted_count)s</strong> Users"
 msgstr[0] "<strong>%(formatted_count)s</strong> Utente"
@@ -2822,11 +3753,6 @@ msgstr "Cerca Utenti"
 #: users/templates/users/customuser_list.html:34
 msgid "Find a user"
 msgstr "Trova un utente"
-
-#: users/templates/users/customuser_list.html:37
-#: users/templates/users/customuser_list.html:41
-msgid "Search"
-msgstr "Cerca"
 
 #: users/templates/users/customuser_list.html:70
 msgid "Default profile picture"

--- a/polls/templates/polls/partials/poll_results.html
+++ b/polls/templates/polls/partials/poll_results.html
@@ -1,5 +1,6 @@
+{% load i18n %}
 <div class="box">
-    <h3 class="title is-5">Results</h3>
+    <h3 class="title is-5">{% trans "Results" %}</h3>
     {% if total_votes > 0 %}
         {% for choice in choices %}
             <div class="mb-4">
@@ -17,7 +18,7 @@
                     <div class="level-right">
                         <div class="level-item">
                             <span class="is-size-7 has-text-grey">
-                                {{ choice.vote_count }} vote{{ choice.vote_count|pluralize }}
+                                {% blocktrans count counter=choice.vote_count %}{{ counter }} vote{% plural %}{{ counter }} votes{% endblocktrans %}
                                 ({% widthratio choice.vote_count total_votes 100 %}%)
                             </span>
                         </div>
@@ -32,9 +33,9 @@
             </div>
         {% endfor %}
         <p class="is-size-7 has-text-grey mt-3">
-            <strong>{{ total_votes }}</strong> total vote{{ total_votes|pluralize }}
+            {% blocktrans count counter=total_votes %}<strong>{{ counter }}</strong> total vote{% plural %}<strong>{{ counter }}</strong> total votes{% endblocktrans %}
         </p>
     {% else %}
-        <p class="has-text-grey">No votes have been cast yet.</p>
+        <p class="has-text-grey">{% trans "No votes have been cast yet." %}</p>
     {% endif %}
 </div>

--- a/polls/templates/polls/poll_confirm_delete.html
+++ b/polls/templates/polls/poll_confirm_delete.html
@@ -1,15 +1,15 @@
 {% extends parent_template|default:"base.html" %}
-{% block title %}Delete Poll - Metron{% endblock %}
+{% load i18n %}
+{% block title %}{% trans "Delete Poll - Metron" %}{% endblock %}
 {% block content %}
     <section class="section">
         <div class="container">
             <div class="columns is-centered">
                 <div class="column is-half">
                     <div class="box">
-                        <h1 class="title is-4">Delete Poll</h1>
+                        <h1 class="title is-4">{% trans "Delete Poll" %}</h1>
                         <p class="mb-4">
-                            Are you sure you want to delete <strong>{{ object.title }}</strong>?
-                            This will also delete all votes cast in this poll and cannot be undone.
+                            {% blocktrans with title=object.title %}Are you sure you want to delete <strong>{{ title }}</strong>? This will also delete all votes cast in this poll and cannot be undone.{% endblocktrans %}
                         </p>
                         <form method="post">
                             {% csrf_token %}
@@ -17,12 +17,12 @@
                                 <div class="control">
                                     <button type="submit" class="button is-danger">
                                         <span class="icon"><i class="fas fa-trash"></i></span>
-                                        <span>Delete</span>
+                                        <span>{% trans "Delete" %}</span>
                                     </button>
                                 </div>
                                 <div class="control">
                                     <a href="{% url 'polls:detail' object.pk %}"
-                                       class="button">Cancel</a>
+                                       class="button">{% trans "Cancel" %}</a>
                                 </div>
                             </div>
                         </form>

--- a/polls/templates/polls/poll_detail.html
+++ b/polls/templates/polls/poll_detail.html
@@ -1,12 +1,13 @@
 {% extends parent_template|default:"base.html" %}
-{% block title %}{{ poll.title }} - Metron{% endblock %}
+{% load i18n %}
+{% block title %}{% blocktrans with title=poll.title %}{{ title }} - Metron{% endblocktrans %}{% endblock %}
 {% block content %}
     <nav class="breadcrumb mb-4" aria-label="breadcrumbs">
         <ul>
             <li>
                 <a href="{% url 'polls:list' %}">
                     <span class="icon is-small"><i class="fas fa-poll"></i></span>
-                    <span>Polls</span>
+                    <span>{% trans "Polls" %}</span>
                 </a>
             </li>
             <li class="is-active">
@@ -18,11 +19,11 @@
         <h1 class="title">{{ poll.title }}</h1>
         <div class="tags">
             {% if poll.status == "active" %}
-                <span class="tag is-success is-medium">Active</span>
+                <span class="tag is-success is-medium">{% trans "Active" %}</span>
             {% elif poll.status == "upcoming" %}
-                <span class="tag is-info is-medium">Upcoming</span>
+                <span class="tag is-info is-medium">{% trans "Upcoming" %}</span>
             {% else %}
-                <span class="tag is-dark is-medium">Closed</span>
+                <span class="tag is-dark is-medium">{% trans "Closed" %}</span>
             {% endif %}
         </div>
     </header>
@@ -34,7 +35,7 @@
                     <a class="button is-danger"
                        href="{% url 'polls:delete' poll.pk %}">
                         <span class="icon is-small"><i class="fas fa-trash"></i></span>
-                        <span>Delete</span>
+                        <span>{% trans "Delete" %}</span>
                     </a>
                 </div>
             </div>
@@ -44,14 +45,14 @@
         <div class="column is-two-thirds">
             {% if poll.description %}
                 <div class="box">
-                    <h2 class="title is-5">Proposal</h2>
+                    <h2 class="title is-5">{% trans "Proposal" %}</h2>
                     <div class="content">{{ poll.description|linebreaksbr }}</div>
                 </div>
             {% endif %}
             <div id="poll-voting-section">
                 {% if can_vote %}
                     <div class="box">
-                        <h2 class="title is-5">Cast Your Vote</h2>
+                        <h2 class="title is-5">{% trans "Cast Your Vote" %}</h2>
                         <form hx-post="{% url 'polls:vote' poll.pk %}"
                               hx-target="#poll-voting-section"
                               hx-swap="innerHTML">
@@ -73,7 +74,7 @@
                                 <div class="control">
                                     <button type="submit" class="button is-primary ">
                                         <span class="icon"><i class="fas fa-vote-yea"></i></span>
-                                        <span>Cast Vote</span>
+                                        <span>{% trans "Cast Vote" %}</span>
                                     </button>
                                 </div>
                             </div>
@@ -82,12 +83,12 @@
                 {% elif poll.status == "upcoming" %}
                     <div class="notification is-info is-light">
                         <span class="icon"><i class="fas fa-clock"></i></span>
-                        Voting opens on {{ poll.start_date|date:"F j, Y" }}.
+                        {% blocktrans with start_date=poll.start_date|date:"F j, Y" %}Voting opens on {{ start_date }}.{% endblocktrans %}
                     </div>
                 {% elif not user.is_authenticated and poll.status == "active" %}
                     <div class="notification is-warning is-light">
-                        <a href="{% url 'login' %}?next={{ request.path }}">Log in</a>
-                        to cast your vote.
+                        <a href="{% url 'login' %}?next={{ request.path }}">{% trans "Log in" %}</a>
+                        {% trans "to cast your vote." %}
                     </div>
                 {% else %}
                     {% include "polls/partials/poll_results.html" %}
@@ -96,20 +97,20 @@
         </div>
         <div class="column">
             <div class="box">
-                <h2 class="title is-6">Poll Details</h2>
+                <h2 class="title is-6">{% trans "Poll Details" %}</h2>
                 <dl>
-                    <dt class="has-text-weight-bold">Status:</dt>
+                    <dt class="has-text-weight-bold">{% trans "Status:" %}</dt>
                     <dd class="mb-3">
-                        {% if poll.status == "active" %}Active{% elif poll.status == "upcoming" %}Upcoming{% else %}Closed{% endif %}
+                        {% if poll.status == "active" %}{% trans "Active" %}{% elif poll.status == "upcoming" %}{% trans "Upcoming" %}{% else %}{% trans "Closed" %}{% endif %}
                     </dd>
-                    <dt class="has-text-weight-bold">Voting Opens:</dt>
+                    <dt class="has-text-weight-bold">{% trans "Voting Opens:" %}</dt>
                     <dd class="mb-3">{{ poll.start_date|date:"F j, Y" }}</dd>
-                    <dt class="has-text-weight-bold">Voting Closes:</dt>
+                    <dt class="has-text-weight-bold">{% trans "Voting Closes:" %}</dt>
                     <dd class="mb-3">{{ poll.end_date|date:"F j, Y" }}</dd>
-                    <dt class="has-text-weight-bold">Total Votes:</dt>
+                    <dt class="has-text-weight-bold">{% trans "Total Votes:" %}</dt>
                     <dd class="mb-3">{{ total_votes }}</dd>
                     {% if poll.created_by %}
-                        <dt class="has-text-weight-bold">Created By:</dt>
+                        <dt class="has-text-weight-bold">{% trans "Created By:" %}</dt>
                         <dd class="mb-3">{{ poll.created_by.username }}</dd>
                     {% endif %}
                 </dl>

--- a/polls/templates/polls/poll_list.html
+++ b/polls/templates/polls/poll_list.html
@@ -1,9 +1,10 @@
 {% extends parent_template|default:"base.html" %}
-{% block title %}Community Polls - Metron{% endblock %}
+{% load i18n %}
+{% block title %}{% trans "Community Polls - Metron" %}{% endblock %}
 {% block content %}
     <header class="block has-text-centered">
-        <h1 class="title">Community Polls</h1>
-        <p class="subtitle">Vote on governance and policy proposals for the Metron project</p>
+        <h1 class="title">{% trans "Community Polls" %}</h1>
+        <p class="subtitle">{% trans "Vote on governance and policy proposals for the Metron project" %}</p>
     </header>
     <section class="section pt-0">
         <div class="container">
@@ -21,11 +22,11 @@
                                     <div class="content">
                                         <p class="mb-2">
                                             {% if poll.status == "active" %}
-                                                <span class="tag is-success">Active</span>
+                                                <span class="tag is-success">{% trans "Active" %}</span>
                                             {% elif poll.status == "upcoming" %}
-                                                <span class="tag is-info">Upcoming</span>
+                                                <span class="tag is-info">{% trans "Upcoming" %}</span>
                                             {% else %}
-                                                <span class="tag is-dark">Closed</span>
+                                                <span class="tag is-dark">{% trans "Closed" %}</span>
                                             {% endif %}
                                         </p>
                                         {% if poll.description %}
@@ -40,7 +41,9 @@
                                         <p class="is-size-7 has-text-grey">
                                             <span class="icon-text">
                                                 <span class="icon"><i class="fas fa-vote-yea"></i></span>
-                                                <span>{{ poll.vote_count }} vote{{ poll.vote_count|pluralize }}</span>
+                                                <span>
+                                                    {% blocktrans count counter=poll.vote_count %}{{ counter }} vote{% plural %}{{ counter }} votes{% endblocktrans %}
+                                                </span>
                                             </span>
                                         </p>
                                     </div>
@@ -51,8 +54,8 @@
                 </div>
             {% else %}
                 <div class="has-text-centered">
-                    <p class="title is-4">No polls yet</p>
-                    <p class="subtitle">Check back later for community governance polls.</p>
+                    <p class="title is-4">{% trans "No polls yet" %}</p>
+                    <p class="subtitle">{% trans "Check back later for community governance polls." %}</p>
                 </div>
             {% endif %}
         </div>

--- a/polls/views.py
+++ b/polls/views.py
@@ -6,6 +6,7 @@ from django.http import HttpResponseBadRequest, HttpResponseForbidden
 from django.shortcuts import get_object_or_404, render
 from django.urls import reverse_lazy
 from django.utils import timezone
+from django.utils.translation import gettext as _
 from django.views.decorators.http import require_POST
 from django.views.generic import DeleteView, DetailView, ListView
 
@@ -74,7 +75,9 @@ class PollDeleteView(LoginRequiredMixin, UserPassesTestMixin, DeleteView):
         return self.request.user.is_staff
 
     def form_valid(self, form):
-        messages.success(self.request, f"Poll '{self.object.title}' deleted.")
+        messages.success(
+            self.request, _("Poll '%(title)s' deleted.") % {"title": self.object.title}
+        )
         return super().form_valid(form)
 
 
@@ -85,14 +88,14 @@ def vote(request, pk):
     now = timezone.now()
 
     if not (poll.start_date <= now <= poll.end_date):
-        return HttpResponseForbidden("Voting is not currently open for this poll.")
+        return HttpResponseForbidden(_("Voting is not currently open for this poll."))
 
     if PollVote.objects.filter(poll=poll, user=request.user).exists():
-        return HttpResponseForbidden("You have already voted in this poll.")
+        return HttpResponseForbidden(_("You have already voted in this poll."))
 
     choice_pk = request.POST.get("choice")
     if not choice_pk:
-        return HttpResponseBadRequest("No choice selected.")
+        return HttpResponseBadRequest(_("No choice selected."))
 
     choice = get_object_or_404(PollChoice, pk=choice_pk, poll=poll)
     PollVote.objects.create(poll=poll, choice=choice, user=request.user)

--- a/pull_list/forms.py
+++ b/pull_list/forms.py
@@ -1,4 +1,5 @@
 from django import forms
+from django.utils.translation import gettext_lazy as _
 
 from comicsdb.autocomplete import SeriesAutocomplete
 from comicsdb.forms.widgets import SafeAutocompleteWidget
@@ -12,10 +13,10 @@ class AddSeriesToPullListForm(forms.Form):
         widget=SafeAutocompleteWidget(
             ac_class=SeriesAutocomplete,
             attrs={
-                "placeholder": "Search for a series...",
+                "placeholder": _("Search for a series..."),
                 "class": "input",
             },
         ),
-        label="Series",
-        help_text="Select a series to add to your pull list",
+        label=_("Series"),
+        help_text=_("Select a series to add to your pull list"),
     )

--- a/pull_list/models.py
+++ b/pull_list/models.py
@@ -1,6 +1,7 @@
 from django.db import models
 from django.db.models.functions import Now
 from django.urls import reverse
+from django.utils.translation import gettext_lazy as _
 
 from comicsdb.models.series import Series
 from users.models import CustomUser
@@ -23,8 +24,8 @@ class PullList(models.Model):
 
     class Meta:
         ordering = ["user"]
-        verbose_name = "Pull List"
-        verbose_name_plural = "Pull Lists"
+        verbose_name = _("Pull List")
+        verbose_name_plural = _("Pull Lists")
 
     def __str__(self) -> str:
         return f"{self.user.username}'s Pull List"
@@ -52,8 +53,8 @@ class PullListSeries(models.Model):
         indexes = [
             models.Index(fields=["pull_list", "series"], name="pull_list_series_idx"),
         ]
-        verbose_name = "Pull List Series"
-        verbose_name_plural = "Pull List Series"
+        verbose_name = _("Pull List Series")
+        verbose_name_plural = _("Pull List Series")
 
     def __str__(self) -> str:
         return f"{self.pull_list} — {self.series}"

--- a/pull_list/templates/pull_list/partials/pull_list_button.html
+++ b/pull_list/templates/pull_list/partials/pull_list_button.html
@@ -1,11 +1,12 @@
+{% load i18n %}
 <button id="pull-list-btn"
         class="button {% if on_pull_list %}is-info{% else %}is-light{% endif %}"
         hx-post="{% url 'pull-list:toggle' series.slug %}"
         hx-target="#pull-list-btn"
         hx-swap="outerHTML"
-        title="{% if on_pull_list %}Remove from pull list{% else %}Add to pull list{% endif %}">
+        title="{% if on_pull_list %}{% trans 'Remove from pull list' %}{% else %}{% trans 'Add to pull list' %}{% endif %}">
     <span class="icon is-small">
         <i class="{% if on_pull_list %}fas{% else %}far{% endif %} fa-bookmark" aria-hidden="true"></i>
     </span>
-    <span>Pull List</span>
+    <span>{% trans "Pull List" %}</span>
 </button>

--- a/pull_list/templates/pull_list/pulllist_detail.html
+++ b/pull_list/templates/pull_list/pulllist_detail.html
@@ -1,13 +1,13 @@
 {% extends parent_template|default:"base.html" %}
-{% load static %}
-{% block title %}{{ pull_list }} - Metron{% endblock %}
+{% load static i18n %}
+{% block title %}{% blocktrans with name=pull_list %}{{ name }} - Metron{% endblocktrans %}{% endblock %}
 {% block content %}
     <header class="block">
         <h1 class="title">{{ pull_list }}</h1>
     </header>
     {% if is_owner %}
         <div class="box mb-5">
-            <h2 class="title is-5">Add a Series</h2>
+            <h2 class="title is-5">{% trans "Add a Series" %}</h2>
             <form method="post">
                 {% csrf_token %}
                 {% if form.non_field_errors %}
@@ -25,7 +25,7 @@
                     <div class="control">
                         <button type="submit" class="button is-primary ">
                             <span class="icon is-small"><i class="fas fa-plus"></i></span>
-                            <span>Add</span>
+                            <span>{% trans "Add" %}</span>
                         </button>
                     </div>
                 </div>
@@ -36,15 +36,17 @@
     <div class="columns">
         <div class="column is-two-thirds">
             <div class="box">
-                <h2 class="title is-5">Series on Pull List ({{ series_on_list|length }})</h2>
+                <h2 class="title is-5">
+                    {% blocktrans with count=series_on_list|length %}Series on Pull List ({{ count }}){% endblocktrans %}
+                </h2>
                 {% if series_on_list %}
                     <div class="table-container">
                         <table class="table is-fullwidth is-striped is-hoverable">
                             <thead>
                                 <tr>
-                                    <th>Series</th>
-                                    <th>Publisher</th>
-                                    <th>Type</th>
+                                    <th>{% trans "Series" %}</th>
+                                    <th>{% trans "Publisher" %}</th>
+                                    <th>{% trans "Type" %}</th>
                                     {% if is_owner %}<th></th>{% endif %}
                                 </tr>
                             </thead>
@@ -63,7 +65,7 @@
                                                 <a href="{% url 'pull-list:remove-series' pls.series.pk %}"
                                                    class="button is-danger is-small is-outlined">
                                                     <span class="icon is-small"><i class="fas fa-times"></i></span>
-                                                    <span>Remove</span>
+                                                    <span>{% trans "Remove" %}</span>
                                                 </a>
                                             </td>
                                         {% endif %}
@@ -73,21 +75,21 @@
                         </table>
                     </div>
                 {% else %}
-                    <p class="has-text-grey">No series on this pull list yet.</p>
+                    <p class="has-text-grey">{% trans "No series on this pull list yet." %}</p>
                 {% endif %}
             </div>
         </div>
 
         <div class="column">
             <div class="box">
-                <h2 class="title is-5">Upcoming Issues</h2>
+                <h2 class="title is-5">{% trans "Upcoming Issues" %}</h2>
                 {% if upcoming_issues %}
                     <div class="table-container">
                         <table class="table is-fullwidth is-striped is-hoverable">
                             <thead>
                                 <tr>
-                                    <th>Issue</th>
-                                    <th>Store Date</th>
+                                    <th>{% trans "Issue" %}</th>
+                                    <th>{% trans "Store Date" %}</th>
                                 </tr>
                             </thead>
                             <tbody>
@@ -103,7 +105,7 @@
                         </table>
                     </div>
                 {% else %}
-                    <p class="has-text-grey">No upcoming issues found for series on this pull list.</p>
+                    <p class="has-text-grey">{% trans "No upcoming issues found for series on this pull list." %}</p>
                 {% endif %}
             </div>
         </div>

--- a/pull_list/templates/pull_list/remove_series_confirm.html
+++ b/pull_list/templates/pull_list/remove_series_confirm.html
@@ -1,9 +1,9 @@
 {% extends parent_template|default:"base.html" %}
-{% load static %}
-{% block title %}Remove Series from Pull List - Metron{% endblock %}
+{% load static i18n %}
+{% block title %}{% trans "Remove Series from Pull List - Metron" %}{% endblock %}
 {% block content %}
     <header class="block has-text-centered">
-        <h1 class="title">Remove Series</h1>
+        <h1 class="title">{% trans "Remove Series" %}</h1>
     </header>
     <section class="section">
         <div class="container">
@@ -12,22 +12,22 @@
                     <div class="box">
                         <article class="message is-warning">
                             <div class="message-header">
-                                <p>Confirm Removal</p>
+                                <p>{% trans "Confirm Removal" %}</p>
                             </div>
                             <div class="message-body">
-                                <p>Are you sure you want to remove
-                                    <strong>{{ object.series }}</strong>
-                                    from your pull list?</p>
+                                <p>
+                                    {% blocktrans with series=object.series %}Are you sure you want to remove <strong>{{ series }}</strong> from your pull list?{% endblocktrans %}
+                                </p>
                             </div>
                         </article>
                         <form method="post">
                             {% csrf_token %}
                             <div class="field is-grouped is-grouped-right">
                                 <div class="control">
-                                    <a href="{% url 'pull-list:detail' %}" class="button">Cancel</a>
+                                    <a href="{% url 'pull-list:detail' %}" class="button">{% trans "Cancel" %}</a>
                                 </div>
                                 <div class="control">
-                                    <button type="submit" class="button is-warning">Remove</button>
+                                    <button type="submit" class="button is-warning">{% trans "Remove" %}</button>
                                 </div>
                             </div>
                         </form>

--- a/pull_list/views.py
+++ b/pull_list/views.py
@@ -4,6 +4,7 @@ from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse, reverse_lazy
 from django.utils import timezone
+from django.utils.translation import gettext as _
 from django.views.decorators.http import require_POST
 from django.views.generic import DeleteView, FormView
 
@@ -14,7 +15,7 @@ from pull_list.models import PullList, PullListSeries
 
 
 def get_or_create_pull_list(user):
-    pull_list, _ = PullList.objects.get_or_create(user=user)
+    pull_list, _created = PullList.objects.get_or_create(user=user)
     return pull_list
 
 
@@ -30,11 +31,16 @@ class PullListDetailView(LoginRequiredMixin, FormView):
     def form_valid(self, form):
         pull_list = self.get_pull_list()
         series = form.cleaned_data["series"]
-        _, created = PullListSeries.objects.get_or_create(pull_list=pull_list, series=series)
+        _obj, created = PullListSeries.objects.get_or_create(pull_list=pull_list, series=series)
         if created:
-            messages.success(self.request, f"Added {series} to your pull list.")
+            messages.success(
+                self.request, _("Added %(series)s to your pull list.") % {"series": series}
+            )
         else:
-            messages.info(self.request, f"{series} is already on your pull list.")
+            messages.info(
+                self.request,
+                _("%(series)s is already on your pull list.") % {"series": series},
+            )
         return redirect(self.get_success_url())
 
     def get_success_url(self):
@@ -78,7 +84,10 @@ class RemoveSeriesFromPullListView(LoginRequiredMixin, UserPassesTestMixin, Dele
     def form_valid(self, form):
         series_name = str(self.get_object().series)
         result = super().form_valid(form)
-        messages.success(self.request, f"Removed {series_name} from your pull list.")
+        messages.success(
+            self.request,
+            _("Removed %(series)s from your pull list.") % {"series": series_name},
+        )
         return result
 
 
@@ -86,7 +95,7 @@ class RemoveSeriesFromPullListView(LoginRequiredMixin, UserPassesTestMixin, Dele
 @require_POST
 def toggle_pull_list_series(request, slug):
     series = get_object_or_404(Series, slug=slug)
-    pull_list, _ = PullList.objects.get_or_create(user=request.user)
+    pull_list, _created = PullList.objects.get_or_create(user=request.user)
     pull_list_series, created = PullListSeries.objects.get_or_create(
         pull_list=pull_list, series=series
     )

--- a/reading_lists/forms.py
+++ b/reading_lists/forms.py
@@ -1,4 +1,5 @@
 from django import forms
+from django.utils.translation import gettext_lazy as _
 
 from comicsdb.autocomplete import ArcAutocomplete, IssueAutocomplete, SeriesAutocomplete
 from comicsdb.forms.widgets import SafeAutocompleteWidget
@@ -15,21 +16,21 @@ class ReadingListForm(forms.ModelForm):
     previous = forms.ModelChoiceField(
         queryset=ReadingList.objects.all(),
         required=False,
-        label="Previous List",
-        help_text="The reading list that comes before this one in a reading order (optional)",
+        label=_("Previous List"),
+        help_text=_("The reading list that comes before this one in a reading order (optional)"),
         widget=SafeAutocompleteWidget(
             ac_class=ReadingListAutocomplete,
-            attrs={"placeholder": "Search for a reading list...", "class": "input"},
+            attrs={"placeholder": _("Search for a reading list..."), "class": "input"},
         ),
     )
     next = forms.ModelChoiceField(
         queryset=ReadingList.objects.all(),
         required=False,
-        label="Next List",
-        help_text="The reading list that comes after this one in a reading order (optional)",
+        label=_("Next List"),
+        help_text=_("The reading list that comes after this one in a reading order (optional)"),
         widget=SafeAutocompleteWidget(
             ac_class=ReadingListAutocomplete,
-            attrs={"placeholder": "Search for a reading list...", "class": "input"},
+            attrs={"placeholder": _("Search for a reading list..."), "class": "input"},
         ),
     )
 
@@ -47,11 +48,11 @@ class ReadingListForm(forms.ModelForm):
             "next",
         )
         widgets = {
-            "name": forms.TextInput(attrs={"placeholder": "Enter a name for your reading list"}),
+            "name": forms.TextInput(attrs={"placeholder": _("Enter a name for your reading list")}),
             "image": forms.ClearableFileInput(),
             "desc": forms.Textarea(
                 attrs={
-                    "placeholder": "Describe the reading list (optional)",
+                    "placeholder": _("Describe the reading list (optional)"),
                     "rows": 5,
                 }
             ),
@@ -65,18 +66,18 @@ class ReadingListForm(forms.ModelForm):
             ),
         }
         labels = {
-            "desc": "Description",
-            "is_private": "Private List",
-            "list_type": "List Type",
-            "attribution_source": "Source",
-            "attribution_url": "Source URL",
+            "desc": _("Description"),
+            "is_private": _("Private List"),
+            "list_type": _("List Type"),
+            "attribution_source": _("Source"),
+            "attribution_url": _("Source URL"),
         }
         help_texts = {
-            "is_private": (
+            "is_private": _(
                 "Private lists are only visible to you. Public lists can be viewed by anyone."
             ),
-            "attribution_source": "Where did you get this reading list from? (optional)",
-            "attribution_url": "URL of the specific page for this reading list (optional)",
+            "attribution_source": _("Where did you get this reading list from? (optional)"),
+            "attribution_url": _("URL of the specific page for this reading list (optional)"),
         }
 
     def __init__(self, *args, **kwargs):
@@ -98,20 +99,20 @@ class AddIssueWithSearchForm(forms.Form):
         widget=SafeAutocompleteWidget(
             ac_class=IssueAutocomplete,
             attrs={
-                "placeholder": "Search for issues...",
+                "placeholder": _("Search for issues..."),
                 "class": "input",
             },
             options={
                 "multiselect": True,
             },
         ),
-        label="Search for Issues (Optional)",
-        help_text="Add new issues and/or reorder existing issues by dragging",
+        label=_("Search for Issues (Optional)"),
+        help_text=_("Add new issues and/or reorder existing issues by dragging"),
     )
     issue_order = forms.CharField(
         required=False,
         widget=forms.HiddenInput(),
-        help_text="Stores the order of selected issues after drag-and-drop",
+        help_text=_("Stores the order of selected issues after drag-and-drop"),
     )
 
 
@@ -119,8 +120,8 @@ class AddIssuesFromSeriesForm(forms.Form):
     """Form for adding multiple issues from a series to a reading list."""
 
     RANGE_CHOICES = [
-        ("all", "All issues"),
-        ("range", "Issue range"),
+        ("all", _("All issues")),
+        ("range", _("Issue range")),
     ]
 
     series = forms.ModelChoiceField(
@@ -129,19 +130,19 @@ class AddIssuesFromSeriesForm(forms.Form):
         widget=SafeAutocompleteWidget(
             ac_class=SeriesAutocomplete,
             attrs={
-                "placeholder": "Search for a series...",
+                "placeholder": _("Search for a series..."),
                 "class": "input",
             },
         ),
-        label="Series",
-        help_text="Select the series to add issues from",
+        label=_("Series"),
+        help_text=_("Select the series to add issues from"),
     )
 
     range_type = forms.ChoiceField(
         choices=RANGE_CHOICES,
         initial="all",
         widget=forms.RadioSelect(),
-        label="What to add",
+        label=_("What to add"),
         required=True,
     )
 
@@ -149,26 +150,26 @@ class AddIssuesFromSeriesForm(forms.Form):
         max_length=25,
         required=False,
         widget=forms.TextInput(attrs={"placeholder": "1", "class": "input"}),
-        label="Start Issue #",
-        help_text="Leave blank to start from the first issue",
+        label=_("Start Issue #"),
+        help_text=_("Leave blank to start from the first issue"),
     )
 
     end_number = forms.CharField(
         max_length=25,
         required=False,
         widget=forms.TextInput(attrs={"placeholder": "50", "class": "input"}),
-        label="End Issue #",
-        help_text="Leave blank to go to the last issue",
+        label=_("End Issue #"),
+        help_text=_("Leave blank to go to the last issue"),
     )
 
     position = forms.ChoiceField(
         choices=[
-            ("end", "At the end"),
-            ("beginning", "At the beginning"),
+            ("end", _("At the end")),
+            ("beginning", _("At the beginning")),
         ],
         initial="end",
         widget=forms.RadioSelect(),
-        label="Add issues",
+        label=_("Add issues"),
         required=True,
     )
 
@@ -181,7 +182,7 @@ class AddIssuesFromSeriesForm(forms.Form):
         # If range is selected, at least one of start or end must be provided
         if range_type == "range" and not start_number and not end_number:
             raise forms.ValidationError(
-                "Please specify at least a start or end issue number for the range."
+                _("Please specify at least a start or end issue number for the range.")
             )
 
         return cleaned_data
@@ -196,21 +197,21 @@ class AddIssuesFromArcForm(forms.Form):
         widget=SafeAutocompleteWidget(
             ac_class=ArcAutocomplete,
             attrs={
-                "placeholder": "Search for a story arc...",
+                "placeholder": _("Search for a story arc..."),
                 "class": "input",
             },
         ),
-        label="Story Arc",
-        help_text="Select the story arc to add issues from",
+        label=_("Story Arc"),
+        help_text=_("Select the story arc to add issues from"),
     )
 
     position = forms.ChoiceField(
         choices=[
-            ("end", "At the end"),
-            ("beginning", "At the beginning"),
+            ("end", _("At the end")),
+            ("beginning", _("At the beginning")),
         ],
         initial="end",
         widget=forms.RadioSelect(),
-        label="Add issues",
+        label=_("Add issues"),
         required=True,
     )

--- a/reading_lists/models.py
+++ b/reading_lists/models.py
@@ -3,6 +3,7 @@ from django.db import models
 from django.db.models import Avg, Count, Max, Min, Q
 from django.db.models.signals import pre_save
 from django.urls import reverse
+from django.utils.translation import gettext_lazy as _
 from sorl.thumbnail import ImageField
 
 from comicsdb.models.common import AbstractRating, CommonInfo, pre_save_slug
@@ -58,50 +59,50 @@ class ReadingList(CommonInfo):
     class ListType(models.TextChoices):
         """Reading list type choices."""
 
-        CREATOR = "CREATOR", "Creator"
-        EVENT = "EVENT", "Event"
-        STORY = "STORY", "Story"
-        CHARACTERS = "CHARACTERS", "Characters"
-        TEAMS = "TEAMS", "Teams"
-        MASTER = "MASTER", "Master"
+        CREATOR = "CREATOR", _("Creator")
+        EVENT = "EVENT", _("Event")
+        STORY = "STORY", _("Story")
+        CHARACTERS = "CHARACTERS", _("Characters")
+        TEAMS = "TEAMS", _("Teams")
+        MASTER = "MASTER", _("Master")
 
     class AttributionSource(models.TextChoices):
         """Source attribution choices."""
 
-        CBRO = "CBRO", "Comic Book Reading Orders"
-        CMRO = "CMRO", "Complete Marvel Reading Orders"
-        CBH = "CBH", "Comic Book Herald"
-        CBT = "CBT", "Comic Book Treasury"
-        MG = "MG", "Marvel Guides"
-        HTLC = "HTLC", "How To Love Comics"
-        LOCG = "LOCG", "League of ComicGeeks"
-        OTHER = "OTHER", "Other"
+        CBRO = "CBRO", _("Comic Book Reading Orders")
+        CMRO = "CMRO", _("Complete Marvel Reading Orders")
+        CBH = "CBH", _("Comic Book Herald")
+        CBT = "CBT", _("Comic Book Treasury")
+        MG = "MG", _("Marvel Guides")
+        HTLC = "HTLC", _("How To Love Comics")
+        LOCG = "LOCG", _("League of ComicGeeks")
+        OTHER = "OTHER", _("Other")
 
     user = models.ForeignKey(
         CustomUser,
         on_delete=models.CASCADE,
         related_name="reading_lists",
-        help_text="The user who owns this reading list",
+        help_text=_("The user who owns this reading list"),
     )
     is_private = models.BooleanField(
         default=False,
-        help_text="Whether this list is private (only visible to the owner)",
+        help_text=_("Whether this list is private (only visible to the owner)"),
     )
     list_type = models.CharField(
         max_length=10,
         choices=ListType.choices,
         default=ListType.EVENT,
-        help_text="The type of reading list",
+        help_text=_("The type of reading list"),
     )
     attribution_source = models.CharField(
         max_length=10,
         choices=AttributionSource.choices,
         blank=True,
-        help_text="Source where this reading list information was obtained",
+        help_text=_("Source where this reading list information was obtained"),
     )
     attribution_url = models.URLField(
         blank=True,
-        help_text="URL of the specific page where this reading list was obtained",
+        help_text=_("URL of the specific page where this reading list was obtained"),
     )
     image = ImageField(upload_to="reading_list/%Y/%m/%d/", blank=True)
     issues = models.ManyToManyField(
@@ -116,7 +117,7 @@ class ReadingList(CommonInfo):
         null=True,
         blank=True,
         related_name="+",
-        help_text="The reading list that comes before this one in a reading order",
+        help_text=_("The reading list that comes before this one in a reading order"),
     )
     next = models.ForeignKey(
         "self",
@@ -124,7 +125,7 @@ class ReadingList(CommonInfo):
         null=True,
         blank=True,
         related_name="+",
-        help_text="The reading list that comes after this one in a reading order",
+        help_text=_("The reading list that comes after this one in a reading order"),
     )
 
     class Meta:
@@ -140,11 +141,13 @@ class ReadingList(CommonInfo):
     def clean(self):
         super().clean()
         if self.previous_id and self.previous_id == self.pk:
-            raise ValidationError({"previous": "A reading list cannot be its own previous list."})
+            raise ValidationError(
+                {"previous": _("A reading list cannot be its own previous list.")}
+            )
         if self.next_id and self.next_id == self.pk:
-            raise ValidationError({"next": "A reading list cannot be its own next list."})
+            raise ValidationError({"next": _("A reading list cannot be its own next list.")})
         if self.previous_id and self.next_id and self.previous_id == self.next_id:
-            raise ValidationError("The previous and next reading lists must be different.")
+            raise ValidationError(_("The previous and next reading lists must be different."))
 
     def save(self, *args, **kwargs):
         old_previous_id = None
@@ -211,10 +214,10 @@ class ReadingListItem(models.Model):
     class IssueType(models.TextChoices):
         """Issue type choices for reading list items."""
 
-        PROLOGUE = "PROLOGUE", "Prologue"
-        CORE = "CORE", "Core Issue"
-        TIE_IN = "TIE_IN", "Tie-In"
-        EPILOGUE = "EPILOGUE", "Epilogue"
+        PROLOGUE = "PROLOGUE", _("Prologue")
+        CORE = "CORE", _("Core Issue")
+        TIE_IN = "TIE_IN", _("Tie-In")
+        EPILOGUE = "EPILOGUE", _("Epilogue")
 
     reading_list = models.ForeignKey(
         ReadingList,
@@ -228,13 +231,13 @@ class ReadingListItem(models.Model):
     )
     order = models.PositiveIntegerField(
         default=1,
-        help_text="Position of this issue in the reading list",
+        help_text=_("Position of this issue in the reading list"),
     )
     issue_type = models.CharField(
         max_length=10,
         choices=IssueType.choices,
         blank=True,
-        help_text="Optional categorization of this issue's role in the reading list",
+        help_text=_("Optional categorization of this issue's role in the reading list"),
     )
 
     class Meta:

--- a/reading_lists/templates/reading_lists/add_issue_autocomplete.html
+++ b/reading_lists/templates/reading_lists/add_issue_autocomplete.html
@@ -1,13 +1,13 @@
 {% extends parent_template|default:"base.html" %}
-{% load static %}
-{% block title %}Manage Issues - {{ reading_list.name }} - Metron{% endblock %}
+{% load static i18n %}
+{% block title %}{% blocktrans with name=reading_list.name %}Manage Issues - {{ name }} - Metron{% endblocktrans %}{% endblock %}
 {% block js %}
     {{ form.media }}
     <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js"></script>
 {% endblock js %}
 {% block content %}
     <header class="block has-text-centered">
-        <h1 class="title">Manage Reading List</h1>
+        <h1 class="title">{% trans "Manage Reading List" %}</h1>
         <p class="subtitle">{{ reading_list.name }}</p>
     </header>
     <section class="section">
@@ -27,8 +27,8 @@
                             <!-- Draggable issue order area -->
                             <div class="field" id="selected-issues-container" style="display: none;">
                                 <label class="label">
-                                    Selected Issues
-                                    <span class="help">Drag to reorder</span>
+                                    {% trans "Selected Issues" %}
+                                    <span class="help">{% trans "Drag to reorder" %}</span>
                                 </label>
                                 <div id="selected-issues-list" class="box" style="min-height: 100px">
                                     <!-- Selected issues will appear here as draggable items -->
@@ -39,22 +39,22 @@
                             <div class="field is-grouped is-grouped-right mt-5">
                                 <div class="control">
                                     <a href="{% url 'reading-list:detail' reading_list.slug %}"
-                                       class="button">Cancel</a>
+                                       class="button">{% trans "Cancel" %}</a>
                                 </div>
                                 <div class="control">
-                                    <button type="submit" class="button is-primary">Save Changes</button>
+                                    <button type="submit" class="button is-primary">{% trans "Save Changes" %}</button>
                                 </div>
                             </div>
                         </form>
                     </div>
                     <div class="content mt-5">
-                        <h3 class="title is-5">How to use:</h3>
+                        <h3 class="title is-5">{% trans "How to use:" %}</h3>
                         <ul>
-                            <li>To add new issues: Start typing in the search box to find issues by series name, issue number, or story title</li>
-                            <li>Select multiple issues from the dropdown (they will appear as chips)</li>
-                            <li>All issues (existing and new) will appear below in a draggable list</li>
-                            <li>Drag and drop the issues to set your preferred reading order</li>
-                            <li>Click "Save Changes" to add new issues and/or save the reordered list</li>
+                            <li>{% trans "To add new issues: Start typing in the search box to find issues by series name, issue number, or story title" %}</li>
+                            <li>{% trans "Select multiple issues from the dropdown (they will appear as chips)" %}</li>
+                            <li>{% trans "All issues (existing and new) will appear below in a draggable list" %}</li>
+                            <li>{% trans "Drag and drop the issues to set your preferred reading order" %}</li>
+                            <li>{% blocktrans %}Click "Save Changes" to add new issues and/or save the reordered list{% endblocktrans %}</li>
                         </ul>
                     </div>
                 </div>
@@ -186,13 +186,13 @@
                 // Rebuild the list
                 selectedIssuesList.innerHTML = '';
                 finalOrder.forEach(issueId => {
-                    const issueLabel = issueData[issueId] || `Issue #${issueId}`;
+                    const issueLabel = issueData[issueId] || `{% filter escapejs %}{% trans "Issue #" %}{% endfilter %}${issueId}`;
                     const isExisting = existingIssueIds.has(issueId);
                     const div = document.createElement('div');
                     div.className = `draggable-issue box mb-2 p-3 ${isExisting ? 'is-existing-issue' : 'is-new-issue'}`;
                     div.dataset.issueId = issueId;
 
-                    const badge = isExisting ? '<span class="tag is-info is-light ml-2">Current</span>' : '<span class="tag is-success is-light ml-2">New</span>';
+                    const badge = isExisting ? '<span class="tag is-info is-light ml-2">{% filter escapejs %}{% trans "Current" %}{% endfilter %}</span>' : '<span class="tag is-success is-light ml-2">{% filter escapejs %}{% trans "New" %}{% endfilter %}</span>';
 
                     div.innerHTML = `
                         <span class="icon is-small" style="vertical-align: middle;">

--- a/reading_lists/templates/reading_lists/add_issues_from_arc.html
+++ b/reading_lists/templates/reading_lists/add_issues_from_arc.html
@@ -1,12 +1,12 @@
 {% extends parent_template|default:"base.html" %}
-{% load static %}
-{% block title %}Add from Story Arc - {{ reading_list.name }} - Metron{% endblock %}
+{% load static i18n %}
+{% block title %}{% blocktrans with name=reading_list.name %}Add from Story Arc - {{ name }} - Metron{% endblocktrans %}{% endblock %}
 {% block js %}
     {{ form.media }}
 {% endblock js %}
 {% block content %}
     <header class="block has-text-centered">
-        <h1 class="title">Add Issues from Story Arc</h1>
+        <h1 class="title">{% trans "Add Issues from Story Arc" %}</h1>
         <p class="subtitle">{{ reading_list.name }}</p>
     </header>
     <section class="section">
@@ -40,30 +40,30 @@
                             <div class="field is-grouped is-grouped-right mt-5">
                                 <div class="control">
                                     <a href="{% url 'reading-list:detail' reading_list.slug %}"
-                                       class="button">Cancel</a>
+                                       class="button">{% trans "Cancel" %}</a>
                                 </div>
                                 <div class="control">
-                                    <button type="submit" class="button is-primary">Add Issues</button>
+                                    <button type="submit" class="button is-primary">{% trans "Add Issues" %}</button>
                                 </div>
                             </div>
                         </form>
                     </div>
                     <div class="content mt-5">
-                        <h3 class="title is-5">How to use:</h3>
+                        <h3 class="title is-5">{% trans "How to use:" %}</h3>
                         <ul>
                             <li>
-                                <strong>Select a story arc:</strong> Start typing in the search box to find a story arc by name
+                                <strong>{% trans "Select a story arc:" %}</strong> {% trans "Start typing in the search box to find a story arc by name" %}
                             </li>
                             <li>
-                                <strong>All issues from the arc will be added:</strong> Issues are added in chronological order by cover date
+                                <strong>{% trans "All issues from the arc will be added:" %}</strong> {% trans "Issues are added in chronological order by cover date" %}
                             </li>
                             <li>
-                                <strong>Choose position:</strong> Add issues at the beginning or end of your reading list
+                                <strong>{% trans "Choose position:" %}</strong> {% trans "Add issues at the beginning or end of your reading list" %}
                             </li>
-                            <li>Issues already in your reading list will be automatically skipped</li>
+                            <li>{% trans "Issues already in your reading list will be automatically skipped" %}</li>
                         </ul>
                         <div class="notification is-info is-light mt-4">
-                            <strong>Tip:</strong> Story arcs are perfect for reading major crossover events in order! You can combine multiple arcs to build comprehensive reading orders.
+                            <strong>{% trans "Tip:" %}</strong> {% trans "Story arcs are perfect for reading major crossover events in order! You can combine multiple arcs to build comprehensive reading orders." %}
                         </div>
                     </div>
                 </div>

--- a/reading_lists/templates/reading_lists/add_issues_from_series.html
+++ b/reading_lists/templates/reading_lists/add_issues_from_series.html
@@ -1,12 +1,12 @@
 {% extends parent_template|default:"base.html" %}
-{% load static %}
-{% block title %}Add from Series - {{ reading_list.name }} - Metron{% endblock %}
+{% load static i18n %}
+{% block title %}{% blocktrans with name=reading_list.name %}Add from Series - {{ name }} - Metron{% endblocktrans %}{% endblock %}
 {% block js %}
     {{ form.media }}
 {% endblock js %}
 {% block content %}
     <header class="block has-text-centered">
-        <h1 class="title">Add Issues from Series</h1>
+        <h1 class="title">{% trans "Add Issues from Series" %}</h1>
         <p class="subtitle">{{ reading_list.name }}</p>
     </header>
     <section class="section">
@@ -73,38 +73,38 @@
                             <div class="field is-grouped is-grouped-right mt-5">
                                 <div class="control">
                                     <a href="{% url 'reading-list:detail' reading_list.slug %}"
-                                       class="button">Cancel</a>
+                                       class="button">{% trans "Cancel" %}</a>
                                 </div>
                                 <div class="control">
-                                    <button type="submit" class="button is-primary">Add Issues</button>
+                                    <button type="submit" class="button is-primary">{% trans "Add Issues" %}</button>
                                 </div>
                             </div>
                         </form>
                     </div>
                     <div class="content mt-5">
-                        <h3 class="title is-5">How to use:</h3>
+                        <h3 class="title is-5">{% trans "How to use:" %}</h3>
                         <ul>
                             <li>
-                                <strong>Select a series:</strong> Start typing in the search box to find a series by name
+                                <strong>{% trans "Select a series:" %}</strong> {% trans "Start typing in the search box to find a series by name" %}
                             </li>
                             <li>
-                                <strong>Choose what to add:</strong>
+                                <strong>{% trans "Choose what to add:" %}</strong>
                                 <ul>
                                     <li>
-                                        <strong>All issues:</strong> Adds every issue from the series
+                                        <strong>{% trans "All issues:" %}</strong> {% trans "Adds every issue from the series" %}
                                     </li>
                                     <li>
-                                        <strong>Issue range:</strong> Specify a start and/or end issue number (e.g., start at #1, end at #50)
+                                        <strong>{% trans "Issue range:" %}</strong> {% trans "Specify a start and/or end issue number (e.g., start at #1, end at #50)" %}
                                     </li>
                                 </ul>
                             </li>
                             <li>
-                                <strong>Choose position:</strong> Add issues at the beginning or end of your reading list
+                                <strong>{% trans "Choose position:" %}</strong> {% trans "Add issues at the beginning or end of your reading list" %}
                             </li>
-                            <li>Issues already in your reading list will be automatically skipped</li>
+                            <li>{% trans "Issues already in your reading list will be automatically skipped" %}</li>
                         </ul>
                         <div class="notification is-info is-light mt-4">
-                            <strong>Tip:</strong> For large reading orders spanning multiple series, you can use this tool repeatedly to add different series or ranges, building your list quickly!
+                            <strong>{% trans "Tip:" %}</strong> {% trans "For large reading orders spanning multiple series, you can use this tool repeatedly to add different series or ranges, building your list quickly!" %}
                         </div>
                     </div>
                 </div>

--- a/reading_lists/templates/reading_lists/partials/readinglist_card.html
+++ b/reading_lists/templates/reading_lists/partials/readinglist_card.html
@@ -1,4 +1,4 @@
-{% load thumbnail %}
+{% load thumbnail i18n %}
 <div class="column is-one-third-desktop is-half-tablet">
     <a class="rlc" href="{% url 'reading-list:detail' reading_list.slug %}" data-type="{{ reading_list.list_type }}">
         <div class="rlc__band">
@@ -11,7 +11,7 @@
             {% if reading_list.is_private %}
                 <span class="rlc__private">
                     <span class="icon is-small"><i class="fas fa-lock"></i></span>
-                    <span>Private</span>
+                    <span>{% trans "Private" %}</span>
                 </span>
             {% endif %}
             {% if reading_list.average_rating %}
@@ -22,7 +22,7 @@
             {% endif %}
             <span class="rlc__issues">
                 <span class="icon is-small"><i class="fas fa-book"></i></span>
-                <span>{{ reading_list.issue_count }} issue{{ reading_list.issue_count|pluralize }}</span>
+                <span>{% blocktrans count counter=reading_list.issue_count %}{{ counter }} issue{% plural %}{{ counter }} issues{% endblocktrans %}</span>
             </span>
         </div>
         <div class="rlc__body">
@@ -45,7 +45,7 @@
                 </span>
             {% endif %}
             <div class="rlc__meta">
-                <span class="rlc__by">By <strong>{{ reading_list.user.username }}</strong></span>
+                <span class="rlc__by">{% blocktrans with username=reading_list.user.username %}By <strong>{{ username }}</strong>{% endblocktrans %}</span>
                 {% if reading_list.average_rating %}
                     <span class="rlc__stars">
                         {% for star_num in "12345" %}
@@ -59,9 +59,9 @@
                 {% if reading_list.desc %}
                     <p class="rlc__desc">{{ reading_list.desc|truncatewords:18 }}</p>
                 {% else %}
-                    <p class="rlc__desc rlc__desc--empty">No description</p>
+                    <p class="rlc__desc rlc__desc--empty">{% trans "No description" %}</p>
                 {% endif %}
-                <span class="rlc__updated">Updated {{ reading_list.modified|timesince }} ago</span>
+                <span class="rlc__updated">{% blocktrans with timesince=reading_list.modified|timesince %}Updated {{ timesince }} ago{% endblocktrans %}</span>
             </div>
         </div>
     </a>

--- a/reading_lists/templates/reading_lists/partials/readinglist_filter.html
+++ b/reading_lists/templates/reading_lists/partials/readinglist_filter.html
@@ -1,3 +1,4 @@
+{% load i18n %}
 <div class="box mb-5" id="filter-panel">
     <form method="get" accept-charset="utf-8">
         <div class="is-flex is-justify-content-space-between is-align-items-center mb-4">
@@ -6,7 +7,7 @@
                     <span class="icon has-text-link">
                         <i class="fas fa-search"></i>
                     </span>
-                    <span>Search Reading Lists</span>
+                    <span>{% trans "Search Reading Lists" %}</span>
                 </span>
             </h2>
             {% if has_active_filters %}
@@ -14,26 +15,26 @@
                     <span class="icon">
                         <i class="fas fa-filter"></i>
                     </span>
-                    <span>Filters Active</span>
+                    <span>{% trans "Filters Active" %}</span>
                 </span>
             {% endif %}
         </div>
         {# Quick Search Field #}
         <div class="field">
-            <label class="label" for="q">Quick Search</label>
+            <label class="label" for="q">{% trans "Quick Search" %}</label>
             <div class="control has-icons-left">
                 <input class="input"
                        type="text"
                        id="q"
                        name="q"
                        value="{{ request.GET.q }}"
-                       placeholder="Search by list name..."
-                       aria-label="Quick search">
+                       placeholder="{% trans 'Search by list name...' %}"
+                       aria-label="{% trans 'Quick search' %}">
                 <span class="icon is-small is-left">
                     <i class="fas fa-search"></i>
                 </span>
             </div>
-            <p class="help">Search by reading list name</p>
+            <p class="help">{% trans "Search by reading list name" %}</p>
         </div>
         {# Collapsible Advanced Filters #}
         <details>
@@ -42,22 +43,22 @@
                     <span class="icon">
                         <i class="fas fa-sliders-h"></i>
                     </span>
-                    <span>Advanced Filters</span>
+                    <span>{% trans "Advanced Filters" %}</span>
                 </span>
             </summary>
             <div class="columns is-multiline">
                 {# List Name Filter #}
                 <div class="column is-half">
                     <div class="field">
-                        <label class="label" for="name">List Name</label>
+                        <label class="label" for="name">{% trans "List Name" %}</label>
                         <div class="control has-icons-left">
                             <input class="input"
                                    type="text"
                                    id="name"
                                    name="name"
                                    value="{{ request.GET.name }}"
-                                   placeholder="e.g., Marvel Reading Order"
-                                   aria-label="Filter by list name">
+                                   placeholder="{% trans 'e.g., Marvel Reading Order' %}"
+                                   aria-label="{% trans 'Filter by list name' %}">
                             <span class="icon is-small is-left">
                                 <i class="fas fa-list"></i>
                             </span>
@@ -67,15 +68,15 @@
                 {# Creator/Username Filter #}
                 <div class="column is-half">
                     <div class="field">
-                        <label class="label" for="username">Creator</label>
+                        <label class="label" for="username">{% trans "Creator" %}</label>
                         <div class="control has-icons-left">
                             <input class="input"
                                    type="text"
                                    id="username"
                                    name="username"
                                    value="{{ request.GET.username }}"
-                                   placeholder="e.g., Metron"
-                                   aria-label="Filter by creator username">
+                                   placeholder="{% trans 'e.g., Metron' %}"
+                                   aria-label="{% trans 'Filter by creator username' %}">
                             <span class="icon is-small is-left">
                                 <i class="fas fa-user"></i>
                             </span>
@@ -85,15 +86,15 @@
                 {# Publisher Filter #}
                 <div class="column is-half">
                     <div class="field">
-                        <label class="label" for="publisher">Publisher</label>
+                        <label class="label" for="publisher">{% trans "Publisher" %}</label>
                         <div class="control has-icons-left">
                             <input class="input"
                                    type="text"
                                    id="publisher"
                                    name="publisher"
                                    value="{{ request.GET.publisher }}"
-                                   placeholder="e.g., Marvel"
-                                   aria-label="Filter by publisher">
+                                   placeholder="{% trans 'e.g., Marvel' %}"
+                                   aria-label="{% trans 'Filter by publisher' %}">
                             <span class="icon is-small is-left">
                                 <i class="fas fa-building"></i>
                             </span>
@@ -103,11 +104,11 @@
                 {# List Type Filter #}
                 <div class="column is-half">
                     <div class="field">
-                        <label class="label" for="list_type">List Type</label>
+                        <label class="label" for="list_type">{% trans "List Type" %}</label>
                         <div class="control has-icons-left">
                             <div class="select is-fullwidth">
-                                <select id="list_type" name="list_type" aria-label="Filter by list type">
-                                    <option value="">All Types</option>
+                                <select id="list_type" name="list_type" aria-label="{% trans 'Filter by list type' %}">
+                                    <option value="">{% trans "All Types" %}</option>
                                     {% for value, label in list_types %}
                                         <option value="{{ value }}"
                                                 {% if request.GET.list_type == value %}selected{% endif %}>
@@ -125,13 +126,13 @@
                 {# Attribution Source Filter #}
                 <div class="column is-half">
                     <div class="field">
-                        <label class="label" for="attribution_source">Attribution Source</label>
+                        <label class="label" for="attribution_source">{% trans "Attribution Source" %}</label>
                         <div class="control has-icons-left">
                             <div class="select is-fullwidth">
                                 <select id="attribution_source"
                                         name="attribution_source"
-                                        aria-label="Filter by attribution source">
-                                    <option value="">All Sources</option>
+                                        aria-label="{% trans 'Filter by attribution source' %}">
+                                    <option value="">{% trans "All Sources" %}</option>
                                     {% for value, label in attribution_sources %}
                                         <option value="{{ value }}"
                                                 {% if request.GET.attribution_source == value %}selected{% endif %}>
@@ -149,32 +150,32 @@
                 {# Minimum Rating Filter #}
                 <div class="column is-half">
                     <div class="field">
-                        <label class="label" for="average_rating__gte">Minimum Rating</label>
+                        <label class="label" for="average_rating__gte">{% trans "Minimum Rating" %}</label>
                         <div class="control has-icons-left">
                             <div class="select is-fullwidth">
                                 <select id="average_rating__gte"
                                         name="average_rating__gte"
-                                        aria-label="Filter by minimum rating">
-                                    <option value="">All Ratings</option>
+                                        aria-label="{% trans 'Filter by minimum rating' %}">
+                                    <option value="">{% trans "All Ratings" %}</option>
                                     <option value="1"
                                             {% if request.GET.average_rating__gte == "1" %}selected{% endif %}>
-                                        1+ Stars
+                                        {% trans "1+ Stars" %}
                                     </option>
                                     <option value="2"
                                             {% if request.GET.average_rating__gte == "2" %}selected{% endif %}>
-                                        2+ Stars
+                                        {% trans "2+ Stars" %}
                                     </option>
                                     <option value="3"
                                             {% if request.GET.average_rating__gte == "3" %}selected{% endif %}>
-                                        3+ Stars
+                                        {% trans "3+ Stars" %}
                                     </option>
                                     <option value="4"
                                             {% if request.GET.average_rating__gte == "4" %}selected{% endif %}>
-                                        4+ Stars
+                                        {% trans "4+ Stars" %}
                                     </option>
                                     <option value="5"
                                             {% if request.GET.average_rating__gte == "5" %}selected{% endif %}>
-                                        5 Stars
+                                        {% trans "5 Stars" %}
                                     </option>
                                 </select>
                             </div>
@@ -188,18 +189,18 @@
                 {% if user.is_authenticated %}
                     <div class="column is-half">
                         <div class="field">
-                            <label class="label" for="is_private">Privacy</label>
+                            <label class="label" for="is_private">{% trans "Privacy" %}</label>
                             <div class="control has-icons-left">
                                 <div class="select is-fullwidth">
-                                    <select id="is_private" name="is_private" aria-label="Filter by privacy">
-                                        <option value="">All Lists</option>
+                                    <select id="is_private" name="is_private" aria-label="{% trans 'Filter by privacy' %}">
+                                        <option value="">{% trans "All Lists" %}</option>
                                         <option value="false"
                                                 {% if request.GET.is_private == "false" %}selected{% endif %}>
-                                            Public
+                                            {% trans "Public" %}
                                         </option>
                                         <option value="true"
                                                 {% if request.GET.is_private == "true" %}selected{% endif %}>
-                                            Private
+                                            {% trans "Private" %}
                                         </option>
                                     </select>
                                 </div>
@@ -219,17 +220,17 @@
                     <span class="icon">
                         <i class="fas fa-search"></i>
                     </span>
-                    <span>Apply Filters</span>
+                    <span>{% trans "Apply Filters" %}</span>
                 </button>
             </div>
             <div class="control">
                 <a class="button is-light"
                    href="{% url 'reading-list:list' %}"
-                   title="Clear all filters">
+                   title="{% trans 'Clear all filters' %}">
                     <span class="icon">
                         <i class="fas fa-times"></i>
                     </span>
-                    <span>Clear Filters</span>
+                    <span>{% trans "Clear Filters" %}</span>
                 </a>
             </div>
         </div>

--- a/reading_lists/templates/reading_lists/partials/readinglist_item.html
+++ b/reading_lists/templates/reading_lists/partials/readinglist_item.html
@@ -1,4 +1,4 @@
-{% load static thumbnail %}
+{% load static thumbnail i18n %}
 <li id="item-{{ item.pk }}"
     class="rl-item"
     data-issue-type="{{ item.issue_type|default:'UNCATEGORIZED' }}">
@@ -19,7 +19,7 @@
             {% else %}
                 <img src="{% static 'site/img/image-not-found.webp' %}"
                      width="48"
-                     alt="No image for {{ item.issue }}"
+                     alt="{% blocktrans with issue=item.issue %}No image for {{ issue }}{% endblocktrans %}"
                      loading="lazy"
                      style="display: block; width: 48px; border-radius: 4px;">
             {% endif %}
@@ -49,12 +49,12 @@
                         hx-get="{% url 'reading-list:edit-issue-type' reading_list_slug item.pk %}"
                         hx-target="#item-{{ item.pk }}"
                         hx-swap="outerHTML"
-                        title="Edit issue type">
+                        title="{% trans 'Edit issue type' %}">
                     <span class="icon is-small"><i class="fas fa-tag"></i></span>
                 </button>
                 <a href="{% url 'reading-list:remove-issue' reading_list_slug item.pk %}"
                    class="button is-small is-danger is-outlined"
-                   title="Remove from list">
+                   title="{% trans 'Remove from list' %}">
                     <span class="icon is-small"><i class="fas fa-times"></i></span>
                 </a>
             </div>

--- a/reading_lists/templates/reading_lists/partials/readinglist_item_edit.html
+++ b/reading_lists/templates/reading_lists/partials/readinglist_item_edit.html
@@ -1,4 +1,4 @@
-{% load static thumbnail %}
+{% load static thumbnail i18n %}
 <li id="item-{{ item.pk }}"
     class="rl-item"
     data-issue-type="{{ item.issue_type|default:'UNCATEGORIZED' }}">
@@ -19,7 +19,7 @@
             {% else %}
                 <img src="{% static 'site/img/image-not-found.webp' %}"
                      width="48"
-                     alt="No image for {{ item.issue }}"
+                     alt="{% blocktrans with issue=item.issue %}No image for {{ issue }}{% endblocktrans %}"
                      loading="lazy"
                      style="display: block; width: 48px; border-radius: 4px;">
             {% endif %}
@@ -46,16 +46,16 @@
                 <div class="control">
                     <div class="select is-small">
                         <select name="issue_type">
-                            <option value="">-- No Type --</option>
-                            <option value="PROLOGUE" {% if item.issue_type == 'PROLOGUE' %}selected{% endif %}>Prologue</option>
-                            <option value="CORE" {% if item.issue_type == 'CORE' %}selected{% endif %}>Core</option>
-                            <option value="TIE_IN" {% if item.issue_type == 'TIE_IN' %}selected{% endif %}>Tie-In</option>
-                            <option value="EPILOGUE" {% if item.issue_type == 'EPILOGUE' %}selected{% endif %}>Epilogue</option>
+                            <option value="">{% trans "-- No Type --" %}</option>
+                            <option value="PROLOGUE" {% if item.issue_type == 'PROLOGUE' %}selected{% endif %}>{% trans "Prologue" %}</option>
+                            <option value="CORE" {% if item.issue_type == 'CORE' %}selected{% endif %}>{% trans "Core" %}</option>
+                            <option value="TIE_IN" {% if item.issue_type == 'TIE_IN' %}selected{% endif %}>{% trans "Tie-In" %}</option>
+                            <option value="EPILOGUE" {% if item.issue_type == 'EPILOGUE' %}selected{% endif %}>{% trans "Epilogue" %}</option>
                         </select>
                     </div>
                 </div>
                 <div class="control">
-                    <button type="submit" class="button is-small is-success" title="Save">
+                    <button type="submit" class="button is-small is-success" title="{% trans 'Save' %}">
                         <span class="icon is-small"><i class="fas fa-check"></i></span>
                     </button>
                 </div>
@@ -65,7 +65,7 @@
                             hx-get="{% url 'reading-list:cancel-edit-issue-type' reading_list_slug item.pk %}"
                             hx-target="#item-{{ item.pk }}"
                             hx-swap="outerHTML"
-                            title="Cancel">
+                            title="{% trans 'Cancel' %}">
                         <span class="icon is-small"><i class="fas fa-times"></i></span>
                     </button>
                 </div>

--- a/reading_lists/templates/reading_lists/partials/readinglist_item_list.html
+++ b/reading_lists/templates/reading_lists/partials/readinglist_item_list.html
@@ -1,3 +1,4 @@
+{% load i18n %}
 {% for item in reading_list_items %}
     {% include "reading_lists/partials/readinglist_item.html" with item=item reading_list_slug=reading_list_slug is_owner=is_owner %}
 {% endfor %}
@@ -10,7 +11,7 @@
                 hx-target="#items-container"
                 hx-swap="beforeend"
                 hx-indicator="#items-spinner">
-            <span>Load More Issues</span>
+            <span>{% trans "Load More Issues" %}</span>
         </button>
         <span id="items-spinner" class="htmx-indicator ml-2">
             <i class="fas fa-spinner fa-spin"></i>

--- a/reading_lists/templates/reading_lists/readinglist_confirm_assign_metron.html
+++ b/reading_lists/templates/reading_lists/readinglist_confirm_assign_metron.html
@@ -1,9 +1,9 @@
 {% extends parent_template|default:"base.html" %}
-{% load static %}
-{% block title %}Assign {{ reading_list.name }} to Metron - Metron{% endblock %}
+{% load static i18n %}
+{% block title %}{% blocktrans with name=reading_list.name %}Assign {{ name }} to Metron - Metron{% endblocktrans %}{% endblock %}
 {% block content %}
     <header class="block has-text-centered">
-        <h1 class="title">Assign Reading List to Metron</h1>
+        <h1 class="title">{% trans "Assign Reading List to Metron" %}</h1>
     </header>
     <section class="section">
         <div class="container">
@@ -12,16 +12,13 @@
                     <div class="box">
                         <article class="message is-warning">
                             <div class="message-header">
-                                <p>Confirm ownership change</p>
+                                <p>{% trans "Confirm ownership change" %}</p>
                             </div>
                             <div class="message-body">
                                 <p class="mb-3">
-                                    Are you sure you want to reassign ownership of the reading list
-                                    <strong>"{{ reading_list.name }}"</strong> from
-                                    <strong>{{ reading_list.user.username }}</strong> to the
-                                    <strong>Metron</strong> account?
+                                    {% blocktrans with name=reading_list.name username=reading_list.user.username %}Are you sure you want to reassign ownership of the reading list <strong>"{{ name }}"</strong> from <strong>{{ username }}</strong> to the <strong>Metron</strong> account?{% endblocktrans %}
                                 </p>
-                                <p>This action cannot be undone from this page.</p>
+                                <p>{% trans "This action cannot be undone from this page." %}</p>
                             </div>
                         </article>
                         <form method="post">
@@ -29,10 +26,10 @@
                             <div class="field is-grouped is-grouped-right">
                                 <div class="control">
                                     <a href="{% url 'reading-list:detail' reading_list.slug %}"
-                                       class="button">Cancel</a>
+                                       class="button">{% trans "Cancel" %}</a>
                                 </div>
                                 <div class="control">
-                                    <button type="submit" class="button is-warning">Assign to Metron</button>
+                                    <button type="submit" class="button is-warning">{% trans "Assign to Metron" %}</button>
                                 </div>
                             </div>
                         </form>

--- a/reading_lists/templates/reading_lists/readinglist_confirm_delete.html
+++ b/reading_lists/templates/reading_lists/readinglist_confirm_delete.html
@@ -1,9 +1,9 @@
 {% extends parent_template|default:"base.html" %}
-{% load static %}
-{% block title %}Delete {{ readinglist.name }} - Metron{% endblock %}
+{% load static i18n %}
+{% block title %}{% blocktrans with name=readinglist.name %}Delete {{ name }} - Metron{% endblocktrans %}{% endblock %}
 {% block content %}
     <header class="block has-text-centered">
-        <h1 class="title">Delete Reading List</h1>
+        <h1 class="title">{% trans "Delete Reading List" %}</h1>
     </header>
     <section class="section">
         <div class="container">
@@ -12,14 +12,13 @@
                     <div class="box">
                         <article class="message is-danger">
                             <div class="message-header">
-                                <p>Warning</p>
+                                <p>{% trans "Warning" %}</p>
                             </div>
                             <div class="message-body">
                                 <p class="mb-3">
-                                    Are you sure you want to delete the reading list
-                                    <strong>"{{ readinglist.name }}"</strong>?
+                                    {% blocktrans with name=readinglist.name %}Are you sure you want to delete the reading list <strong>"{{ name }}"</strong>?{% endblocktrans %}
                                 </p>
-                                <p>This action cannot be undone.</p>
+                                <p>{% trans "This action cannot be undone." %}</p>
                             </div>
                         </article>
                         <form method="post">
@@ -27,10 +26,10 @@
                             <div class="field is-grouped is-grouped-right">
                                 <div class="control">
                                     <a href="{% url 'reading-list:detail' readinglist.slug %}"
-                                       class="button">Cancel</a>
+                                       class="button">{% trans "Cancel" %}</a>
                                 </div>
                                 <div class="control">
-                                    <button type="submit" class="button is-danger">Delete</button>
+                                    <button type="submit" class="button is-danger">{% trans "Delete" %}</button>
                                 </div>
                             </div>
                         </form>

--- a/reading_lists/templates/reading_lists/readinglist_detail.html
+++ b/reading_lists/templates/reading_lists/readinglist_detail.html
@@ -1,6 +1,6 @@
 {% extends parent_template|default:"base.html" %}
-{% load static thumbnail %}
-{% block title %}{{ reading_list.name }} - Metron{% endblock %}
+{% load static thumbnail i18n %}
+{% block title %}{% blocktrans with name=reading_list.name %}{{ name }} - Metron{% endblocktrans %}{% endblock %}
 {% block content %}
     {# ============================ HERO ============================ #}
     <header class="block"
@@ -18,19 +18,19 @@
         <div style="position: relative; z-index: 2; padding: 3rem 2rem;">
             <p style="text-transform: uppercase; letter-spacing: 3px; font-size: 0.75rem; font-weight: 600; color: #fff; opacity: 0.7; margin-bottom: 0.75rem;">
                 <span class="icon is-small"><i class="fas fa-layer-group"></i></span>
-                Reading List &middot; {{ reading_list.get_list_type_display }}
+                {% blocktrans with list_type=reading_list.get_list_type_display %}Reading List &middot; {{ list_type }}{% endblocktrans %}
             </p>
             <h1 class="title is-1 has-text-white"
                 style="font-weight: 800; letter-spacing: -1px; margin-bottom: 0.75rem;">
                 {{ reading_list.name }}
                 {% if reading_list.is_private %}
-                    <span class="tag is-warning is-medium" style="vertical-align: middle;">Private</span>
+                    <span class="tag is-warning is-medium" style="vertical-align: middle;">{% trans "Private" %}</span>
                 {% endif %}
             </h1>
 
             <div class="is-flex is-align-items-center is-flex-wrap-wrap" style="gap: 1rem;">
                 <span class="has-text-white">
-                    Curated by
+                    {% trans "Curated by" %}
                     <a href="{% url 'user-detail' username=reading_list.user.username %}"
                        class="has-text-white has-text-weight-bold"
                        style="border-bottom: 1px solid rgba(255,255,255,0.4);">{{ reading_list.user.username }}</a>
@@ -44,31 +44,33 @@
                                     <i class="{% if star_num|add:'0' <= average_rating %}fas{% else %}far{% endif %} fa-star"></i>
                                 {% endfor %}
                             </span>
-                            <span class="ml-1">{{ average_rating|floatformat:1 }} &middot; {{ rating_count }} rating{{ rating_count|pluralize }}</span>
+                            <span class="ml-1">
+                                {% blocktrans count counter=rating_count with avg=average_rating|floatformat:1 %}{{ avg }} &middot; {{ counter }} rating{% plural %}{{ avg }} &middot; {{ counter }} ratings{% endblocktrans %}
+                            </span>
                         {% else %}
-                            <span style="opacity: 0.8;">No ratings yet</span>
+                            <span style="opacity: 0.8;">{% trans "No ratings yet" %}</span>
                         {% endif %}
                     </span>
                     <span style="opacity: 0.4; color: #fff;">|</span>
                     <span class="tag is-success" style="background: rgba(72,199,142,0.22); color: #a8f0cd;">
                         <span class="icon is-small"><i class="fas fa-globe"></i></span>
-                        <span>Public</span>
+                        <span>{% trans "Public" %}</span>
                     </span>
                 {% endif %}
             </div>
 
             <div class="buttons mt-4">
                 <button class="button is-light"
-                        onclick="navigator.clipboard.writeText(window.location.href); var l=this.querySelector('.label-text'); var o=l.textContent; l.textContent='Link copied!'; setTimeout(function(){l.textContent=o;}, 1800);">
+                        onclick="navigator.clipboard.writeText(window.location.href); var l=this.querySelector('.label-text'); var o=l.textContent; l.textContent='{% filter escapejs %}{% trans "Link copied!" %}{% endfilter %}'; setTimeout(function(){l.textContent=o;}, 1800);">
                     <span class="icon is-small"><i class="fas fa-share-alt"></i></span>
-                    <span class="label-text">Share</span>
+                    <span class="label-text">{% trans "Share" %}</span>
                 </button>
                 {% if not reading_list.is_private %}
                     <a class="button is-light is-outlined"
                        href="#reading-list-rating-{{ reading_list.pk }}"
                        style="color: #fff; border-color: rgba(255,255,255,0.7);">
                         <span class="icon is-small"><i class="fas fa-star"></i></span>
-                        <span>Rate this list</span>
+                        <span>{% trans "Rate this list" %}</span>
                     </a>
                 {% endif %}
             </div>
@@ -79,11 +81,11 @@
     <div class="box" style="margin-top: -2.5rem; position: relative; z-index: 3;">
         <div class="is-flex is-align-items-center is-flex-wrap-wrap" style="gap: 1.5rem;">
             <div>
-                <p class="heading">Issues</p>
+                <p class="heading">{% trans "Issues" %}</p>
                 <p class="title is-4 mb-0">{{ reading_list_items_count }}</p>
             </div>
             <div style="border-left: 1px solid #ededed; padding-left: 1.5rem;">
-                <p class="heading">Reading span</p>
+                <p class="heading">{% trans "Reading span" %}</p>
                 <p class="title is-4 mb-0">
                     {% if start_year %}
                         {{ start_year }}{% if end_year and end_year != start_year %}&ndash;{{ end_year }}{% endif %}
@@ -91,16 +93,16 @@
                 </p>
             </div>
             <div style="border-left: 1px solid #ededed; padding-left: 1.5rem;">
-                <p class="heading">Publishers</p>
+                <p class="heading">{% trans "Publishers" %}</p>
                 <p class="title is-4 mb-0">{% if publisher_breakdown %}{{ publisher_breakdown|length }}{% else %}{{ publishers|length }}{% endif %}</p>
             </div>
             <div style="border-left: 1px solid #ededed; padding-left: 1.5rem;">
-                <p class="heading">Series</p>
+                <p class="heading">{% trans "Series" %}</p>
                 <p class="title is-4 mb-0">{{ series_breakdown|length }}</p>
             </div>
             {% if issue_type_breakdown %}
                 <div class="is-flex-grow-1" style="min-width: 240px; border-left: 1px solid #ededed; padding-left: 1.5rem;">
-                    <p class="heading">Composition</p>
+                    <p class="heading">{% trans "Composition" %}</p>
                     <div style="display: flex; height: 10px; border-radius: 5px; overflow: hidden; background: #ededed;">
                         {% for seg in issue_type_breakdown %}
                             <div style="width: {% widthratio seg.count reading_list_items_count 100 %}%; background: {{ seg.color }};"></div>
@@ -127,7 +129,7 @@
                     <a class="level-item" href="{{ reading_list.previous.get_absolute_url }}">
                         <span class="icon"><i class="fas fa-arrow-left"></i></span>
                         <span>
-                            <span class="has-text-grey is-size-7 is-block">Previous</span>
+                            <span class="has-text-grey is-size-7 is-block">{% trans "Previous" %}</span>
                             <span class="has-text-weight-semibold">{{ reading_list.previous.name }}</span>
                         </span>
                     </a>
@@ -137,7 +139,7 @@
                 {% if reading_list.next %}
                     <a class="level-item has-text-right" href="{{ reading_list.next.get_absolute_url }}">
                         <span>
-                            <span class="has-text-grey is-size-7 is-block">Next</span>
+                            <span class="has-text-grey is-size-7 is-block">{% trans "Next" %}</span>
                             <span class="has-text-weight-semibold">{{ reading_list.next.name }}</span>
                         </span>
                         <span class="icon"><i class="fas fa-arrow-right"></i></span>
@@ -156,30 +158,30 @@
                     {% if is_owner %}
                         <a class="button is-primary" href="{% url 'reading-list:add-issue' reading_list.slug %}">
                             <span class="icon is-small"><i class="fas fa-plus"></i></span>
-                            <span>Add Issues</span>
+                            <span>{% trans "Add Issues" %}</span>
                         </a>
                         <a class="button is-primary is-light" href="{% url 'reading-list:add-from-series' reading_list.slug %}">
                             <span class="icon is-small"><i class="fas fa-layer-group"></i></span>
-                            <span>Add from Series</span>
+                            <span>{% trans "Add from Series" %}</span>
                         </a>
                         <a class="button is-primary is-light" href="{% url 'reading-list:add-from-arc' reading_list.slug %}">
                             <span class="icon is-small"><i class="fas fa-book"></i></span>
-                            <span>Add from Arc</span>
+                            <span>{% trans "Add from Arc" %}</span>
                         </a>
                         <a class="button is-info" href="{% url 'reading-list:update' reading_list.slug %}">
                             <span class="icon is-small"><i class="fas fa-edit"></i></span>
-                            <span>Edit</span>
+                            <span>{% trans "Edit" %}</span>
                         </a>
                         <a class="button is-danger" href="{% url 'reading-list:delete' reading_list.slug %}">
                             <span class="icon is-small"><i class="fas fa-trash"></i></span>
-                            <span>Delete</span>
+                            <span>{% trans "Delete" %}</span>
                         </a>
                     {% endif %}
                     {% if can_assign_to_metron %}
                         <a class="button is-warning is-outlined"
                            href="{% url 'reading-list:assign-to-metron' reading_list.slug %}">
                             <span class="icon is-small"><i class="fas fa-user-shield"></i></span>
-                            <span>Assign to Metron</span>
+                            <span>{% trans "Assign to Metron" %}</span>
                         </a>
                     {% endif %}
                 </div>
@@ -192,19 +194,19 @@
         <div class="column is-three-quarters">
             {% if reading_list.desc %}
                 <div class="box">
-                    <h2 class="title is-5">About this list</h2>
+                    <h2 class="title is-5">{% trans "About this list" %}</h2>
                     <div class="content">{{ reading_list.desc|linebreaksbr }}</div>
                 </div>
             {% endif %}
 
             <div class="box">
-                <h2 class="title is-5">Issues ({{ reading_list_items_count }})</h2>
+                <h2 class="title is-5">{% blocktrans with count=reading_list_items_count %}Issues ({{ count }}){% endblocktrans %}</h2>
                 {% if reading_list_items_count > 0 %}
                     {# ---- Type filter chips ---- #}
                     {% if issue_type_breakdown %}
                         <div class="rl-filters mb-4" style="display: flex; flex-wrap: wrap; gap: 0.4rem;">
                             <button class="button is-small is-rounded is-link rl-filter" data-filter="all">
-                                All <span class="ml-1 has-text-weight-bold">{{ reading_list_items_count }}</span>
+                                {% trans "All" %} <span class="ml-1 has-text-weight-bold">{{ reading_list_items_count }}</span>
                             </button>
                             {% for seg in issue_type_breakdown %}
                                 <button class="button is-small is-rounded rl-filter" data-filter="{{ seg.key }}">
@@ -227,7 +229,7 @@
                                     hx-target="#items-container"
                                     hx-swap="beforeend"
                                     hx-indicator="#items-spinner">
-                                <span>Load More Issues</span>
+                                <span>{% trans "Load More Issues" %}</span>
                             </button>
                             <span id="items-spinner" class="htmx-indicator ml-2">
                                 <i class="fas fa-spinner fa-spin"></i>
@@ -235,20 +237,20 @@
                         </div>
                     {% endif %}
                 {% else %}
-                    <p class="has-text-grey">No issues in this list yet.</p>
+                    <p class="has-text-grey">{% trans "No issues in this list yet." %}</p>
                     {% if is_owner %}
                         <div class="buttons mt-3">
                             <a href="{% url 'reading-list:add-issue' reading_list.slug %}" class="button is-primary">
                                 <span class="icon"><i class="fas fa-plus"></i></span>
-                                <span>Add Issues</span>
+                                <span>{% trans "Add Issues" %}</span>
                             </a>
                             <a href="{% url 'reading-list:add-from-series' reading_list.slug %}" class="button is-primary is-light">
                                 <span class="icon"><i class="fas fa-layer-group"></i></span>
-                                <span>Add from Series</span>
+                                <span>{% trans "Add from Series" %}</span>
                             </a>
                             <a href="{% url 'reading-list:add-from-arc' reading_list.slug %}" class="button is-primary is-light">
                                 <span class="icon"><i class="fas fa-book"></i></span>
-                                <span>Add from Arc</span>
+                                <span>{% trans "Add from Arc" %}</span>
                             </a>
                         </div>
                     {% endif %}
@@ -259,30 +261,30 @@
         {# ----------------------- SIDEBAR ----------------------- #}
         <div class="column">
             <div class="box">
-                <h2 class="title is-6">List details</h2>
+                <h2 class="title is-6">{% trans "List details" %}</h2>
                 <dl>
-                    <dt class="has-text-weight-bold">Owner:</dt>
+                    <dt class="has-text-weight-bold">{% trans "Owner:" %}</dt>
                     <dd class="mb-3">
                         <a href="{% url 'user-detail' username=reading_list.user.username %}">{{ reading_list.user.username }}</a>
                     </dd>
-                    <dt class="has-text-weight-bold">Type:</dt>
+                    <dt class="has-text-weight-bold">{% trans "Type:" %}</dt>
                     <dd class="mb-3"><span class="tag is-link is-light">{{ reading_list.get_list_type_display }}</span></dd>
-                    <dt class="has-text-weight-bold">Visibility:</dt>
+                    <dt class="has-text-weight-bold">{% trans "Visibility:" %}</dt>
                     <dd class="mb-3">
                         {% if reading_list.is_private %}
-                            <span class="tag is-warning">Private</span>
+                            <span class="tag is-warning">{% trans "Private" %}</span>
                         {% else %}
-                            <span class="tag is-success">Public</span>
+                            <span class="tag is-success">{% trans "Public" %}</span>
                         {% endif %}
                     </dd>
                     {% if start_year %}
-                        <dt class="has-text-weight-bold">Reading span:</dt>
+                        <dt class="has-text-weight-bold">{% trans "Reading span:" %}</dt>
                         <dd class="mb-3">
                             {% if start_year == end_year %}{{ start_year }}{% else %}{{ start_year }} &ndash; {{ end_year }}{% endif %}
                         </dd>
                     {% endif %}
                     {% if reading_list.attribution_source %}
-                        <dt class="has-text-weight-bold">Source:</dt>
+                        <dt class="has-text-weight-bold">{% trans "Source:" %}</dt>
                         <dd class="mb-3">
                             {% if reading_list.attribution_url %}
                                 <a href="{{ reading_list.attribution_url }}" target="_blank" rel="noopener noreferrer">
@@ -294,9 +296,9 @@
                             {% endif %}
                         </dd>
                     {% endif %}
-                    <dt class="has-text-weight-bold">Created:</dt>
+                    <dt class="has-text-weight-bold">{% trans "Created:" %}</dt>
                     <dd class="mb-3">{{ reading_list.created_on|date:"F d, Y" }}</dd>
-                    <dt class="has-text-weight-bold">Last modified:</dt>
+                    <dt class="has-text-weight-bold">{% trans "Last modified:" %}</dt>
                     <dd class="mb-3">{{ reading_list.modified|date:"F d, Y" }}</dd>
                 </dl>
                 <hr>
@@ -305,7 +307,7 @@
 
             {% if series_breakdown %}
                 <div class="box">
-                    <h2 class="title is-6">Series in this list</h2>
+                    <h2 class="title is-6">{% trans "Series in this list" %}</h2>
                     {% for entry in series_breakdown %}
                         <div class="is-flex is-align-items-center mb-2" style="gap: 0.6rem;">
                             <a href="{% url 'series:detail' entry.series.slug %}" class="is-flex-grow-1" style="min-width: 0;">
@@ -322,12 +324,14 @@
 
             {% if publisher_breakdown %}
                 <div class="box">
-                    <h2 class="title is-6">Publishers</h2>
+                    <h2 class="title is-6">{% trans "Publishers" %}</h2>
                     {% for entry in publisher_breakdown %}
                         <div class="mb-3">
                             <div class="is-flex is-justify-content-space-between is-align-items-baseline">
                                 <a href="{% url 'publisher:detail' entry.publisher.slug %}" class="has-text-weight-semibold">{{ entry.publisher.name }}</a>
-                                <span class="has-text-grey is-size-7">{{ entry.count }} issue{{ entry.count|pluralize }}</span>
+                                <span class="has-text-grey is-size-7">
+                                    {% blocktrans count counter=entry.count %}{{ counter }} issue{% plural %}{{ counter }} issues{% endblocktrans %}
+                                </span>
                             </div>
                             <div style="height: 6px; border-radius: 3px; background: #ededed; margin-top: 6px; overflow: hidden;">
                                 <div style="width: {% widthratio entry.count reading_list_items_count 100 %}%; height: 100%; background: #3273dc;"></div>
@@ -337,7 +341,7 @@
                 </div>
             {% elif publishers %}
                 <div class="box">
-                    <h2 class="title is-6">Publishers</h2>
+                    <h2 class="title is-6">{% trans "Publishers" %}</h2>
                     <div class="content">
                         {% for publisher in publishers %}
                             <a href="{% url 'publisher:detail' publisher.slug %}">{{ publisher.name }}</a>{% if not forloop.last %}, {% endif %}
@@ -348,7 +352,7 @@
 
             {% if top_characters %}
                 <div class="box">
-                    <h2 class="title is-6">Top Characters</h2>
+                    <h2 class="title is-6">{% trans "Top Characters" %}</h2>
                     {% for character in top_characters %}
                         <article class="media{% if not forloop.last %} mb-4{% endif %}">
                             <figure class="media-left">
@@ -373,7 +377,9 @@
                             <div class="media-content" style="align-self: center;">
                                 <a href="{% url 'character:detail' character.slug %}"
                                    class="has-text-weight-semibold is-size-7">{{ character.name }}</a>
-                                <p class="is-size-7 has-text-grey-light">{{ character.appearance_count }} issue{{ character.appearance_count|pluralize }}</p>
+                                <p class="is-size-7 has-text-grey-light">
+                                    {% blocktrans count counter=character.appearance_count %}{{ counter }} issue{% plural %}{{ counter }} issues{% endblocktrans %}
+                                </p>
                             </div>
                         </article>
                     {% endfor %}
@@ -382,7 +388,7 @@
 
             {% if featured_creators %}
                 <div class="box">
-                    <h2 class="title is-6">Featured Creators</h2>
+                    <h2 class="title is-6">{% trans "Featured Creators" %}</h2>
                     {% for entry in featured_creators %}
                         <article class="media{% if not forloop.last %} mb-4{% endif %}">
                             <figure class="media-left">

--- a/reading_lists/templates/reading_lists/readinglist_form.html
+++ b/reading_lists/templates/reading_lists/readinglist_form.html
@@ -1,6 +1,6 @@
 {% extends parent_template|default:"base.html" %}
-{% load static bulma_tags %}
-{% block title %}{{ title }} - Metron{% endblock %}
+{% load static bulma_tags i18n %}
+{% block title %}{% blocktrans %}{{ title }} - Metron{% endblocktrans %}{% endblock %}
 {% block headcss %}
     {{ form.media.css }}
 {% endblock %}
@@ -98,7 +98,7 @@
                                                             class="button is-small is-light mt-2"
                                                             data-ac-clear="{{ field.name }}">
                                                         <span class="icon is-small"><i class="fas fa-times"></i></span>
-                                                        <span>Clear selection</span>
+                                                        <span>{% trans "Clear selection" %}</span>
                                                     </button>
                                                 {% endif %}
                                             </div>
@@ -111,7 +111,7 @@
                             <div class="field is-grouped is-grouped-right mt-5">
                                 <div class="control">
                                     <a href="{% if object %}{% url 'reading-list:detail' object.slug %}{% else %}{% url 'reading-list:my-lists' %}{% endif %}"
-                                       class="button">Cancel</a>
+                                       class="button">{% trans "Cancel" %}</a>
                                 </div>
                                 <div class="control">
                                     <button type="submit" class="button is-primary">{{ button_text }}</button>

--- a/reading_lists/templates/reading_lists/readinglist_list.html
+++ b/reading_lists/templates/reading_lists/readinglist_list.html
@@ -1,9 +1,9 @@
 {% extends parent_template|default:"base.html" %}
-{% load static humanize %}
-{% block title %}{% if is_user_view %}My Reading Lists{% else %}Reading Lists{% endif %} - Metron{% endblock %}
+{% load static humanize i18n %}
+{% block title %}{% if is_user_view %}{% trans "My Reading Lists" %}{% else %}{% trans "Reading Lists" %}{% endif %} - Metron{% endblock %}
 {% block content %}
     <header class="block has-text-centered">
-        <h1 class="title">{% if is_user_view %}My Reading Lists{% else %}Reading Lists{% endif %}</h1>
+        <h1 class="title">{% if is_user_view %}{% trans "My Reading Lists" %}{% else %}{% trans "Reading Lists" %}{% endif %}</h1>
     </header>
     {% if not is_user_view %}
         <section class="section">
@@ -18,11 +18,11 @@
     {% if reading_lists %}
         <section class="section pt-0">
             <div class="container">
-                <nav class="level" aria-label="Reading list navigation">
+                <nav class="level" aria-label="{% trans 'Reading list navigation' %}">
                     <div class="level-left">
                         <div class="level-item">
                             <p class="subtitle is-5">
-                                <strong>{{ page_obj.paginator.count|intcomma }}</strong> reading list{{ page_obj.paginator.count|pluralize }}
+                                {% blocktrans count counter=page_obj.paginator.count with formatted_count=page_obj.paginator.count|intcomma %}<strong>{{ formatted_count }}</strong> reading list{% plural %}<strong>{{ formatted_count }}</strong> reading lists{% endblocktrans %}
                             </p>
                         </div>
                     </div>
@@ -33,17 +33,17 @@
                                     {% if is_user_view %}
                                         <a href="{% url 'reading-list:list' %}" class="button is-link">
                                             <span class="icon"><i class="fas fa-list"></i></span>
-                                            <span>All Reading Lists</span>
+                                            <span>{% trans "All Reading Lists" %}</span>
                                         </a>
                                     {% else %}
                                         <a href="{% url 'reading-list:my-lists' %}" class="button is-link">
                                             <span class="icon"><i class="fas fa-user"></i></span>
-                                            <span>My Reading Lists</span>
+                                            <span>{% trans "My Reading Lists" %}</span>
                                         </a>
                                     {% endif %}
                                     <a href="{% url 'reading-list:create' %}" class="button is-primary">
                                         <span class="icon"><i class="fas fa-plus"></i></span>
-                                        <span>Create Reading List</span>
+                                        <span>{% trans "Create Reading List" %}</span>
                                     </a>
                                 </div>
                             </div>
@@ -62,29 +62,29 @@
         <section class="section pt-0">
             <div class="container has-text-centered">
                 {% if is_user_view %}
-                    <p class="title is-4">You don't have any reading lists yet</p>
-                    <p class="subtitle">Create your first reading list!</p>
+                    <p class="title is-4">{% trans "You don't have any reading lists yet" %}</p>
+                    <p class="subtitle">{% trans "Create your first reading list!" %}</p>
                     <a href="{% url 'reading-list:create' %}" class="button is-primary is-large">
                         <span class="icon"><i class="fas fa-plus"></i></span>
-                        <span>Create Reading List</span>
+                        <span>{% trans "Create Reading List" %}</span>
                     </a>
                 {% elif has_active_filters %}
-                    <p class="title is-4">No results found</p>
-                    <p class="subtitle">Try adjusting your search filters</p>
+                    <p class="title is-4">{% trans "No results found" %}</p>
+                    <p class="subtitle">{% trans "Try adjusting your search filters" %}</p>
                     <a href="{% url 'reading-list:list' %}" class="button is-light is-medium">
                         <span class="icon"><i class="fas fa-times"></i></span>
-                        <span>Clear All Filters</span>
+                        <span>{% trans "Clear All Filters" %}</span>
                     </a>
                 {% else %}
-                    <p class="title is-4">No reading lists found</p>
+                    <p class="title is-4">{% trans "No reading lists found" %}</p>
                     {% if user.is_authenticated %}
-                        <p class="subtitle">Create your first reading list!</p>
+                        <p class="subtitle">{% trans "Create your first reading list!" %}</p>
                         <a href="{% url 'reading-list:create' %}" class="button is-primary is-large">
                             <span class="icon"><i class="fas fa-plus"></i></span>
-                            <span>Create Reading List</span>
+                            <span>{% trans "Create Reading List" %}</span>
                         </a>
                     {% else %}
-                        <p class="subtitle">Login to create your own reading lists</p>
+                        <p class="subtitle">{% trans "Login to create your own reading lists" %}</p>
                     {% endif %}
                 {% endif %}
             </div>

--- a/reading_lists/templates/reading_lists/remove_issue_confirm.html
+++ b/reading_lists/templates/reading_lists/remove_issue_confirm.html
@@ -1,9 +1,9 @@
 {% extends parent_template|default:"base.html" %}
-{% load static %}
-{% block title %}Remove Issue - Metron{% endblock %}
+{% load static i18n %}
+{% block title %}{% trans "Remove Issue - Metron" %}{% endblock %}
 {% block content %}
     <header class="block has-text-centered">
-        <h1 class="title">Remove Issue from Reading List</h1>
+        <h1 class="title">{% trans "Remove Issue from Reading List" %}</h1>
     </header>
     <section class="section">
         <div class="container">
@@ -13,8 +13,7 @@
                         <article class="message is-warning">
                             <div class="message-body">
                                 <p>
-                                    Remove <strong>{{ readinglistitem.issue }}</strong> from
-                                    <strong>{{ readinglistitem.reading_list.name }}</strong>?
+                                    {% blocktrans with issue=readinglistitem.issue name=readinglistitem.reading_list.name %}Remove <strong>{{ issue }}</strong> from <strong>{{ name }}</strong>?{% endblocktrans %}
                                 </p>
                             </div>
                         </article>
@@ -23,10 +22,10 @@
                             <div class="field is-grouped is-grouped-right">
                                 <div class="control">
                                     <a href="{% url 'reading-list:detail' readinglistitem.reading_list.slug %}"
-                                       class="button">Cancel</a>
+                                       class="button">{% trans "Cancel" %}</a>
                                 </div>
                                 <div class="control">
-                                    <button type="submit" class="button is-danger">Remove</button>
+                                    <button type="submit" class="button is-danger">{% trans "Remove" %}</button>
                                 </div>
                             </div>
                         </form>

--- a/reading_lists/views.py
+++ b/reading_lists/views.py
@@ -8,6 +8,7 @@ from django.db.models import Avg, Count, Prefetch
 from django.http import HttpResponseForbidden
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse, reverse_lazy
+from django.utils.translation import gettext_lazy as _, ngettext
 from django.views import View
 from django.views.decorators.http import require_POST
 from django.views.generic import CreateView, DeleteView, DetailView, FormView, ListView, UpdateView
@@ -39,43 +40,44 @@ READING_LIST_DETAIL_PAGINATE_BY = 50
 _NON_FILTER_PARAMS = {"page"}
 
 _FILTER_LABELS = {
-    "q": "Search",
-    "name": "Name",
-    "username": "Creator",
-    "publisher": "Publisher",
-    "list_type": "List Type",
-    "attribution_source": "Attribution",
-    "average_rating__gte": "Min Rating",
-    "is_private": "Privacy",
+    "q": _("Search"),
+    "name": _("Name"),
+    "username": _("Creator"),
+    "publisher": _("Publisher"),
+    "list_type": _("List Type"),
+    "attribution_source": _("Attribution"),
+    "average_rating__gte": _("Min Rating"),
+    "is_private": _("Privacy"),
 }
 
 _RATING_DISPLAY = {
-    "1": "1+ Stars",
-    "2": "2+ Stars",
-    "3": "3+ Stars",
-    "4": "4+ Stars",
-    "5": "5 Stars",
+    "1": _("1+ Stars"),
+    "2": _("2+ Stars"),
+    "3": _("3+ Stars"),
+    "4": _("4+ Stars"),
+    "5": _("5 Stars"),
 }
 
-_PRIVACY_DISPLAY = {"true": "Private", "false": "Public"}
+_PRIVACY_DISPLAY = {"true": _("Private"), "false": _("Public")}
 
 _ISSUE_TYPE_META = {
-    "CORE": ("Core", "#3273dc"),
-    "TIE_IN": ("Tie-In", "#f5b400"),
-    "PROLOGUE": ("Prologue", "#3e8ed0"),
-    "EPILOGUE": ("Epilogue", "#48c78e"),
+    "CORE": (_("Core"), "#3273dc"),
+    "TIE_IN": (_("Tie-In"), "#f5b400"),
+    "PROLOGUE": (_("Prologue"), "#3e8ed0"),
+    "EPILOGUE": (_("Epilogue"), "#48c78e"),
 }
 
+# These keys must match Role.name values in the database exactly - do not translate.
 _CREDIT_ROLE_NAMES = ["Artist", "Finishes", "Inker", "Penciller", "Script", "Story", "Writer"]
 
 _CREDIT_ROLE_DISPLAY = {
-    "Artist": "Artist",
-    "Finishes": "Artist",
-    "Inker": "Artist",
-    "Penciller": "Artist",
-    "Script": "Writer",
-    "Story": "Writer",
-    "Writer": "Writer",
+    "Artist": _("Artist"),
+    "Finishes": _("Artist"),
+    "Inker": _("Artist"),
+    "Penciller": _("Artist"),
+    "Script": _("Writer"),
+    "Story": _("Writer"),
+    "Writer": _("Writer"),
 }
 
 
@@ -367,7 +369,7 @@ def build_reading_list_breakdown_context(reading_list_items):
         {
             "creator": c,
             "roles": ", ".join(
-                sorted({_CREDIT_ROLE_DISPLAY.get(r, r) for r in role_map.get(c.id, [])})
+                sorted({str(_CREDIT_ROLE_DISPLAY.get(r, r)) for r in role_map.get(c.id, [])})
             ),
         }
         for c in top6
@@ -495,13 +497,15 @@ class ReadingListCreateView(LoginRequiredMixin, CreateView):
     def form_valid(self, form):
         # Set the user to the current user
         form.instance.user = self.request.user
-        messages.success(self.request, f"Reading list '{form.instance.name}' created!")
+        messages.success(
+            self.request, _("Reading list '%(name)s' created!") % {"name": form.instance.name}
+        )
         return super().form_valid(form)
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context["title"] = "Create Reading List"
-        context["button_text"] = "Create"
+        context["title"] = _("Create Reading List")
+        context["button_text"] = _("Create")
         return context
 
 
@@ -528,13 +532,15 @@ class ReadingListUpdateView(LoginRequiredMixin, UserPassesTestMixin, UpdateView)
 
     def form_valid(self, form):
         # Update the edited_by field (via the modified timestamp)
-        messages.success(self.request, f"Reading list '{form.instance.name}' updated!")
+        messages.success(
+            self.request, _("Reading list '%(name)s' updated!") % {"name": form.instance.name}
+        )
         return super().form_valid(form)
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context["title"] = "Edit Reading List"
-        context["button_text"] = "Update"
+        context["title"] = _("Edit Reading List")
+        context["button_text"] = _("Update")
         return context
 
 
@@ -551,7 +557,9 @@ class ReadingListDeleteView(LoginRequiredMixin, UserPassesTestMixin, DeleteView)
         return can_manage_reading_list(self.request.user, reading_list)
 
     def form_valid(self, form):
-        messages.success(self.request, f"Reading list '{self.object.name}' deleted!")
+        messages.success(
+            self.request, _("Reading list '%(name)s' deleted!") % {"name": self.object.name}
+        )
         return super().form_valid(form)
 
 
@@ -577,7 +585,7 @@ class AssignReadingListToMetronView(
         try:
             metron_user = CustomUser.objects.get(username="Metron")
         except CustomUser.DoesNotExist:
-            messages.error(request, "The 'Metron' user account does not exist.")
+            messages.error(request, _("The 'Metron' user account does not exist."))
             return redirect(self.reading_list.get_absolute_url())
 
         if self.reading_list.user_id != metron_user.id:
@@ -585,7 +593,8 @@ class AssignReadingListToMetronView(
             self.reading_list.save()
             messages.success(
                 request,
-                f"Ownership of '{self.reading_list.name}' has been reassigned to Metron.",
+                _("Ownership of '%(name)s' has been reassigned to Metron.")
+                % {"name": self.reading_list.name},
             )
         return redirect(self.reading_list.get_absolute_url())
 
@@ -608,7 +617,8 @@ class RemoveIssueFromReadingListView(
     def get_success_url(self):
         messages.success(
             self.request,
-            f"Removed {self.object.issue} from '{self.reading_list.name}'!",
+            _("Removed %(issue)s from '%(name)s'!")
+            % {"issue": self.object.issue, "name": self.reading_list.name},
         )
         return reverse("reading-list:detail", kwargs={"slug": self.reading_list.slug})
 
@@ -679,30 +689,53 @@ class AddIssueWithAutocompleteView(
                     continue
 
         # Provide feedback
-        messages_to_show = []
+        message_parts = []
         if added_count > 0:
             if added_count == 1:
-                messages_to_show.append(f"Added {added_issues[0]}")
+                message_parts.append(_("Added %(issue)s") % {"issue": added_issues[0]})
             else:
-                messages_to_show.append(f"Added {added_count} issue(s)")
+                message_parts.append(
+                    ngettext("Added %(count)d issue", "Added %(count)d issues", added_count)
+                    % {"count": added_count}
+                )
 
         if reordered_count > 0:
-            messages_to_show.append(f"reordered {reordered_count} existing issue(s)")
+            message_parts.append(
+                ngettext(
+                    "reordered %(count)d existing issue",
+                    "reordered %(count)d existing issues",
+                    reordered_count,
+                )
+                % {"count": reordered_count}
+            )
 
-        if messages_to_show:
+        if message_parts:
+            if len(message_parts) > 1:
+                summary = _("%(first)s and %(second)s") % {
+                    "first": message_parts[0],
+                    "second": message_parts[1],
+                }
+            else:
+                summary = message_parts[0]
             messages.success(
                 self.request,
-                f"{', '.join(messages_to_show)} in '{self.reading_list.name}'!",
+                _("%(summary)s in '%(name)s'!")
+                % {"summary": summary, "name": self.reading_list.name},
             )
 
         if skipped_count > 0:
             messages.info(
                 self.request,
-                f"Skipped {skipped_count} duplicate issue(s).",
+                ngettext(
+                    "Skipped %(count)d duplicate issue.",
+                    "Skipped %(count)d duplicate issues.",
+                    skipped_count,
+                )
+                % {"count": skipped_count},
             )
 
         if added_count == 0 and reordered_count == 0 and skipped_count == 0:
-            messages.info(self.request, "No changes were made.")
+            messages.info(self.request, _("No changes were made."))
 
         return redirect(self.get_success_url())
 
@@ -742,15 +775,26 @@ class AddIssuesFromSeriesView(
         if added_count == 0:
             messages.info(
                 self.request,
-                f"No new issues to add. All issues from {series} are already in the list.",
+                _("No new issues to add. All issues from %(series)s are already in the list.")
+                % {"series": series},
             )
             return redirect(self.get_success_url())
 
-        position_text = "at the beginning" if position == "beginning" else "at the end"
+        if position == "beginning":
+            message = ngettext(
+                "Added %(count)d issue from %(series)s at the beginning of '%(name)s'!",
+                "Added %(count)d issues from %(series)s at the beginning of '%(name)s'!",
+                added_count,
+            )
+        else:
+            message = ngettext(
+                "Added %(count)d issue from %(series)s at the end of '%(name)s'!",
+                "Added %(count)d issues from %(series)s at the end of '%(name)s'!",
+                added_count,
+            )
         messages.success(
             self.request,
-            f"Added {added_count} issue(s) from {series} {position_text} "
-            f"of '{self.reading_list.name}'!",
+            message % {"count": added_count, "series": series, "name": self.reading_list.name},
         )
 
         return redirect(self.get_success_url())
@@ -774,15 +818,26 @@ class AddIssuesFromArcView(
         if added_count == 0:
             messages.info(
                 self.request,
-                f"No new issues to add. All issues from {arc} are already in the list.",
+                _("No new issues to add. All issues from %(arc)s are already in the list.")
+                % {"arc": arc},
             )
             return redirect(self.get_success_url())
 
-        position_text = "at the beginning" if position == "beginning" else "at the end"
+        if position == "beginning":
+            message = ngettext(
+                "Added %(count)d issue from %(arc)s at the beginning of '%(name)s'!",
+                "Added %(count)d issues from %(arc)s at the beginning of '%(name)s'!",
+                added_count,
+            )
+        else:
+            message = ngettext(
+                "Added %(count)d issue from %(arc)s at the end of '%(name)s'!",
+                "Added %(count)d issues from %(arc)s at the end of '%(name)s'!",
+                added_count,
+            )
         messages.success(
             self.request,
-            f"Added {added_count} issue(s) from {arc} {position_text} "
-            f"of '{self.reading_list.name}'!",
+            message % {"count": added_count, "arc": arc, "name": self.reading_list.name},
         )
 
         return redirect(self.get_success_url())

--- a/templates/404.html
+++ b/templates/404.html
@@ -1,7 +1,7 @@
 {% extends parent_template|default:"base.html" %}
-{% load static %}
+{% load static i18n %}
 {% block title %}
-    Page Not Found - Metron
+    {% trans "Page Not Found - Metron" %}
 {% endblock title %}
 {% block content %}
     <section class="hero is-medium">
@@ -13,7 +13,7 @@
                         <i class="fas fa-exclamation-triangle fa-5x"></i>
                     </span>
                     <h1 class="title is-1 mt-4 has-text-grey-dark">404</h1>
-                    <h2 class="subtitle is-3 has-text-grey">Page Not Found</h2>
+                    <h2 class="subtitle is-3 has-text-grey">{% trans "Page Not Found" %}</h2>
                 </div>
                 {# Error Message #}
                 <div class="columns is-centered">
@@ -21,7 +21,7 @@
                         <div class="box">
                             <div class="content">
                                 <p class="is-size-5 mb-4">
-                                    Sorry, we couldn't find the page you're looking for. It might have been moved, deleted, or never existed.
+                                    {% trans "Sorry, we couldn't find the page you're looking for. It might have been moved, deleted, or never existed." %}
                                 </p>
                                 {# Helpful Actions #}
                                 <div class="buttons is-centered mt-5">
@@ -29,37 +29,41 @@
                                         <span class="icon">
                                             <i class="fas fa-home"></i>
                                         </span>
-                                        <span>Go to Home</span>
+                                        <span>{% trans "Go to Home" %}</span>
                                     </a>
                                     <button class="button is-light is-medium" onclick="history.back()">
                                         <span class="icon">
                                             <i class="fas fa-arrow-left"></i>
                                         </span>
-                                        <span>Go Back</span>
+                                        <span>{% trans "Go Back" %}</span>
                                     </button>
                                 </div>
                             </div>
                         </div>
                         {# Suggestions #}
                         <div class="notification is-info is-light">
-                            <p class="has-text-weight-bold mb-3">You might want to:</p>
+                            <p class="has-text-weight-bold mb-3">{% trans "You might want to:" %}</p>
                             <div class="content">
                                 <ul class="has-text-left">
-                                    <li>Check the URL for typos</li>
-                                    <li>Use the search feature to find what you're looking for</li>
+                                    <li>{% trans "Check the URL for typos" %}</li>
+                                    <li>{% trans "Use the search feature to find what you're looking for" %}</li>
                                     <li>
-                                        Browse our <a href="{% url 'issue:list' %}">issues</a>, <a href="{% url 'series:list' %}">series</a>, or <a href="{% url 'character:list' %}">characters</a>
+                                        {% url 'issue:list' as issue_list_url %}
+                                        {% url 'series:list' as series_list_url %}
+                                        {% url 'character:list' as character_list_url %}
+                                        {% blocktrans %}Browse our <a href="{{ issue_list_url }}">issues</a>, <a href="{{ series_list_url }}">series</a>, or <a href="{{ character_list_url }}">characters</a>{% endblocktrans %}
                                     </li>
                                     <li>
-                                        Return to the <a href="{% url 'home' %}">homepage</a>
+                                        {% url 'home' as home_url %}
+                                        {% blocktrans %}Return to the <a href="{{ home_url }}">homepage</a>{% endblocktrans %}
                                     </li>
                                 </ul>
                             </div>
                         </div>
                         {# Contact Section #}
                         <div class="box">
-                            <p class="has-text-weight-bold mb-2">Still need help?</p>
-                            <p class="mb-3">If you believe this is an error, please let us know:</p>
+                            <p class="has-text-weight-bold mb-2">{% trans "Still need help?" %}</p>
+                            <p class="mb-3">{% trans "If you believe this is an error, please let us know:" %}</p>
                             <div class="buttons is-centered">
                                 <a class="button is-link is-outlined is-small"
                                    href="https://github.com/Metron-Project/metron/issues/new/choose"
@@ -68,14 +72,14 @@
                                     <span class="icon">
                                         <i class="fas fa-bug"></i>
                                     </span>
-                                    <span>Report Issue</span>
+                                    <span>{% trans "Report Issue" %}</span>
                                 </a>
                                 <a class="button is-link is-outlined is-small"
                                    href="mailto:admin@metron.cloud">
                                     <span class="icon">
                                         <i class="fas fa-envelope"></i>
                                     </span>
-                                    <span>Contact Us</span>
+                                    <span>{% trans "Contact Us" %}</span>
                                 </a>
                             </div>
                         </div>

--- a/templates/500.html
+++ b/templates/500.html
@@ -1,7 +1,7 @@
 {% extends parent_template|default:"base.html" %}
-{% load static %}
+{% load static i18n %}
 {% block title %}
-    Page Not Found - Metron
+    {% trans "Page Not Found - Metron" %}
 {% endblock title %}
 {% block content %}
     <section class="hero is-medium">
@@ -13,7 +13,7 @@
                         <i class="fas fa-exclamation-triangle fa-5x"></i>
                     </span>
                     <h1 class="title is-1 mt-4 has-text-grey-dark">404</h1>
-                    <h2 class="subtitle is-3 has-text-grey">Page Not Found</h2>
+                    <h2 class="subtitle is-3 has-text-grey">{% trans "Page Not Found" %}</h2>
                 </div>
                 {# Error Message #}
                 <div class="columns is-centered">
@@ -21,7 +21,7 @@
                         <div class="box">
                             <div class="content">
                                 <p class="is-size-5 mb-4">
-                                    Sorry, we couldn't find the page you're looking for. It might have been moved, deleted, or never existed.
+                                    {% trans "Sorry, we couldn't find the page you're looking for. It might have been moved, deleted, or never existed." %}
                                 </p>
                                 {# Helpful Actions #}
                                 <div class="buttons is-centered mt-5">
@@ -29,37 +29,41 @@
                                         <span class="icon">
                                             <i class="fas fa-home"></i>
                                         </span>
-                                        <span>Go to Home</span>
+                                        <span>{% trans "Go to Home" %}</span>
                                     </a>
                                     <button class="button is-light is-medium" onclick="history.back()">
                                         <span class="icon">
                                             <i class="fas fa-arrow-left"></i>
                                         </span>
-                                        <span>Go Back</span>
+                                        <span>{% trans "Go Back" %}</span>
                                     </button>
                                 </div>
                             </div>
                         </div>
                         {# Suggestions #}
                         <div class="notification is-info is-light">
-                            <p class="has-text-weight-bold mb-3">You might want to:</p>
+                            <p class="has-text-weight-bold mb-3">{% trans "You might want to:" %}</p>
                             <div class="content">
                                 <ul class="has-text-left">
-                                    <li>Check the URL for typos</li>
-                                    <li>Use the search feature to find what you're looking for</li>
+                                    <li>{% trans "Check the URL for typos" %}</li>
+                                    <li>{% trans "Use the search feature to find what you're looking for" %}</li>
                                     <li>
-                                        Browse our <a href="{% url 'issue:list' %}">issues</a>, <a href="{% url 'series:list' %}">series</a>, or <a href="{% url 'character:list' %}">characters</a>
+                                        {% url 'issue:list' as issue_list_url %}
+                                        {% url 'series:list' as series_list_url %}
+                                        {% url 'character:list' as character_list_url %}
+                                        {% blocktrans %}Browse our <a href="{{ issue_list_url }}">issues</a>, <a href="{{ series_list_url }}">series</a>, or <a href="{{ character_list_url }}">characters</a>{% endblocktrans %}
                                     </li>
                                     <li>
-                                        Return to the <a href="{% url 'home' %}">homepage</a>
+                                        {% url 'home' as home_url %}
+                                        {% blocktrans %}Return to the <a href="{{ home_url }}">homepage</a>{% endblocktrans %}
                                     </li>
                                 </ul>
                             </div>
                         </div>
                         {# Contact Section #}
                         <div class="box">
-                            <p class="has-text-weight-bold mb-2">Still need help?</p>
-                            <p class="mb-3">If you believe this is an error, please let us know:</p>
+                            <p class="has-text-weight-bold mb-2">{% trans "Still need help?" %}</p>
+                            <p class="mb-3">{% trans "If you believe this is an error, please let us know:" %}</p>
                             <div class="buttons is-centered">
                                 <a class="button is-link is-outlined is-small"
                                    href="https://github.com/Metron-Project/metron/issues/new/choose"
@@ -68,14 +72,14 @@
                                     <span class="icon">
                                         <i class="fas fa-bug"></i>
                                     </span>
-                                    <span>Report Issue</span>
+                                    <span>{% trans "Report Issue" %}</span>
                                 </a>
                                 <a class="button is-link is-outlined is-small"
                                    href="mailto:admin@metron.cloud">
                                     <span class="icon">
                                         <i class="fas fa-envelope"></i>
                                     </span>
-                                    <span>Contact Us</span>
+                                    <span>{% trans "Contact Us" %}</span>
                                 </a>
                             </div>
                         </div>

--- a/templates/django/forms/widgets/clearable_file_input.html
+++ b/templates/django/forms/widgets/clearable_file_input.html
@@ -1,3 +1,4 @@
+{% load i18n %}
 {% comment %}
     Custom template for Django's ClearableFileInput widget
     Styled with Bulma CSS framework for consistency with Metron
@@ -61,14 +62,14 @@
                            type="{{ widget.type }}"
                            name="{{ widget.name }}"
                            {% include "django/forms/widgets/attrs.html" %}
-                           onchange="document.getElementById('filename-{{ widget.name }}').textContent = this.files.length > 0 ? this.files[0].name : 'No file selected';">
+                           onchange="document.getElementById('filename-{{ widget.name }}').textContent = this.files.length > 0 ? this.files[0].name : '{% filter escapejs %}{% trans "No file selected" %}{% endfilter %}';">
                     <span class="file-cta">
                         <span class="file-icon">
                             <i class="fas fa-upload"></i>
                         </span>
-                        <span class="file-label">Choose new file…</span>
+                        <span class="file-label">{% trans "Choose new file…" %}</span>
                     </span>
-                    <span class="file-name" id="filename-{{ widget.name }}">No file selected</span>
+                    <span class="file-name" id="filename-{{ widget.name }}">{% trans "No file selected" %}</span>
                 </label>
             </div>
         </div>
@@ -81,14 +82,14 @@
                    type="{{ widget.type }}"
                    name="{{ widget.name }}"
                    {% include "django/forms/widgets/attrs.html" %}
-                   onchange="document.getElementById('filename-{{ widget.name }}').textContent = this.files.length > 0 ? this.files[0].name : 'No file selected';">
+                   onchange="document.getElementById('filename-{{ widget.name }}').textContent = this.files.length > 0 ? this.files[0].name : '{% filter escapejs %}{% trans "No file selected" %}{% endfilter %}';">
             <span class="file-cta">
                 <span class="file-icon">
                     <i class="fas fa-upload"></i>
                 </span>
-                <span class="file-label">Choose a file…</span>
+                <span class="file-label">{% trans "Choose a file…" %}</span>
             </span>
-            <span class="file-name" id="filename-{{ widget.name }}">No file selected</span>
+            <span class="file-name" id="filename-{{ widget.name }}">{% trans "No file selected" %}</span>
         </label>
     </div>
 {% endif %}

--- a/templates/partials/rating_summary.html
+++ b/templates/partials/rating_summary.html
@@ -1,3 +1,4 @@
+{% load i18n %}
 {% comment %}
 Compact average-rating summary (stars + count), used in page headers.
 
@@ -20,6 +21,8 @@ Required context:
                 <i class="{% if star_num|add:'0' <= average_rating %}fas{% else %}far{% endif %} fa-star"></i>
             {% endfor %}
         </span>
-        <span class="has-text-grey ml-1">{{ average_rating|floatformat:1 }} ({{ rating_count }} rating{{ rating_count|pluralize }})</span>
+        <span class="has-text-grey ml-1">
+            {% blocktrans count counter=rating_count with avg=average_rating|floatformat:1 %}{{ avg }} ({{ counter }} rating){% plural %}{{ avg }} ({{ counter }} ratings){% endblocktrans %}
+        </span>
     {% endif %}
 </span>

--- a/templates/partials/rating_widget.html
+++ b/templates/partials/rating_widget.html
@@ -1,3 +1,4 @@
+{% load i18n %}
 {% comment %}
 Generic 1-5 star rating widget, shared by reading_lists and issue_ratings.
 
@@ -15,7 +16,7 @@ Required context:
     <div id="rating-widget-{{ rated_object.pk }}" class="rating-widget" style="scroll-margin-top: 4rem;">
         {# Display average rating #}
         <div class="average-rating mb-2">
-            <span class="has-text-weight-bold">Average Rating:</span>
+            <span class="has-text-weight-bold">{% trans "Average Rating:" %}</span>
             {% if average_rating %}
                 <span class="rating-stars">
                     {% for star_num in "12345" %}
@@ -23,15 +24,17 @@ Required context:
                            style="color: #ffd700"></i>
                     {% endfor %}
                 </span>
-                <span class="rating-value">{{ average_rating|floatformat:1 }} ({{ rating_count }} rating{{ rating_count|pluralize }})</span>
+                <span class="rating-value">
+                    {% blocktrans count counter=rating_count with avg=average_rating|floatformat:1 %}{{ avg }} ({{ counter }} rating){% plural %}{{ avg }} ({{ counter }} ratings){% endblocktrans %}
+                </span>
             {% else %}
-                <span class="has-text-grey-light">No ratings yet</span>
+                <span class="has-text-grey-light">{% trans "No ratings yet" %}</span>
             {% endif %}
         </div>
         {# User's rating (if allowed) #}
         {% if can_rate %}
             <div class="user-rating">
-                <span class="has-text-weight-bold">Your Rating:</span>
+                <span class="has-text-weight-bold">{% trans "Your Rating:" %}</span>
                 <div class="star-rating">
                     {% for star_num in "12345" %}
                         <button type="button"
@@ -40,7 +43,7 @@ Required context:
                                 hx-vals='{"rating": "{{ forloop.counter }}"}'
                                 hx-target="#rating-widget-{{ rated_object.pk }}"
                                 hx-swap="outerHTML"
-                                title="Rate {{ forloop.counter }} star{% if forloop.counter > 1 %}s{% endif %}">
+                                title="{% blocktrans count counter=forloop.counter %}Rate {{ counter }} star{% plural %}Rate {{ counter }} stars{% endblocktrans %}">
                             <i class="{% if user_rating and forloop.counter <= user_rating.rating %}fas{% else %}far{% endif %} fa-star"></i>
                         </button>
                     {% endfor %}
@@ -51,7 +54,7 @@ Required context:
                                 hx-vals='{"rating": "0"}'
                                 hx-target="#rating-widget-{{ rated_object.pk }}"
                                 hx-swap="outerHTML"
-                                title="Clear rating">
+                                title="{% trans 'Clear rating' %}">
                             <i class="fas fa-times-circle"></i>
                         </button>
                     {% endif %}

--- a/templates/partials/social_meta.html
+++ b/templates/partials/social_meta.html
@@ -1,3 +1,4 @@
+{% load i18n %}
 {% comment %}
     Social media meta tags for Twitter and Open Graph
     Can be overridden in child templates by redefining the social_meta block
@@ -6,20 +7,20 @@
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:site" content="@MetronDB">
 <meta name="twitter:title"
-      content="{% block twitter_title %}Metron Comic Book Database{% endblock %}">
+      content="{% block twitter_title %}{% trans 'Metron Comic Book Database' %}{% endblock %}">
 <meta name="twitter:description"
-      content="{% block twitter_description %}A community-based comic book database.{% endblock %}">
+      content="{% block twitter_description %}{% trans 'A community-based comic book database.' %}{% endblock %}">
 <meta name="twitter:image"
       content="{% block twitter_image %}https://metron-static.nyc3.digitaloceanspaces.com/misc/metron-twitter-card.jpg{% endblock %}">
 <meta name="twitter:image:alt"
-      content="{% block twitter_image_alt %}An image of the New God Metron seated and pondering the universe.{% endblock %}">
+      content="{% block twitter_image_alt %}{% trans 'An image of the New God Metron seated and pondering the universe.' %}{% endblock %}">
 {# Open Graph Meta Tags #}
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="Metron Comic Book Database">
 <meta property="og:title"
-      content="{% block og_title %}Metron Comic Book Database{% endblock %}">
+      content="{% block og_title %}{% trans 'Metron Comic Book Database' %}{% endblock %}">
 <meta property="og:description"
-      content="{% block og_description %}A community-based comic book database.{% endblock %}">
+      content="{% block og_description %}{% trans 'A community-based comic book database.' %}{% endblock %}">
 <meta property="og:url"
       content="{% block og_url %}https://metron.cloud/{% endblock %}">
 <meta property="og:image"

--- a/templates/registration/login.html
+++ b/templates/registration/login.html
@@ -1,8 +1,8 @@
 {% extends "base.html" %}
 {% load bulma_tags %}
-{% load static %}
+{% load static i18n %}
 {% block title %}
-    Login - Metron
+    {% trans "Login - Metron" %}
 {% endblock title %}
 {% block content %}
     {# Page Header #}
@@ -10,8 +10,8 @@
         <span class="icon is-large has-text-link">
             <i class="fas fa-sign-in-alt fa-3x"></i>
         </span>
-        <h1 class="title is-3 mt-4">Login to Metron</h1>
-        <p class="subtitle has-text-grey">Access your account to contribute to the database</p>
+        <h1 class="title is-3 mt-4">{% trans "Login to Metron" %}</h1>
+        <p class="subtitle has-text-grey">{% trans "Access your account to contribute to the database" %}</p>
     </header>
     {# Login Form #}
     <div class="columns is-centered">
@@ -23,7 +23,7 @@
                     {% if form.non_field_errors %}
                         <div class="notification is-danger is-light">
                             <button class="delete"
-                                    aria-label="close"
+                                    aria-label="{% trans 'close' %}"
                                     onclick="this.parentElement.remove();"></button>
                             {% for error in form.non_field_errors %}<p>{{ error }}</p>{% endfor %}
                         </div>
@@ -54,7 +54,7 @@
                                 <span class="icon">
                                     <i class="fas fa-sign-in-alt"></i>
                                 </span>
-                                <span>Login</span>
+                                <span>{% trans "Login" %}</span>
                             </button>
                         </div>
                     </div>
@@ -65,7 +65,7 @@
                                 <span class="icon is-small">
                                     <i class="fas fa-question-circle"></i>
                                 </span>
-                                <span>Forgot your password?</span>
+                                <span>{% trans "Forgot your password?" %}</span>
                             </a>
                         </p>
                     </div>
@@ -74,8 +74,8 @@
             {# Sign Up Prompt #}
             <div class="notification is-info is-light has-text-centered">
                 <p>
-                    Don't have an account?
-                    <a href="{% url 'signup' %}" class="has-text-weight-bold">Sign up here</a>
+                    {% trans "Don't have an account?" %}
+                    <a href="{% url 'signup' %}" class="has-text-weight-bold">{% trans "Sign up here" %}</a>
                 </p>
             </div>
         </div>

--- a/templates/registration/password_reset_complete.html
+++ b/templates/registration/password_reset_complete.html
@@ -1,6 +1,7 @@
 {% extends 'base.html' %}
+{% load i18n %}
 {% block title %}
-    Password Reset Complete - Metron
+    {% trans "Password Reset Complete - Metron" %}
 {% endblock title %}
 {% block content %}
     {# Success Header #}
@@ -8,7 +9,7 @@
         <span class="icon is-large has-text-success">
             <i class="fas fa-check-circle fa-4x"></i>
         </span>
-        <h1 class="title is-3 mt-4">Password Reset Complete</h1>
+        <h1 class="title is-3 mt-4">{% trans "Password Reset Complete" %}</h1>
     </header>
     {# Success Message #}
     <div class="columns is-centered">
@@ -16,8 +17,8 @@
             <div class="box">
                 <article class="message is-success">
                     <div class="message-body">
-                        <p class="mb-3">Your password has been successfully changed!</p>
-                        <p>You can now log in with your new password.</p>
+                        <p class="mb-3">{% trans "Your password has been successfully changed!" %}</p>
+                        <p>{% trans "You can now log in with your new password." %}</p>
                     </div>
                 </article>
                 <div class="content has-text-centered mt-5">
@@ -26,7 +27,7 @@
                             <span class="icon">
                                 <i class="fas fa-sign-in-alt"></i>
                             </span>
-                            <span>Go to Login Page</span>
+                            <span>{% trans "Go to Login Page" %}</span>
                         </a>
                     </div>
                 </div>
@@ -37,14 +38,14 @@
                     <span class="icon">
                         <i class="fas fa-shield-alt"></i>
                     </span>
-                    Security Tip
+                    {% trans "Security Tip" %}
                 </p>
                 <div class="content">
                     <ul>
-                        <li>Keep your password secure and don't share it with anyone</li>
-                        <li>Use a unique password for Metron</li>
-                        <li>Consider using a password manager</li>
-                        <li>Change your password periodically for better security</li>
+                        <li>{% trans "Keep your password secure and don't share it with anyone" %}</li>
+                        <li>{% trans "Use a unique password for Metron" %}</li>
+                        <li>{% trans "Consider using a password manager" %}</li>
+                        <li>{% trans "Change your password periodically for better security" %}</li>
                     </ul>
                 </div>
             </div>

--- a/templates/registration/password_reset_confirm.html
+++ b/templates/registration/password_reset_confirm.html
@@ -1,8 +1,8 @@
 {% extends 'base.html' %}
 {% load bulma_tags %}
-{% load static %}
+{% load static i18n %}
 {% block title %}
-    Set New Password - Metron
+    {% trans "Set New Password - Metron" %}
 {% endblock title %}
 {% block content %}
     {# Page Header #}
@@ -10,8 +10,8 @@
         <span class="icon is-large has-text-success">
             <i class="fas fa-lock fa-3x"></i>
         </span>
-        <h1 class="title is-3 mt-4">Set Your New Password</h1>
-        <p class="subtitle has-text-grey">Choose a strong password for your account</p>
+        <h1 class="title is-3 mt-4">{% trans "Set Your New Password" %}</h1>
+        <p class="subtitle has-text-grey">{% trans "Choose a strong password for your account" %}</p>
     </header>
     {# Password Reset Form #}
     <div class="columns is-centered">
@@ -23,7 +23,7 @@
                     {% if form.non_field_errors %}
                         <div class="notification is-danger is-light">
                             <button class="delete"
-                                    aria-label="close"
+                                    aria-label="{% trans 'close' %}"
                                     onclick="this.parentElement.remove();"></button>
                             {% for error in form.non_field_errors %}<p>{{ error }}</p>{% endfor %}
                         </div>
@@ -50,7 +50,7 @@
                                 <span class="icon">
                                     <i class="fas fa-check"></i>
                                 </span>
-                                <span>Change Password</span>
+                                <span>{% trans "Change Password" %}</span>
                             </button>
                         </div>
                     </div>
@@ -58,12 +58,12 @@
             </div>
             {# Password Requirements #}
             <div class="notification is-info is-light">
-                <p class="has-text-weight-bold mb-2">Password Requirements:</p>
+                <p class="has-text-weight-bold mb-2">{% trans "Password Requirements:" %}</p>
                 <ul class="content is-small">
-                    <li>Your password can't be too similar to your other personal information</li>
-                    <li>Your password must contain at least 8 characters</li>
-                    <li>Your password can't be a commonly used password</li>
-                    <li>Your password can't be entirely numeric</li>
+                    <li>{% trans "Your password can't be too similar to your other personal information" %}</li>
+                    <li>{% trans "Your password must contain at least 8 characters" %}</li>
+                    <li>{% trans "Your password can't be a commonly used password" %}</li>
+                    <li>{% trans "Your password can't be entirely numeric" %}</li>
                 </ul>
             </div>
         </div>

--- a/templates/registration/password_reset_done.html
+++ b/templates/registration/password_reset_done.html
@@ -1,6 +1,7 @@
 {% extends 'base.html' %}
+{% load i18n %}
 {% block title %}
-    Reset Email Sent - Metron
+    {% trans "Reset Email Sent - Metron" %}
 {% endblock title %}
 {% block content %}
     {# Success Header #}
@@ -8,7 +9,7 @@
         <span class="icon is-large has-text-success">
             <i class="fas fa-envelope-open-text fa-4x"></i>
         </span>
-        <h1 class="title is-3 mt-4">Check Your Inbox</h1>
+        <h1 class="title is-3 mt-4">{% trans "Check Your Inbox" %}</h1>
     </header>
     {# Success Message #}
     <div class="columns is-centered">
@@ -16,8 +17,8 @@
             <div class="box">
                 <article class="message is-success">
                     <div class="message-body">
-                        <p class="mb-3">We've sent password reset instructions to your email address.</p>
-                        <p>You should receive the email within a few minutes.</p>
+                        <p class="mb-3">{% trans "We've sent password reset instructions to your email address." %}</p>
+                        <p>{% trans "You should receive the email within a few minutes." %}</p>
                     </div>
                 </article>
                 <div class="content has-text-centered mt-5">
@@ -26,34 +27,35 @@
                             <span class="icon">
                                 <i class="fas fa-sign-in-alt"></i>
                             </span>
-                            <span>Back to Login</span>
+                            <span>{% trans "Back to Login" %}</span>
                         </a>
                     </div>
                 </div>
             </div>
             {# Troubleshooting Box #}
             <div class="notification is-warning is-light">
-                <p class="has-text-weight-bold mb-2">Didn't receive the email?</p>
+                <p class="has-text-weight-bold mb-2">{% trans "Didn't receive the email?" %}</p>
                 <ul class="content">
-                    <li>Check your spam or junk folder</li>
-                    <li>Make sure you entered the correct email address</li>
-                    <li>Wait a few minutes - emails can be delayed</li>
+                    <li>{% trans "Check your spam or junk folder" %}</li>
+                    <li>{% trans "Make sure you entered the correct email address" %}</li>
+                    <li>{% trans "Wait a few minutes - emails can be delayed" %}</li>
                     <li>
-                        Try the <a href="{% url 'password_reset' %}">password reset</a> again
+                        {% url 'password_reset' as password_reset_url %}
+                        {% blocktrans %}Try the <a href="{{ password_reset_url }}">password reset</a> again{% endblocktrans %}
                     </li>
                 </ul>
             </div>
             {# Support Box #}
             <div class="box has-text-centered">
-                <p class="has-text-weight-bold mb-2">Still having trouble?</p>
-                <p class="mb-3">Contact us for assistance</p>
+                <p class="has-text-weight-bold mb-2">{% trans "Still having trouble?" %}</p>
+                <p class="mb-3">{% trans "Contact us for assistance" %}</p>
                 <div class="buttons is-centered">
                     <a class="button is-link is-outlined is-small"
                        href="mailto:admin@metron.cloud">
                         <span class="icon">
                             <i class="fas fa-envelope"></i>
                         </span>
-                        <span>Contact Support</span>
+                        <span>{% trans "Contact Support" %}</span>
                     </a>
                 </div>
             </div>

--- a/templates/registration/password_reset_form.html
+++ b/templates/registration/password_reset_form.html
@@ -1,8 +1,8 @@
 {% extends "base.html" %}
 {% load bulma_tags %}
-{% load static %}
+{% load static i18n %}
 {% block title %}
-    Password Reset - Metron
+    {% trans "Password Reset - Metron" %}
 {% endblock title %}
 {% block content %}
     {# Page Header #}
@@ -10,8 +10,8 @@
         <span class="icon is-large has-text-warning">
             <i class="fas fa-key fa-3x"></i>
         </span>
-        <h1 class="title is-3 mt-4">Reset Your Password</h1>
-        <p class="subtitle has-text-grey">Enter your email address and we'll send you reset instructions</p>
+        <h1 class="title is-3 mt-4">{% trans "Reset Your Password" %}</h1>
+        <p class="subtitle has-text-grey">{% trans "Enter your email address and we'll send you reset instructions" %}</p>
     </header>
     {# Reset Form #}
     <div class="columns is-centered">
@@ -21,7 +21,7 @@
                     {% csrf_token %}
                     {# Email Field #}
                     <div class="field" data-field-name="email">
-                        <label class="label {{ form.required_css_class }}" for="email">Email Address</label>
+                        <label class="label {{ form.required_css_class }}" for="email">{% trans "Email Address" %}</label>
                         <div class="control has-icons-left">
                             {{ form.email|add_field_class:'input' }}
                             <span class="icon is-small is-left">
@@ -38,7 +38,7 @@
                                 <span class="icon">
                                     <i class="fas fa-paper-plane"></i>
                                 </span>
-                                <span>Send Reset Instructions</span>
+                                <span>{% trans "Send Reset Instructions" %}</span>
                             </button>
                         </div>
                     </div>
@@ -49,7 +49,7 @@
                                 <span class="icon is-small">
                                     <i class="fas fa-arrow-left"></i>
                                 </span>
-                                <span>Back to Login</span>
+                                <span>{% trans "Back to Login" %}</span>
                             </a>
                         </p>
                     </div>
@@ -57,12 +57,12 @@
             </div>
             {# Information Box #}
             <div class="notification is-info is-light">
-                <p class="has-text-weight-bold mb-2">What happens next?</p>
+                <p class="has-text-weight-bold mb-2">{% trans "What happens next?" %}</p>
                 <ul class="content">
-                    <li>We'll send an email to the address you provided</li>
-                    <li>Check your inbox (and spam folder)</li>
-                    <li>Follow the link in the email to reset your password</li>
-                    <li>The link expires in 24 hours</li>
+                    <li>{% trans "We'll send an email to the address you provided" %}</li>
+                    <li>{% trans "Check your inbox (and spam folder)" %}</li>
+                    <li>{% trans "Follow the link in the email to reset your password" %}</li>
+                    <li>{% trans "The link expires in 24 hours" %}</li>
                 </ul>
             </div>
         </div>

--- a/timeline/templates/timeline.html
+++ b/timeline/templates/timeline.html
@@ -1,7 +1,7 @@
 {% extends parent_template|default:"base.html" %}
-{% load static %}
+{% load static i18n %}
 
-{% block title %}Timeline{% endblock %}
+{% block title %}{% trans "Timeline" %}{% endblock %}
 {% block headcss %}
   <link rel="stylesheet" href="{% static "site/css/timeline/timeline.css" %}">
 {% endblock %}

--- a/user_collection/forms.py
+++ b/user_collection/forms.py
@@ -1,4 +1,5 @@
 from django import forms
+from django.utils.translation import gettext_lazy as _
 
 from comicsdb.autocomplete import IssueAutocomplete, SeriesAutocomplete
 from comicsdb.forms.widgets import BulmaMoneyWidget, SafeAutocompleteWidget
@@ -28,7 +29,7 @@ class CollectionItemForm(forms.ModelForm):
             "issue": SafeAutocompleteWidget(
                 ac_class=IssueAutocomplete,
                 attrs={
-                    "placeholder": "Search for an issue...",
+                    "placeholder": _("Search for an issue..."),
                     "class": "input",
                 },
             ),
@@ -51,42 +52,42 @@ class CollectionItemForm(forms.ModelForm):
             ),
             "purchase_store": forms.TextInput(
                 attrs={
-                    "placeholder": "Local Comic Shop",
+                    "placeholder": _("Local Comic Shop"),
                 }
             ),
             "storage_location": forms.TextInput(
                 attrs={
-                    "placeholder": "Long Box 3",
+                    "placeholder": _("Long Box 3"),
                 }
             ),
             "notes": forms.Textarea(
                 attrs={
-                    "placeholder": "Additional notes (optional)",
+                    "placeholder": _("Additional notes (optional)"),
                     "rows": 4,
                 }
             ),
         }
         labels = {
-            "book_format": "Format",
-            "grade": "Grade",
-            "grading_company": "Grading Company",
-            "purchase_date": "Date Purchased",
-            "purchase_price": "Price Paid",
-            "purchase_store": "Store/Vendor",
-            "is_read": "Have you read this issue?",
+            "book_format": _("Format"),
+            "grade": _("Grade"),
+            "grading_company": _("Grading Company"),
+            "purchase_date": _("Date Purchased"),
+            "purchase_price": _("Price Paid"),
+            "purchase_store": _("Store/Vendor"),
+            "is_read": _("Have you read this issue?"),
         }
         help_texts = {
-            "issue": "Search using 'Series Name (Year) #Number' format.",
-            "quantity": "Number of copies you own",
-            "book_format": "Physical print, digital, or both",
-            "grade": "Comic book condition grade (CGC scale)",
-            "grading_company": "Professional grading company (leave blank if user-assessed)",
-            "purchase_date": "When did you purchase this issue?",
-            "purchase_price": "How much did you pay?",
-            "purchase_store": "Where did you buy it?",
-            "storage_location": "Where is it stored?",
-            "notes": "Any additional notes about this item",
-            "is_read": "Mark this if you've read the issue (read dates managed in detail view)",
+            "issue": _("Search using 'Series Name (Year) #Number' format."),
+            "quantity": _("Number of copies you own"),
+            "book_format": _("Physical print, digital, or both"),
+            "grade": _("Comic book condition grade (CGC scale)"),
+            "grading_company": _("Professional grading company (leave blank if user-assessed)"),
+            "purchase_date": _("When did you purchase this issue?"),
+            "purchase_price": _("How much did you pay?"),
+            "purchase_store": _("Where did you buy it?"),
+            "storage_location": _("Where is it stored?"),
+            "notes": _("Any additional notes about this item"),
+            "is_read": _("Mark this if you've read the issue (read dates managed in detail view)"),
         }
 
     def __init__(self, *args, **kwargs):
@@ -105,7 +106,7 @@ class CollectionItemForm(forms.ModelForm):
             and issue
             and CollectionItem.objects.filter(user=self.user, issue=issue).exists()
         ):
-            raise forms.ValidationError("This issue is already in your collection.")
+            raise forms.ValidationError(_("This issue is already in your collection."))
 
         return issue
 
@@ -114,8 +115,8 @@ class AddIssuesFromSeriesForm(forms.Form):
     """Form for adding multiple issues from a series to a collection."""
 
     RANGE_CHOICES = [
-        ("all", "All issues"),
-        ("range", "Issue range"),
+        ("all", _("All issues")),
+        ("range", _("Issue range")),
     ]
 
     series = forms.ModelChoiceField(
@@ -124,20 +125,20 @@ class AddIssuesFromSeriesForm(forms.Form):
         widget=SafeAutocompleteWidget(
             ac_class=SeriesAutocomplete,
             attrs={
-                "placeholder": "Search for a series...",
+                "placeholder": _("Search for a series..."),
                 "class": "input",
             },
         ),
-        label="Series",
-        help_text="Select the series to add issues from",
+        label=_("Series"),
+        help_text=_("Select the series to add issues from"),
     )
 
     range_type = forms.ChoiceField(
         choices=RANGE_CHOICES,
         initial="all",
         widget=forms.RadioSelect(),
-        label="Which issues?",
-        help_text="Choose whether to add all issues or specify a range",
+        label=_("Which issues?"),
+        help_text=_("Choose whether to add all issues or specify a range"),
     )
 
     start_number = forms.CharField(
@@ -145,12 +146,12 @@ class AddIssuesFromSeriesForm(forms.Form):
         max_length=25,
         widget=forms.TextInput(
             attrs={
-                "placeholder": "e.g., 1 or 1.1",
+                "placeholder": _("e.g., 1 or 1.1"),
                 "class": "input",
             }
         ),
-        label="Start Issue Number",
-        help_text="Optional: Issue number to start from (leave blank to start from beginning)",
+        label=_("Start Issue Number"),
+        help_text=_("Optional: Issue number to start from (leave blank to start from beginning)"),
     )
 
     end_number = forms.CharField(
@@ -158,12 +159,12 @@ class AddIssuesFromSeriesForm(forms.Form):
         max_length=25,
         widget=forms.TextInput(
             attrs={
-                "placeholder": "e.g., 50",
+                "placeholder": _("e.g., 50"),
                 "class": "input",
             }
         ),
-        label="End Issue Number",
-        help_text="Optional: Issue number to end at (leave blank to go to end)",
+        label=_("End Issue Number"),
+        help_text=_("Optional: Issue number to end at (leave blank to go to end)"),
     )
 
     default_format = forms.ChoiceField(
@@ -171,13 +172,13 @@ class AddIssuesFromSeriesForm(forms.Form):
         initial=CollectionItem.BookFormat.PRINT,
         required=False,
         widget=forms.Select(attrs={"class": "select"}),
-        label="Default Format",
-        help_text="The format to use for all added issues",
+        label=_("Default Format"),
+        help_text=_("The format to use for all added issues"),
     )
 
     mark_as_read = forms.BooleanField(
         required=False,
         initial=False,
-        label="Mark as read",
-        help_text="Check this to mark all added issues as read",
+        label=_("Mark as read"),
+        help_text=_("Check this to mark all added issues as read"),
     )

--- a/user_collection/models.py
+++ b/user_collection/models.py
@@ -4,6 +4,7 @@ from django.db import models
 from django.db.models.functions import Now
 from django.urls import reverse
 from django.utils import timezone
+from django.utils.translation import gettext_lazy as _
 from djmoney.models.fields import MoneyField
 
 from comicsdb.models.issue import Issue
@@ -11,31 +12,31 @@ from users.models import CustomUser
 
 # CGC Grading Scale choices
 GRADE_CHOICES = [
-    (Decimal("10.0"), "10.0 (Gem Mint)"),
-    (Decimal("9.9"), "9.9 (Mint)"),
-    (Decimal("9.8"), "9.8 (NM/M - Near Mint/Mint)"),
-    (Decimal("9.6"), "9.6 (NM+ - Near Mint+)"),
-    (Decimal("9.4"), "9.4 (NM - Near Mint)"),
-    (Decimal("9.2"), "9.2 (NM- - Near Mint-)"),
-    (Decimal("9.0"), "9.0 (VF/NM - Very Fine/Near Mint)"),
-    (Decimal("8.5"), "8.5 (VF+ - Very Fine+)"),
-    (Decimal("8.0"), "8.0 (VF - Very Fine)"),
-    (Decimal("7.5"), "7.5 (VF- - Very Fine-)"),
-    (Decimal("7.0"), "7.0 (FN/VF - Fine/Very Fine)"),
-    (Decimal("6.5"), "6.5 (FN+ - Fine+)"),
-    (Decimal("6.0"), "6.0 (FN - Fine)"),
-    (Decimal("5.5"), "5.5 (FN- - Fine-)"),
-    (Decimal("5.0"), "5.0 (VG/FN - Very Good/Fine)"),
-    (Decimal("4.5"), "4.5 (VG+ - Very Good+)"),
-    (Decimal("4.0"), "4.0 (VG - Very Good)"),
-    (Decimal("3.5"), "3.5 (VG- - Very Good-)"),
-    (Decimal("3.0"), "3.0 (GD/VG - Good/Very Good)"),
-    (Decimal("2.5"), "2.5 (GD+ - Good+)"),
-    (Decimal("2.0"), "2.0 (GD - Good)"),
-    (Decimal("1.8"), "1.8 (GD- - Good-)"),
-    (Decimal("1.5"), "1.5 (FR/GD - Fair/Good)"),
-    (Decimal("1.0"), "1.0 (FR - Fair)"),
-    (Decimal("0.5"), "0.5 (PR - Poor)"),
+    (Decimal("10.0"), _("10.0 (Gem Mint)")),
+    (Decimal("9.9"), _("9.9 (Mint)")),
+    (Decimal("9.8"), _("9.8 (NM/M - Near Mint/Mint)")),
+    (Decimal("9.6"), _("9.6 (NM+ - Near Mint+)")),
+    (Decimal("9.4"), _("9.4 (NM - Near Mint)")),
+    (Decimal("9.2"), _("9.2 (NM- - Near Mint-)")),
+    (Decimal("9.0"), _("9.0 (VF/NM - Very Fine/Near Mint)")),
+    (Decimal("8.5"), _("8.5 (VF+ - Very Fine+)")),
+    (Decimal("8.0"), _("8.0 (VF - Very Fine)")),
+    (Decimal("7.5"), _("7.5 (VF- - Very Fine-)")),
+    (Decimal("7.0"), _("7.0 (FN/VF - Fine/Very Fine)")),
+    (Decimal("6.5"), _("6.5 (FN+ - Fine+)")),
+    (Decimal("6.0"), _("6.0 (FN - Fine)")),
+    (Decimal("5.5"), _("5.5 (FN- - Fine-)")),
+    (Decimal("5.0"), _("5.0 (VG/FN - Very Good/Fine)")),
+    (Decimal("4.5"), _("4.5 (VG+ - Very Good+)")),
+    (Decimal("4.0"), _("4.0 (VG - Very Good)")),
+    (Decimal("3.5"), _("3.5 (VG- - Very Good-)")),
+    (Decimal("3.0"), _("3.0 (GD/VG - Good/Very Good)")),
+    (Decimal("2.5"), _("2.5 (GD+ - Good+)")),
+    (Decimal("2.0"), _("2.0 (GD - Good)")),
+    (Decimal("1.8"), _("1.8 (GD- - Good-)")),
+    (Decimal("1.5"), _("1.5 (FR/GD - Fair/Good)")),
+    (Decimal("1.0"), _("1.0 (FR - Fair)")),
+    (Decimal("0.5"), _("0.5 (PR - Poor)")),
 ]
 
 
@@ -43,36 +44,36 @@ class CollectionItem(models.Model):
     """Model for tracking a user's comic book collection."""
 
     class BookFormat(models.TextChoices):
-        PRINT = "PRINT", "Print"
-        DIGITAL = "DIGITAL", "Digital"
-        BOTH = "BOTH", "Both"
+        PRINT = "PRINT", _("Print")
+        DIGITAL = "DIGITAL", _("Digital")
+        BOTH = "BOTH", _("Both")
 
     class GradingCompany(models.TextChoices):
-        CGC = "CGC", "CGC (Certified Guaranty Company)"
-        CBCS = "CBCS", "CBCS (Comic Book Certification Service)"
-        PGX = "PGX", "PGX (Professional Grading Experts)"
+        CGC = "CGC", _("CGC (Certified Guaranty Company)")
+        CBCS = "CBCS", _("CBCS (Comic Book Certification Service)")
+        PGX = "PGX", _("PGX (Professional Grading Experts)")
 
     # Relationships
     user = models.ForeignKey(
         CustomUser,
         on_delete=models.CASCADE,
         related_name="collection_items",
-        help_text="The user who owns this collection item",
+        help_text=_("The user who owns this collection item"),
     )
     issue = models.ForeignKey(
         Issue,
         on_delete=models.CASCADE,
         related_name="in_collections",
-        help_text="The issue in this collection",
+        help_text=_("The issue in this collection"),
     )
 
     # Collection metadata
-    quantity = models.PositiveSmallIntegerField(default=1, help_text="Number of copies owned")
+    quantity = models.PositiveSmallIntegerField(default=1, help_text=_("Number of copies owned"))
     book_format = models.CharField(
         max_length=10,
         choices=BookFormat.choices,
         default=BookFormat.PRINT,
-        help_text="Format of the comic (print, digital, or both)",
+        help_text=_("Format of the comic (print, digital, or both)"),
     )
 
     # Grading information
@@ -82,50 +83,50 @@ class CollectionItem(models.Model):
         null=True,
         blank=True,
         choices=GRADE_CHOICES,
-        help_text="Comic book grade (CGC scale)",
+        help_text=_("Comic book grade (CGC scale)"),
     )
     grading_company = models.CharField(
         max_length=10,
         choices=GradingCompany.choices,
         blank=True,
         default="",
-        help_text="Professional grading company (leave blank for user-assessed grade)",
+        help_text=_("Professional grading company (leave blank for user-assessed grade)"),
     )
 
     # Purchase information
     purchase_date = models.DateField(
-        null=True, blank=True, help_text="Date when the issue was purchased"
+        null=True, blank=True, help_text=_("Date when the issue was purchased")
     )
     purchase_price = MoneyField(
-        "Purchase Price",
+        _("Purchase Price"),
         max_digits=7,
         decimal_places=2,
         blank=True,
         null=True,
-        help_text="Price paid for this issue",
+        help_text=_("Price paid for this issue"),
     )
     purchase_store = models.CharField(
-        max_length=255, blank=True, help_text="Store or vendor where purchased"
+        max_length=255, blank=True, help_text=_("Store or vendor where purchased")
     )
 
     # Storage and notes
     storage_location = models.CharField(
-        max_length=255, blank=True, help_text="Physical location where the issue is stored"
+        max_length=255, blank=True, help_text=_("Physical location where the issue is stored")
     )
-    notes = models.TextField(blank=True, help_text="Additional notes about this collection item")
+    notes = models.TextField(blank=True, help_text=_("Additional notes about this collection item"))
 
     # Reading tracking
-    is_read = models.BooleanField(default=False, help_text="Whether the issue has been read")
+    is_read = models.BooleanField(default=False, help_text=_("Whether the issue has been read"))
     date_read = models.DateTimeField(
         null=True,
         blank=True,
-        help_text="Date and time when the issue was last read (synced from read_dates)",
+        help_text=_("Date and time when the issue was last read (synced from read_dates)"),
     )
     rating = models.PositiveSmallIntegerField(
         null=True,
         blank=True,
         choices=[(i, i) for i in range(1, 6)],
-        help_text="Star rating (1-5) for this issue",
+        help_text=_("Star rating (1-5) for this issue"),
     )
 
     # Timestamps
@@ -143,8 +144,8 @@ class CollectionItem(models.Model):
             models.Index(fields=["user", "grade"], name="user_grade_idx"),
             models.Index(fields=["user", "grading_company"], name="user_grading_company_idx"),
         ]
-        verbose_name = "Collection Item"
-        verbose_name_plural = "Collection Items"
+        verbose_name = _("Collection Item")
+        verbose_name_plural = _("Collection Items")
 
     def __str__(self) -> str:
         return f"{self.user.username}: {self.issue} (x{self.quantity})"
@@ -181,9 +182,9 @@ class ReadDate(models.Model):
         CollectionItem,
         on_delete=models.CASCADE,
         related_name="read_dates",
-        help_text="The collection item this read date belongs to",
+        help_text=_("The collection item this read date belongs to"),
     )
-    read_date = models.DateTimeField(help_text="Date and time when the issue was read")
+    read_date = models.DateTimeField(help_text=_("Date and time when the issue was read"))
     created_on = models.DateTimeField(db_default=Now())
 
     class Meta:
@@ -191,8 +192,8 @@ class ReadDate(models.Model):
         indexes = [
             models.Index(fields=["collection_item", "-read_date"], name="collection_read_date_idx"),
         ]
-        verbose_name = "Read Date"
-        verbose_name_plural = "Read Dates"
+        verbose_name = _("Read Date")
+        verbose_name_plural = _("Read Dates")
 
     def __str__(self) -> str:
         return f"{self.collection_item} - {self.read_date}"

--- a/user_collection/templates/user_collection/add_issues_from_series.html
+++ b/user_collection/templates/user_collection/add_issues_from_series.html
@@ -1,13 +1,13 @@
 {% extends parent_template|default:"base.html" %}
-{% load static %}
-{% block title %}Add from Series - My Collection - Metron{% endblock %}
+{% load static i18n %}
+{% block title %}{% trans "Add from Series - My Collection - Metron" %}{% endblock %}
 {% block js %}
     {{ form.media }}
 {% endblock js %}
 {% block content %}
     <header class="block has-text-centered">
-        <h1 class="title">Add Issues from Series</h1>
-        <p class="subtitle">Bulk add to your collection</p>
+        <h1 class="title">{% trans "Add Issues from Series" %}</h1>
+        <p class="subtitle">{% trans "Bulk add to your collection" %}</p>
     </header>
     <section class="section">
         <div class="container">
@@ -79,40 +79,40 @@
                             </div>
                             <div class="field is-grouped is-flex-direction-column-mobile mt-5">
                                 <div class="control">
-                                    <a href="{% url 'user_collection:list' %}" class="button">Cancel</a>
+                                    <a href="{% url 'user_collection:list' %}" class="button">{% trans "Cancel" %}</a>
                                 </div>
                                 <div class="control">
-                                    <button type="submit" class="button is-primary">Add Issues</button>
+                                    <button type="submit" class="button is-primary">{% trans "Add Issues" %}</button>
                                 </div>
                             </div>
                         </form>
                     </div>
                     <div class="content mt-5">
-                        <h3 class="title is-5">How to use:</h3>
+                        <h3 class="title is-5">{% trans "How to use:" %}</h3>
                         <ul>
                             <li>
-                                <strong>Select a series:</strong> Start typing in the search box to find a series by name
+                                <strong>{% trans "Select a series:" %}</strong> {% trans "Start typing in the search box to find a series by name" %}
                             </li>
                             <li>
-                                <strong>Choose what to add:</strong>
+                                <strong>{% trans "Choose what to add:" %}</strong>
                                 <ul>
                                     <li>
-                                        <strong>All issues:</strong> Adds every issue from the series
+                                        <strong>{% trans "All issues:" %}</strong> {% trans "Adds every issue from the series" %}
                                     </li>
                                     <li>
-                                        <strong>Issue range:</strong> Specify a start and/or end issue number (e.g., start at #1, end at #50)
+                                        <strong>{% trans "Issue range:" %}</strong> {% trans "Specify a start and/or end issue number (e.g., start at #1, end at #50)" %}
                                     </li>
                                 </ul>
                             </li>
-                            <li>Issues already in your collection will be automatically skipped</li>
-                            <li>All issues will be added with your selected format and quantity 1</li>
+                            <li>{% trans "Issues already in your collection will be automatically skipped" %}</li>
+                            <li>{% trans "All issues will be added with your selected format and quantity 1" %}</li>
                             <li>
-                                <strong>Mark as read:</strong> Check this option if you've already read these issues
+                                <strong>{% trans "Mark as read:" %}</strong> {% trans "Check this option if you've already read these issues" %}
                             </li>
-                            <li>You can edit individual items later to add purchase information and update read status</li>
+                            <li>{% trans "You can edit individual items later to add purchase information and update read status" %}</li>
                         </ul>
                         <div class="notification is-info is-light mt-4">
-                            <strong>Tip:</strong> This is a quick way to add an entire series to your collection. After adding, you can update individual issues with purchase details, format preferences, and notes!
+                            <strong>{% trans "Tip:" %}</strong> {% trans "This is a quick way to add an entire series to your collection. After adding, you can update individual issues with purchase details, format preferences, and notes!" %}
                         </div>
                     </div>
                 </div>

--- a/user_collection/templates/user_collection/collection_confirm_delete.html
+++ b/user_collection/templates/user_collection/collection_confirm_delete.html
@@ -1,9 +1,9 @@
 {% extends parent_template|default:"base.html" %}
-{% load static %}
-{% block title %}Remove {{ item.issue }} - Metron{% endblock %}
+{% load static i18n %}
+{% block title %}{% blocktrans with issue=item.issue %}Remove {{ issue }} - Metron{% endblocktrans %}{% endblock %}
 {% block content %}
     <header class="block has-text-centered">
-        <h1 class="title">Remove from Collection</h1>
+        <h1 class="title">{% trans "Remove from Collection" %}</h1>
     </header>
     <section class="section">
         <div class="container">
@@ -12,28 +12,26 @@
                     <div class="box">
                         <article class="message is-danger">
                             <div class="message-header">
-                                <p>Warning</p>
+                                <p>{% trans "Warning" %}</p>
                             </div>
                             <div class="message-body">
                                 <p class="mb-3">
-                                    Are you sure you want to remove
-                                    <strong>{{ item.issue }}</strong>
-                                    from your collection?
+                                    {% blocktrans with issue=item.issue %}Are you sure you want to remove <strong>{{ issue }}</strong> from your collection?{% endblocktrans %}
                                 </p>
                                 {% if item.purchase_price or item.purchase_date or item.notes %}
-                                    <p class="mb-3">This will also delete the associated purchase information and notes.</p>
+                                    <p class="mb-3">{% trans "This will also delete the associated purchase information and notes." %}</p>
                                 {% endif %}
-                                <p>This action cannot be undone.</p>
+                                <p>{% trans "This action cannot be undone." %}</p>
                             </div>
                         </article>
                         <form method="post">
                             {% csrf_token %}
                             <div class="field is-grouped is-grouped-right">
                                 <div class="control">
-                                    <a href="{% url 'user_collection:detail' item.pk %}" class="button">Cancel</a>
+                                    <a href="{% url 'user_collection:detail' item.pk %}" class="button">{% trans "Cancel" %}</a>
                                 </div>
                                 <div class="control">
-                                    <button type="submit" class="button is-danger">Remove from Collection</button>
+                                    <button type="submit" class="button is-danger">{% trans "Remove from Collection" %}</button>
                                 </div>
                             </div>
                         </form>

--- a/user_collection/templates/user_collection/collection_detail.html
+++ b/user_collection/templates/user_collection/collection_detail.html
@@ -1,21 +1,21 @@
 {% extends parent_template|default:"base.html" %}
-{% load static %}
+{% load static i18n %}
 {% load thumbnail %}
-{% block title %}{{ item.issue }} - My Collection - Metron{% endblock %}
+{% block title %}{% blocktrans with issue=item.issue %}{{ issue }} - My Collection - Metron{% endblocktrans %}{% endblock %}
 {% block headcss %}
     <link rel="stylesheet"
           href="{% static 'site/css/bulma-calendar.min.css' %}">
 {% endblock %}
 {% block content %}
     <header class="block">
-        <h1 class="title">Collection Item Details</h1>
+        <h1 class="title">{% trans "Collection Item Details" %}</h1>
     </header>
     <nav class="level mb-5">
         <div class="level-left">
             <div class="level-item">
                 <a class="button" href="{% url 'user_collection:list' %}">
                     <span class="icon"><i class="fas fa-arrow-left"></i></span>
-                    <span>Back to Collection</span>
+                    <span>{% trans "Back to Collection" %}</span>
                 </a>
             </div>
         </div>
@@ -24,12 +24,12 @@
                 <a class="button is-info"
                    href="{% url 'user_collection:update' item.pk %}">
                     <span class="icon is-small"><i class="fas fa-edit"></i></span>
-                    <span>Edit</span>
+                    <span>{% trans "Edit" %}</span>
                 </a>
                 <a class="button is-danger"
                    href="{% url 'user_collection:delete' item.pk %}">
                     <span class="icon is-small"><i class="fas fa-trash"></i></span>
-                    <span>Remove</span>
+                    <span>{% trans "Remove" %}</span>
                 </a>
             </div>
         </div>
@@ -57,22 +57,22 @@
         </div>
         <div class="column">
             <div class="box">
-                <h2 class="title is-5">Issue Information</h2>
+                <h2 class="title is-5">{% trans "Issue Information" %}</h2>
                 <div class="content">
                     <dl>
-                        <dt class="has-text-weight-bold">Issue:</dt>
+                        <dt class="has-text-weight-bold">{% trans "Issue:" %}</dt>
                         <dd class="mb-3">
                             <a href="{% url 'issue:detail' item.issue.slug %}">{{ item.issue }}</a>
                         </dd>
-                        <dt class="has-text-weight-bold">Series:</dt>
+                        <dt class="has-text-weight-bold">{% trans "Series:" %}</dt>
                         <dd class="mb-3">
                             <a href="{% url 'series:detail' item.issue.series.slug %}">{{ item.issue.series.name }}</a>
                         </dd>
-                        <dt class="has-text-weight-bold">Publisher:</dt>
+                        <dt class="has-text-weight-bold">{% trans "Publisher:" %}</dt>
                         <dd class="mb-3">
                             <a href="{% url 'publisher:detail' item.issue.series.publisher.slug %}">{{ item.issue.series.publisher.name }}</a>
                         </dd>
-                        <dt class="has-text-weight-bold">Cover Date:</dt>
+                        <dt class="has-text-weight-bold">{% trans "Cover Date:" %}</dt>
                         <dd class="mb-3">
                             {{ item.issue.cover_date|date:"F Y" }}
                         </dd>
@@ -81,15 +81,15 @@
             </div>
             {% if item.issue.desc %}
                 <div class="box">
-                    <h2 class="title is-5">Description</h2>
+                    <h2 class="title is-5">{% trans "Description" %}</h2>
                     <div class="content">{{ item.issue.desc|linebreaksbr }}</div>
                 </div>
             {% endif %}
             {% if item.grade %}
                 <div class="box">
-                    <h2 class="title is-5">Grading Information</h2>
+                    <h2 class="title is-5">{% trans "Grading Information" %}</h2>
                     <dl>
-                        <dt class="has-text-weight-bold">Grade:</dt>
+                        <dt class="has-text-weight-bold">{% trans "Grade:" %}</dt>
                         <dd class="mb-3">
                             <span class="tag is-primary is-medium">
                                 <span class="icon is-small">
@@ -98,18 +98,18 @@
                                 <span>{{ item.get_grade_display }}</span>
                             </span>
                         </dd>
-                        <dt class="has-text-weight-bold">Grading Type:</dt>
+                        <dt class="has-text-weight-bold">{% trans "Grading Type:" %}</dt>
                         <dd>
                             {% if item.grading_company %}
                                 <span class="icon is-small has-text-info">
                                     <i class="fas fa-certificate"></i>
                                 </span>
-                                <span>Professionally graded by {{ item.get_grading_company_display }}</span>
+                                <span>{% blocktrans with company=item.get_grading_company_display %}Professionally graded by {{ company }}{% endblocktrans %}</span>
                             {% else %}
                                 <span class="icon is-small has-text-grey">
                                     <i class="fas fa-user"></i>
                                 </span>
-                                <span>User-assessed grade</span>
+                                <span>{% trans "User-assessed grade" %}</span>
                             {% endif %}
                         </dd>
                     </dl>
@@ -117,76 +117,76 @@
             {% endif %}
             {% if item.notes %}
                 <div class="box">
-                    <h2 class="title is-5">Notes</h2>
+                    <h2 class="title is-5">{% trans "Notes" %}</h2>
                     <div class="content">{{ item.notes|linebreaksbr }}</div>
                 </div>
             {% endif %}
         </div>
         <div class="column is-one-quarter">
             <div class="box">
-                <h2 class="title is-6">Collection Details</h2>
+                <h2 class="title is-6">{% trans "Collection Details" %}</h2>
                 <dl>
-                    <dt class="has-text-weight-bold">Format:</dt>
+                    <dt class="has-text-weight-bold">{% trans "Format:" %}</dt>
                     <dd class="mb-3">
                         <span class="tag {% if item.book_format == 'DIGITAL' %}is-info{% elif item.book_format == 'BOTH' %}is-success{% else %}is-dark{% endif %}">
                             {{ item.get_book_format_display }}
                         </span>
                     </dd>
-                    <dt class="has-text-weight-bold">Quantity:</dt>
+                    <dt class="has-text-weight-bold">{% trans "Quantity:" %}</dt>
                     <dd class="mb-3">
                         {{ item.quantity }}
                     </dd>
                     {% if item.purchase_date %}
-                        <dt class="has-text-weight-bold">Purchase Date:</dt>
+                        <dt class="has-text-weight-bold">{% trans "Purchase Date:" %}</dt>
                         <dd class="mb-3">
                             {{ item.purchase_date|date:"F d, Y" }}
                         </dd>
                     {% endif %}
                     {% if item.purchase_price %}
-                        <dt class="has-text-weight-bold">Price Paid:</dt>
+                        <dt class="has-text-weight-bold">{% trans "Price Paid:" %}</dt>
                         <dd class="mb-3">
                             {{ item.purchase_price }}
                         </dd>
                     {% endif %}
                     {% if item.purchase_store %}
-                        <dt class="has-text-weight-bold">Store/Vendor:</dt>
+                        <dt class="has-text-weight-bold">{% trans "Store/Vendor:" %}</dt>
                         <dd class="mb-3">
                             {{ item.purchase_store }}
                         </dd>
                     {% endif %}
                     {% if item.storage_location %}
-                        <dt class="has-text-weight-bold">Storage Location:</dt>
+                        <dt class="has-text-weight-bold">{% trans "Storage Location:" %}</dt>
                         <dd class="mb-3">
                             {{ item.storage_location }}
                         </dd>
                     {% endif %}
-                    <dt class="has-text-weight-bold">Read Status:</dt>
+                    <dt class="has-text-weight-bold">{% trans "Read Status:" %}</dt>
                     <dd class="mb-3">
                         {% if item.is_read %}
                             <span class="tag is-success">
                                 <span class="icon"><i class="fas fa-check"></i></span>
-                                <span>Read</span>
+                                <span>{% trans "Read" %}</span>
                             </span>
                         {% else %}
                             <span class="tag is-warning">
                                 <span class="icon"><i class="fas fa-clock"></i></span>
-                                <span>Unread</span>
+                                <span>{% trans "Unread" %}</span>
                             </span>
                         {% endif %}
                     </dd>
-                    <dt class="has-text-weight-bold">Rating:</dt>
+                    <dt class="has-text-weight-bold">{% trans "Rating:" %}</dt>
                     <dd class="mb-3">
                         {% include "user_collection/partials/star_rating.html" %}
                     </dd>
-                    <dt class="has-text-weight-bold">Read History:</dt>
+                    <dt class="has-text-weight-bold">{% trans "Read History:" %}</dt>
                     <dd class="mb-3" id="read-dates-container">
                         {% include "user_collection/partials/read_dates_list.html" %}
                     </dd>
-                    <dt class="has-text-weight-bold">Added to Collection:</dt>
+                    <dt class="has-text-weight-bold">{% trans "Added to Collection:" %}</dt>
                     <dd class="mb-3">
                         {{ item.created_on|date:"F d, Y" }}
                     </dd>
-                    <dt class="has-text-weight-bold">Last Modified:</dt>
+                    <dt class="has-text-weight-bold">{% trans "Last Modified:" %}</dt>
                     <dd>
                         {{ item.modified|date:"F d, Y" }}
                     </dd>

--- a/user_collection/templates/user_collection/collection_form.html
+++ b/user_collection/templates/user_collection/collection_form.html
@@ -1,12 +1,11 @@
 {% extends parent_template|default:"base.html" %}
-{% load static bulma_tags %}
+{% load static bulma_tags i18n %}
 {% block title %}
     {% if object %}
-        Edit
+        {% trans "Edit Collection Item - Metron" %}
     {% else %}
-        Add
+        {% trans "Add Collection Item - Metron" %}
     {% endif %}
-    Collection Item - Metron
 {% endblock %}
 {% block headcss %}
     {{ form.media.css }}
@@ -17,11 +16,10 @@
     <header class="block has-text-centered">
         <h1 class="title">
             {% if object %}
-                Edit
+                {% trans "Edit Collection Item" %}
             {% else %}
-                Add
+                {% trans "Add Collection Item" %}
             {% endif %}
-            Collection Item
         </h1>
     </header>
     <section class="section">
@@ -71,14 +69,14 @@
                             <div class="field is-grouped is-flex-direction-column-mobile mt-5">
                                 <div class="control">
                                     <a href="{% if object %}{% url 'user_collection:detail' object.pk %}{% else %}{% url 'user_collection:list' %}{% endif %}"
-                                       class="button">Cancel</a>
+                                       class="button">{% trans "Cancel" %}</a>
                                 </div>
                                 <div class="control">
                                     <button type="submit" class="button is-primary">
                                         {% if object %}
-                                            Update
+                                            {% trans "Update" %}
                                         {% else %}
-                                            Add to Collection
+                                            {% trans "Add to Collection" %}
                                         {% endif %}
                                     </button>
                                 </div>

--- a/user_collection/templates/user_collection/collection_list.html
+++ b/user_collection/templates/user_collection/collection_list.html
@@ -1,9 +1,9 @@
 {% extends parent_template|default:"base.html" %}
-{% load static %}
-{% block title %}My Collection - Metron{% endblock %}
+{% load static i18n %}
+{% block title %}{% trans "My Collection - Metron" %}{% endblock %}
 {% block content %}
     <header class="block has-text-centered">
-        <h1 class="title">My Comic Collection</h1>
+        <h1 class="title">{% trans "My Comic Collection" %}</h1>
     </header>
     <section class="section">
         <div class="container">
@@ -11,7 +11,7 @@
                 <div class="level-left">
                     <div class="level-item">
                         <p class="subtitle is-5">
-                            <strong>{{ page_obj.paginator.count }}</strong> item{{ page_obj.paginator.count|pluralize }} in your collection
+                            {% blocktrans count counter=page_obj.paginator.count %}<strong>{{ counter }}</strong> item in your collection{% plural %}<strong>{{ counter }}</strong> items in your collection{% endblocktrans %}
                         </p>
                     </div>
                 </div>
@@ -21,27 +21,27 @@
                             <a href="{% url 'user_collection:stats' %}"
                                class="button is-info ">
                                 <span class="icon"><i class="fas fa-chart-bar"></i></span>
-                                <span>View Statistics</span>
+                                <span>{% trans "View Statistics" %}</span>
                             </a>
                             <a href="{% url 'user_collection:history' %}"
                                class="button is-success ">
                                 <span class="icon"><i class="fas fa-book-open"></i></span>
-                                <span>Reading History</span>
+                                <span>{% trans "Reading History" %}</span>
                             </a>
                             <a href="{% url 'user_collection:missing-list' %}"
                                class="button is-warning ">
                                 <span class="icon"><i class="fas fa-th-list"></i></span>
-                                <span>Missing Issues</span>
+                                <span>{% trans "Missing Issues" %}</span>
                             </a>
                             <a href="{% url 'user_collection:add-from-series' %}"
                                class="button is-link ">
                                 <span class="icon"><i class="fas fa-layer-group"></i></span>
-                                <span>Add from Series</span>
+                                <span>{% trans "Add from Series" %}</span>
                             </a>
                             <a href="{% url 'user_collection:create' %}"
                                class="button is-primary ">
                                 <span class="icon"><i class="fas fa-plus"></i></span>
-                                <span>Add Issue</span>
+                                <span>{% trans "Add Issue" %}</span>
                             </a>
                         </div>
                     </div>
@@ -59,15 +59,15 @@
                     <table class="table is-fullwidth is-striped is-hoverable">
                         <thead>
                             <tr>
-                                <th>Issue</th>
-                                <th>Cover Date</th>
-                                <th>Format</th>
-                                <th>Grade</th>
-                                <th>Read</th>
-                                <th>Rating</th>
-                                <th>Quantity</th>
-                                <th>Price Paid</th>
-                                <th>Actions</th>
+                                <th>{% trans "Issue" %}</th>
+                                <th>{% trans "Cover Date" %}</th>
+                                <th>{% trans "Format" %}</th>
+                                <th>{% trans "Grade" %}</th>
+                                <th>{% trans "Read" %}</th>
+                                <th>{% trans "Rating" %}</th>
+                                <th>{% trans "Quantity" %}</th>
+                                <th>{% trans "Price Paid" %}</th>
+                                <th>{% trans "Actions" %}</th>
                             </tr>
                         </thead>
                         <tbody>
@@ -85,7 +85,7 @@
                                     <td>
                                         {% if item.grade %}
                                             <span class="tag is-primary is-small"
-                                                  title="{% if item.grading_company %}{{ item.get_grading_company_display }}{% else %}User-assessed{% endif %}">
+                                                  title="{% if item.grading_company %}{{ item.get_grading_company_display }}{% else %}{% trans 'User-assessed' %}{% endif %}">
                                                 {{ item.grade }}
                                                 {% if item.grading_company %}
                                                     <span class="icon is-small ml-1">
@@ -100,11 +100,11 @@
                                     <td>
                                         {% if item.is_read %}
                                             <span class="icon has-text-success"
-                                                  title="Read{% if item.date_read %} on {{ item.date_read|date:'M d, Y' }}{% endif %}">
+                                                  title="{% if item.date_read %}{% blocktrans with read_date=item.date_read|date:'M d, Y' %}Read on {{ read_date }}{% endblocktrans %}{% else %}{% trans 'Read' %}{% endif %}">
                                                 <i class="fas fa-check-circle"></i>
                                             </span>
                                         {% else %}
-                                            <span class="icon has-text-grey-light" title="Unread">
+                                            <span class="icon has-text-grey-light" title="{% trans 'Unread' %}">
                                                 <i class="far fa-circle"></i>
                                             </span>
                                         {% endif %}
@@ -122,21 +122,21 @@
                                         <div class="buttons are-small">
                                             <a href="{% url 'user_collection:detail' item.pk %}"
                                                class="button is-info is-outlined"
-                                               title="View Details">
+                                               title="{% trans 'View Details' %}">
                                                 <span class="icon is-small">
                                                     <i class="fas fa-eye"></i>
                                                 </span>
                                             </a>
                                             <a href="{% url 'user_collection:update' item.pk %}"
                                                class="button is-primary is-outlined"
-                                               title="Edit">
+                                               title="{% trans 'Edit' %}">
                                                 <span class="icon is-small">
                                                     <i class="fas fa-edit"></i>
                                                 </span>
                                             </a>
                                             <a href="{% url 'user_collection:delete' item.pk %}"
                                                class="button is-danger is-outlined"
-                                               title="Remove">
+                                               title="{% trans 'Remove' %}">
                                                 <span class="icon is-small">
                                                     <i class="fas fa-trash"></i>
                                                 </span>
@@ -154,20 +154,20 @@
         <section class="section pt-0">
             <div class="container has-text-centered">
                 {% if has_active_filters %}
-                    <p class="title is-4">No results found</p>
-                    <p class="subtitle">Try adjusting your search filters</p>
+                    <p class="title is-4">{% trans "No results found" %}</p>
+                    <p class="subtitle">{% trans "Try adjusting your search filters" %}</p>
                     <a href="{% url 'user_collection:list' %}"
                        class="button is-light is-medium">
                         <span class="icon"><i class="fas fa-times"></i></span>
-                        <span>Clear All Filters</span>
+                        <span>{% trans "Clear All Filters" %}</span>
                     </a>
                 {% else %}
-                    <p class="title is-4">Your collection is empty</p>
-                    <p class="subtitle">Start adding issues to track your comic collection!</p>
+                    <p class="title is-4">{% trans "Your collection is empty" %}</p>
+                    <p class="subtitle">{% trans "Start adding issues to track your comic collection!" %}</p>
                     <a href="{% url 'user_collection:create' %}"
                        class="button is-primary is-large">
                         <span class="icon"><i class="fas fa-plus"></i></span>
-                        <span>Add Your First Issue</span>
+                        <span>{% trans "Add Your First Issue" %}</span>
                     </a>
                 {% endif %}
             </div>

--- a/user_collection/templates/user_collection/collection_stats.html
+++ b/user_collection/templates/user_collection/collection_stats.html
@@ -1,5 +1,5 @@
 {% extends parent_template|default:"base.html" %}
-{% load static %}
+{% load static i18n %}
 {% block headscripts %}
     <script src="{% static 'chartkick/Chart.bundle.js' %}"></script>
     <script>
@@ -48,17 +48,17 @@
     </script>
     <script src="{% static 'chartkick/chartkick.js' %}"></script>
 {% endblock %}
-{% block title %}Collection Statistics - Metron{% endblock %}
+{% block title %}{% trans "Collection Statistics - Metron" %}{% endblock %}
 {% block content %}
     <header class="block has-text-centered">
-        <h1 class="title">Collection Statistics</h1>
+        <h1 class="title">{% trans "Collection Statistics" %}</h1>
     </header>
     <nav class="level mb-5">
         <div class="level-left">
             <div class="level-item">
                 <a class="button" href="{% url 'user_collection:list' %}">
                     <span class="icon"><i class="fas fa-arrow-left"></i></span>
-                    <span>Back to Collection</span>
+                    <span>{% trans "Back to Collection" %}</span>
                 </a>
             </div>
         </div>
@@ -69,7 +69,7 @@
             <div class="columns is-multiline">
                 <div class="column is-one-third">
                     <div class="box has-text-centered">
-                        <p class="heading">Total Items</p>
+                        <p class="heading">{% trans "Total Items" %}</p>
                         <p class="title">{{ total_items }}</p>
                         <span class="icon has-text-info">
                             <i class="fas fa-layer-group fa-2x"></i>
@@ -78,7 +78,7 @@
                 </div>
                 <div class="column is-one-third">
                     <div class="box has-text-centered">
-                        <p class="heading">Total Issues</p>
+                        <p class="heading">{% trans "Total Issues" %}</p>
                         <p class="title">{{ total_quantity }}</p>
                         <span class="icon has-text-success">
                             <i class="fas fa-book fa-2x"></i>
@@ -87,7 +87,7 @@
                 </div>
                 <div class="column is-one-third">
                     <div class="box has-text-centered">
-                        <p class="heading">Total Value</p>
+                        <p class="heading">{% trans "Total Value" %}</p>
                         <p class="title">
                             {% if total_value %}
                                 ${{ total_value|floatformat:2 }}
@@ -102,7 +102,7 @@
                 </div>
                 <div class="column is-one-third">
                     <div class="box has-text-centered">
-                        <p class="heading">Issues Read</p>
+                        <p class="heading">{% trans "Issues Read" %}</p>
                         <p class="title">{{ read_count }}</p>
                         <span class="icon has-text-success">
                             <i class="fas fa-check-circle fa-2x"></i>
@@ -111,7 +111,7 @@
                 </div>
                 <div class="column is-one-third">
                     <div class="box has-text-centered">
-                        <p class="heading">Issues Unread</p>
+                        <p class="heading">{% trans "Issues Unread" %}</p>
                         <p class="title">{{ unread_count }}</p>
                         <span class="icon has-text-grey">
                             <i class="far fa-circle fa-2x"></i>
@@ -120,7 +120,7 @@
                 </div>
                 <div class="column is-one-third">
                     <div class="box has-text-centered">
-                        <p class="heading">Reading Progress</p>
+                        <p class="heading">{% trans "Reading Progress" %}</p>
                         <p class="title">
                             {% if total_items > 0 %}
                                 {{ read_count|floatformat:0 }}/{{ total_items }}
@@ -181,13 +181,13 @@
             <div class="columns">
                 <div class="column is-half">
                     <div class="box">
-                        <h2 class="title is-5">By Format</h2>
+                        <h2 class="title is-5">{% trans "By Format" %}</h2>
                         {% if format_counts %}
                             <table class="table is-fullwidth is-striped">
                                 <thead>
                                     <tr>
-                                        <th>Format</th>
-                                        <th class="has-text-right">Count</th>
+                                        <th>{% trans "Format" %}</th>
+                                        <th class="has-text-right">{% trans "Count" %}</th>
                                     </tr>
                                 </thead>
                                 <tbody>
@@ -196,11 +196,11 @@
                                             <td>
                                                 <span class="tag {% if format.book_format == 'DIGITAL' %}is-info{% elif format.book_format == 'BOTH' %}is-success{% else %}is-dark{% endif %}">
                                                     {% if format.book_format == 'PRINT' %}
-                                                        Print
+                                                        {% trans "Print" %}
                                                     {% elif format.book_format == 'DIGITAL' %}
-                                                        Digital
+                                                        {% trans "Digital" %}
                                                     {% elif format.book_format == 'BOTH' %}
-                                                        Both
+                                                        {% trans "Both" %}
                                                     {% endif %}
                                                 </span>
                                             </td>
@@ -212,19 +212,19 @@
                                 </tbody>
                             </table>
                         {% else %}
-                            <p class="has-text-grey">No format data available</p>
+                            <p class="has-text-grey">{% trans "No format data available" %}</p>
                         {% endif %}
                     </div>
                 </div>
                 <div class="column is-half">
                     <div class="box">
-                        <h2 class="title is-5">Top Series</h2>
+                        <h2 class="title is-5">{% trans "Top Series" %}</h2>
                         {% if top_series %}
                             <table class="table is-fullwidth is-striped">
                                 <thead>
                                     <tr>
-                                        <th>Series</th>
-                                        <th class="has-text-right">Issues</th>
+                                        <th>{% trans "Series" %}</th>
+                                        <th class="has-text-right">{% trans "Issues" %}</th>
                                     </tr>
                                 </thead>
                                 <tbody>
@@ -241,7 +241,7 @@
                                 </tbody>
                             </table>
                         {% else %}
-                            <p class="has-text-grey">No series data available</p>
+                            <p class="has-text-grey">{% trans "No series data available" %}</p>
                         {% endif %}
                     </div>
                 </div>

--- a/user_collection/templates/user_collection/missing_issues_detail.html
+++ b/user_collection/templates/user_collection/missing_issues_detail.html
@@ -1,9 +1,9 @@
 {% extends parent_template|default:"base.html" %}
-{% load static %}
-{% block title %}Missing Issues - {{ series.name }} - Metron{% endblock %}
+{% load static i18n %}
+{% block title %}{% blocktrans with name=series.name %}Missing Issues - {{ name }} - Metron{% endblocktrans %}{% endblock %}
 {% block content %}
     <header class="block">
-        <h1 class="title">Missing Issues</h1>
+        <h1 class="title">{% trans "Missing Issues" %}</h1>
         <h2 class="subtitle">
             {{ series.name }}
             {% if series.year_began %}({{ series.year_began }}){% endif %}
@@ -15,12 +15,12 @@
                 <a class="button"
                    href="{% url 'user_collection:missing-list' %}">
                     <span class="icon"><i class="fas fa-arrow-left"></i></span>
-                    <span>Back to Missing List</span>
+                    <span>{% trans "Back to Missing List" %}</span>
                 </a>
                 <a class="button is-light"
                    href="{% url 'user_collection:list' %}">
                     <span class="icon"><i class="fas fa-home"></i></span>
-                    <span>Collection</span>
+                    <span>{% trans "Collection" %}</span>
                 </a>
             </div>
         </div>
@@ -30,18 +30,18 @@
             <div class="box">
                 <div class="columns is-vcentered">
                     <div class="column">
-                        <h3 class="title is-5">Series Information</h3>
+                        <h3 class="title is-5">{% trans "Series Information" %}</h3>
                         <dl>
-                            <dt class="has-text-weight-bold">Publisher:</dt>
+                            <dt class="has-text-weight-bold">{% trans "Publisher:" %}</dt>
                             <dd class="mb-2">
                                 {{ series.publisher.name }}
                             </dd>
-                            <dt class="has-text-weight-bold">Series Type:</dt>
+                            <dt class="has-text-weight-bold">{% trans "Series Type:" %}</dt>
                             <dd class="mb-2">
                                 {{ series.series_type.name }}
                             </dd>
                             {% if series.volume %}
-                                <dt class="has-text-weight-bold">Volume:</dt>
+                                <dt class="has-text-weight-bold">{% trans "Volume:" %}</dt>
                                 <dd>
                                     {{ series.volume }}
                                 </dd>
@@ -49,10 +49,10 @@
                         </dl>
                     </div>
                     <div class="column">
-                        <h3 class="title is-5">Collection Progress</h3>
+                        <h3 class="title is-5">{% trans "Collection Progress" %}</h3>
                         <div class="has-text-centered mb-3">
                             <p class="title is-3">{{ owned_issues }} / {{ total_issues }}</p>
-                            <p class="subtitle is-6">{{ completion_percentage }}% Complete</p>
+                            <p class="subtitle is-6">{% blocktrans with pct=completion_percentage %}{{ pct }}% Complete{% endblocktrans %}</p>
                         </div>
                         <progress class="progress {% if completion_percentage < 50 %}is-danger{% elif completion_percentage < 80 %}is-warning{% else %}is-success{% endif %}"
                                   value="{{ owned_issues }}"
@@ -60,7 +60,9 @@
                             {{ completion_percentage }}%
                         </progress>
                         <p class="has-text-centered mt-2">
-                            <span class="tag is-warning is-medium">{{ missing_count }} issue{{ missing_count|pluralize }} missing</span>
+                            <span class="tag is-warning is-medium">
+                                {% blocktrans count counter=missing_count %}{{ counter }} issue missing{% plural %}{{ counter }} issues missing{% endblocktrans %}
+                            </span>
                         </p>
                     </div>
                 </div>
@@ -74,11 +76,11 @@
                     <table class="table is-fullwidth is-striped is-hoverable">
                         <thead>
                             <tr>
-                                <th>Issue</th>
-                                <th>Story Title</th>
-                                <th>Cover Date</th>
-                                <th>Store Date</th>
-                                <th>Cover Price</th>
+                                <th>{% trans "Issue" %}</th>
+                                <th>{% trans "Story Title" %}</th>
+                                <th>{% trans "Cover Date" %}</th>
+                                <th>{% trans "Store Date" %}</th>
+                                <th>{% trans "Cover Price" %}</th>
                             </tr>
                         </thead>
                         <tbody>
@@ -122,8 +124,8 @@
                 <span class="icon is-large has-text-success">
                     <i class="fas fa-check-circle fa-3x"></i>
                 </span>
-                <p class="title is-4 mt-4">No Missing Issues!</p>
-                <p class="subtitle">You own all issues from this series.</p>
+                <p class="title is-4 mt-4">{% trans "No Missing Issues!" %}</p>
+                <p class="subtitle">{% trans "You own all issues from this series." %}</p>
             </div>
         </section>
     {% endif %}

--- a/user_collection/templates/user_collection/missing_issues_list.html
+++ b/user_collection/templates/user_collection/missing_issues_list.html
@@ -1,24 +1,24 @@
 {% extends parent_template|default:"base.html" %}
-{% load static %}
-{% block title %}Missing Issues - My Collection - Metron{% endblock %}
+{% load static i18n %}
+{% block title %}{% trans "Missing Issues - My Collection - Metron" %}{% endblock %}
 {% block content %}
     <header class="block has-text-centered">
-        <h1 class="title">Missing Issues by Series</h1>
-        <p class="subtitle">Find gaps in your collection</p>
+        <h1 class="title">{% trans "Missing Issues by Series" %}</h1>
+        <p class="subtitle">{% trans "Find gaps in your collection" %}</p>
     </header>
     <nav class="level mb-5">
         <div class="level-left">
             <div class="level-item">
                 <a class="button" href="{% url 'user_collection:list' %}">
                     <span class="icon"><i class="fas fa-arrow-left"></i></span>
-                    <span>Back to Collection</span>
+                    <span>{% trans "Back to Collection" %}</span>
                 </a>
             </div>
         </div>
         <div class="level-right">
             <div class="level-item">
                 <p class="subtitle is-5">
-                    <strong>{{ page_obj.paginator.count }}</strong> series with missing issues
+                    {% blocktrans count counter=page_obj.paginator.count %}<strong>{{ counter }}</strong> series with missing issues{% plural %}<strong>{{ counter }}</strong> series with missing issues{% endblocktrans %}
                 </p>
             </div>
         </div>
@@ -26,10 +26,7 @@
     <section class="section">
         <div class="container">
             <div class="notification is-info is-light">
-                <p>
-                    This page shows series where you own at least one issue but are missing others.
-                    Use it to identify gaps in your collection.
-                </p>
+                <p>{% trans "This page shows series where you own at least one issue but are missing others. Use it to identify gaps in your collection." %}</p>
             </div>
         </div>
     </section>
@@ -40,12 +37,12 @@
                     <table class="table is-fullwidth is-striped is-hoverable">
                         <thead>
                             <tr>
-                                <th>Series</th>
-                                <th>Publisher</th>
-                                <th>Type</th>
-                                <th class="has-text-centered">Progress</th>
-                                <th class="has-text-centered">Missing</th>
-                                <th>Actions</th>
+                                <th>{% trans "Series" %}</th>
+                                <th>{% trans "Publisher" %}</th>
+                                <th>{% trans "Type" %}</th>
+                                <th class="has-text-centered">{% trans "Progress" %}</th>
+                                <th class="has-text-centered">{% trans "Missing" %}</th>
+                                <th>{% trans "Actions" %}</th>
                             </tr>
                         </thead>
                         <tbody>
@@ -78,7 +75,7 @@
                                         <a href="{% url 'user_collection:missing-detail' series.id %}"
                                            class="button is-info is-small">
                                             <span class="icon"><i class="fas fa-list"></i></span>
-                                            <span>View Missing</span>
+                                            <span>{% trans "View Missing" %}</span>
                                         </a>
                                     </td>
                                 </tr>
@@ -94,8 +91,8 @@
                 <span class="icon is-large has-text-success">
                     <i class="fas fa-trophy fa-3x"></i>
                 </span>
-                <p class="title is-4 mt-4">No Missing Issues!</p>
-                <p class="subtitle">You have complete runs of all your series.</p>
+                <p class="title is-4 mt-4">{% trans "No Missing Issues!" %}</p>
+                <p class="subtitle">{% trans "You have complete runs of all your series." %}</p>
             </div>
         </section>
     {% endif %}

--- a/user_collection/templates/user_collection/partials/collection_filter.html
+++ b/user_collection/templates/user_collection/partials/collection_filter.html
@@ -1,3 +1,4 @@
+{% load i18n %}
 <div class="box mb-5" id="filter-panel">
     <form method="get" accept-charset="utf-8">
         <div class="is-flex is-justify-content-space-between is-align-items-center mb-4">
@@ -6,7 +7,7 @@
                     <span class="icon has-text-link">
                         <i class="fas fa-search"></i>
                     </span>
-                    <span>Search Collection</span>
+                    <span>{% trans "Search Collection" %}</span>
                 </span>
             </h2>
             {% if has_active_filters %}
@@ -14,26 +15,26 @@
                     <span class="icon">
                         <i class="fas fa-filter"></i>
                     </span>
-                    <span>Filters Active</span>
+                    <span>{% trans "Filters Active" %}</span>
                 </span>
             {% endif %}
         </div>
         {# Quick Search Field #}
         <div class="field">
-            <label class="label" for="q">Quick Search</label>
+            <label class="label" for="q">{% trans "Quick Search" %}</label>
             <div class="control has-icons-left">
                 <input class="input"
                        type="text"
                        id="q"
                        name="q"
                        value="{{ request.GET.q }}"
-                       placeholder="Search across series and notes..."
-                       aria-label="Quick search">
+                       placeholder="{% trans 'Search across series and notes...' %}"
+                       aria-label="{% trans 'Quick search' %}">
                 <span class="icon is-small is-left">
                     <i class="fas fa-search"></i>
                 </span>
             </div>
-            <p class="help">Search across series names and notes</p>
+            <p class="help">{% trans "Search across series names and notes" %}</p>
         </div>
         {# Collapsible Advanced Filters #}
         <details {% if has_active_filters %}open{% endif %}>
@@ -42,22 +43,22 @@
                     <span class="icon">
                         <i class="fas fa-sliders-h"></i>
                     </span>
-                    <span>Advanced Filters</span>
+                    <span>{% trans "Advanced Filters" %}</span>
                 </span>
             </summary>
             <div class="columns is-multiline">
                 {# Series Filters #}
                 <div class="column is-half">
                     <div class="field">
-                        <label class="label" for="series_name">Series Name</label>
+                        <label class="label" for="series_name">{% trans "Series Name" %}</label>
                         <div class="control has-icons-left">
                             <input class="input"
                                    type="text"
                                    id="series_name"
                                    name="series_name"
                                    value="{{ request.GET.series_name }}"
-                                   placeholder="e.g., Amazing Spider-Man"
-                                   aria-label="Filter by series name">
+                                   placeholder="{% trans 'e.g., Amazing Spider-Man' %}"
+                                   aria-label="{% trans 'Filter by series name' %}">
                             <span class="icon is-small is-left">
                                 <i class="fas fa-book-open"></i>
                             </span>
@@ -66,13 +67,13 @@
                 </div>
                 <div class="column is-half">
                     <div class="field">
-                        <label class="label" for="series_type">Series Type</label>
+                        <label class="label" for="series_type">{% trans "Series Type" %}</label>
                         <div class="control has-icons-left">
                             <div class="select is-fullwidth">
                                 <select id="series_type"
                                         name="series_type"
-                                        aria-label="Filter by series type">
-                                    <option value="">All Types</option>
+                                        aria-label="{% trans 'Filter by series type' %}">
+                                    <option value="">{% trans "All Types" %}</option>
                                     {% for type in series_type %}
                                         <option value="{{ type.id }}"
                                                 {% if request.GET.series_type == type.id|stringformat:"s" %}selected{% endif %}>
@@ -90,15 +91,15 @@
                 {# Publisher Filter #}
                 <div class="column is-half">
                     <div class="field">
-                        <label class="label" for="publisher_name">Publisher</label>
+                        <label class="label" for="publisher_name">{% trans "Publisher" %}</label>
                         <div class="control has-icons-left">
                             <input class="input"
                                    type="text"
                                    id="publisher_name"
                                    name="publisher_name"
                                    value="{{ request.GET.publisher_name }}"
-                                   placeholder="e.g., Marvel"
-                                   aria-label="Filter by publisher">
+                                   placeholder="{% trans 'e.g., Marvel' %}"
+                                   aria-label="{% trans 'Filter by publisher' %}">
                             <span class="icon is-small is-left">
                                 <i class="fas fa-building"></i>
                             </span>
@@ -108,15 +109,15 @@
                 {# Issue Number Filter #}
                 <div class="column is-half">
                     <div class="field">
-                        <label class="label" for="issue_number">Issue Number</label>
+                        <label class="label" for="issue_number">{% trans "Issue Number" %}</label>
                         <div class="control has-icons-left">
                             <input class="input"
                                    type="text"
                                    id="issue_number"
                                    name="issue_number"
                                    value="{{ request.GET.issue_number }}"
-                                   placeholder="e.g., 1"
-                                   aria-label="Filter by issue number">
+                                   placeholder="{% trans 'e.g., 1' %}"
+                                   aria-label="{% trans 'Filter by issue number' %}">
                             <span class="icon is-small is-left">
                                 <i class="fas fa-hashtag"></i>
                             </span>
@@ -126,11 +127,11 @@
                 {# Format Filter #}
                 <div class="column is-half">
                     <div class="field">
-                        <label class="label" for="book_format">Format</label>
+                        <label class="label" for="book_format">{% trans "Format" %}</label>
                         <div class="control has-icons-left">
                             <div class="select is-fullwidth">
-                                <select id="book_format" name="book_format" aria-label="Filter by format">
-                                    <option value="">All Formats</option>
+                                <select id="book_format" name="book_format" aria-label="{% trans 'Filter by format' %}">
+                                    <option value="">{% trans "All Formats" %}</option>
                                     {% for value, label in book_formats %}
                                         <option value="{{ value }}"
                                                 {% if request.GET.book_format == value %}selected{% endif %}>
@@ -148,15 +149,15 @@
                 {# Read Status Filter #}
                 <div class="column is-half">
                     <div class="field">
-                        <label class="label" for="is_read">Read Status</label>
+                        <label class="label" for="is_read">{% trans "Read Status" %}</label>
                         <div class="control has-icons-left">
                             <div class="select is-fullwidth">
-                                <select id="is_read" name="is_read" aria-label="Filter by read status">
-                                    <option value="">All</option>
+                                <select id="is_read" name="is_read" aria-label="{% trans 'Filter by read status' %}">
+                                    <option value="">{% trans "All" %}</option>
                                     <option value="true"
-                                            {% if request.GET.is_read == "true" %}selected{% endif %}>Read</option>
+                                            {% if request.GET.is_read == "true" %}selected{% endif %}>{% trans "Read" %}</option>
                                     <option value="false"
-                                            {% if request.GET.is_read == "false" %}selected{% endif %}>Unread</option>
+                                            {% if request.GET.is_read == "false" %}selected{% endif %}>{% trans "Unread" %}</option>
                                 </select>
                             </div>
                             <span class="icon is-small is-left">
@@ -168,11 +169,11 @@
                 {# Grade Filter #}
                 <div class="column is-half">
                     <div class="field">
-                        <label class="label" for="grade">Grade</label>
+                        <label class="label" for="grade">{% trans "Grade" %}</label>
                         <div class="control has-icons-left">
                             <div class="select is-fullwidth">
-                                <select id="grade" name="grade" aria-label="Filter by grade">
-                                    <option value="">All Grades</option>
+                                <select id="grade" name="grade" aria-label="{% trans 'Filter by grade' %}">
+                                    <option value="">{% trans "All Grades" %}</option>
                                     {% for value, label in grade_choices %}
                                         <option value="{{ value }}"
                                                 {% if request.GET.grade == value|stringformat:"s" %}selected{% endif %}>
@@ -190,13 +191,13 @@
                 {# Grading Company Filter #}
                 <div class="column is-half">
                     <div class="field">
-                        <label class="label" for="grading_company">Grading Company</label>
+                        <label class="label" for="grading_company">{% trans "Grading Company" %}</label>
                         <div class="control has-icons-left">
                             <div class="select is-fullwidth">
                                 <select id="grading_company"
                                         name="grading_company"
-                                        aria-label="Filter by grading company">
-                                    <option value="">All Companies</option>
+                                        aria-label="{% trans 'Filter by grading company' %}">
+                                    <option value="">{% trans "All Companies" %}</option>
                                     {% for value, label in grading_companies %}
                                         <option value="{{ value }}"
                                                 {% if request.GET.grading_company == value %}selected{% endif %}>
@@ -214,15 +215,15 @@
                 {# Rating Filter #}
                 <div class="column is-half">
                     <div class="field">
-                        <label class="label" for="rating">Rating</label>
+                        <label class="label" for="rating">{% trans "Rating" %}</label>
                         <div class="control has-icons-left">
                             <div class="select is-fullwidth">
-                                <select id="rating" name="rating" aria-label="Filter by rating">
-                                    <option value="">All Ratings</option>
+                                <select id="rating" name="rating" aria-label="{% trans 'Filter by rating' %}">
+                                    <option value="">{% trans "All Ratings" %}</option>
                                     {% for value, label in rating_choices %}
                                         <option value="{{ value }}"
                                                 {% if request.GET.rating == value|stringformat:"s" %}selected{% endif %}>
-                                            {{ label }} Star{{ label|pluralize }}
+                                            {% blocktrans count counter=label %}{{ counter }} Star{% plural %}{{ counter }} Stars{% endblocktrans %}
                                         </option>
                                     {% endfor %}
                                 </select>
@@ -242,17 +243,17 @@
                     <span class="icon">
                         <i class="fas fa-search"></i>
                     </span>
-                    <span>Apply Filters</span>
+                    <span>{% trans "Apply Filters" %}</span>
                 </button>
             </div>
             <div class="control">
                 <a class="button is-light"
                    href="{% url 'user_collection:list' %}"
-                   title="Clear all filters">
+                   title="{% trans 'Clear all filters' %}">
                     <span class="icon">
                         <i class="fas fa-times"></i>
                     </span>
-                    <span>Clear Filters</span>
+                    <span>{% trans "Clear Filters" %}</span>
                 </a>
             </div>
         </div>

--- a/user_collection/templates/user_collection/partials/read_dates_list.html
+++ b/user_collection/templates/user_collection/partials/read_dates_list.html
@@ -1,3 +1,4 @@
+{% load i18n %}
 <div class="content">
     {% if item.read_dates.exists %}
         <ul>
@@ -5,7 +6,7 @@
                 <li class="is-flex is-align-items-center">
                     <span class="mr-2">{{ read_date_entry.read_date|date:"F d, Y g:i A" }}</span>
                     <button class="delete is-small"
-                            aria-label="Remove read date"
+                            aria-label="{% trans 'Remove read date' %}"
                             hx-on:click="document.getElementById('delete-read-date-modal-{{ read_date_entry.pk }}').classList.add('is-active'); document.documentElement.classList.add('is-clipped');">
                     </button>
                 </li>
@@ -16,34 +17,36 @@
                     </div>
                     <div class="modal-card">
                         <header class="modal-card-head">
-                            <p class="modal-card-title">Confirm Delete</p>
+                            <p class="modal-card-title">{% trans "Confirm Delete" %}</p>
                             <button class="delete"
-                                    aria-label="close"
+                                    aria-label="{% trans 'close' %}"
                                     hx-on:click="this.closest('.modal').classList.remove('is-active'); document.documentElement.classList.remove('is-clipped');">
                             </button>
                         </header>
                         <section class="modal-card-body">
                             <p>
-                                Are you sure you want to remove the read date <strong>{{ read_date_entry.read_date|date:"F d, Y g:i A" }}</strong>?
+                                {% blocktrans with read_date=read_date_entry.read_date|date:"F d, Y g:i A" %}Are you sure you want to remove the read date <strong>{{ read_date }}</strong>?{% endblocktrans %}
                             </p>
-                            <p class="mt-2 has-text-grey">This action cannot be undone.</p>
+                            <p class="mt-2 has-text-grey">{% trans "This action cannot be undone." %}</p>
                         </section>
                         <footer class="modal-card-foot">
                             <button class="button is-danger"
                                     hx-post="{% url 'user_collection:delete_read_date' item.pk read_date_entry.pk %}"
-                                    hx-target="#read-dates-container">Remove Read Date</button>
+                                    hx-target="#read-dates-container">{% trans "Remove Read Date" %}</button>
                             <button class="button"
                                     hx-on:click="this.closest('.modal').classList.remove('is-active'); document.documentElement.classList.remove('is-clipped');">
-                                Cancel
+                                {% trans "Cancel" %}
                             </button>
                         </footer>
                     </div>
                 </div>
             {% endfor %}
         </ul>
-        <p class="is-size-7 has-text-grey">Read {{ item.get_read_count }} time{{ item.get_read_count|pluralize }}</p>
+        <p class="is-size-7 has-text-grey">
+            {% blocktrans count counter=item.get_read_count %}Read {{ counter }} time{% plural %}Read {{ counter }} times{% endblocktrans %}
+        </p>
     {% else %}
-        <p class="has-text-grey-light">Not read yet</p>
+        <p class="has-text-grey-light">{% trans "Not read yet" %}</p>
     {% endif %}
     <div class="mt-3">
         <div class="field">
@@ -52,11 +55,11 @@
                        type="text"
                        name="read_date"
                        id="new-read-date-{{ item.pk }}"
-                       placeholder="Optional: specify date/time"
+                       placeholder="{% trans 'Optional: specify date/time' %}"
                        data-bulma-calendar="on"
                        data-type="datetime">
             </div>
-            <p class="help is-size-7">Leave blank to use current date/time</p>
+            <p class="help is-size-7">{% trans "Leave blank to use current date/time" %}</p>
         </div>
         <div class="field">
             <div class="control">
@@ -67,7 +70,7 @@
                     <span class="icon is-small">
                         <i class="fas fa-plus"></i>
                     </span>
-                    <span>Add Read Date</span>
+                    <span>{% trans "Add Read Date" %}</span>
                 </button>
             </div>
         </div>

--- a/user_collection/templates/user_collection/partials/star_rating.html
+++ b/user_collection/templates/user_collection/partials/star_rating.html
@@ -1,3 +1,4 @@
+{% load i18n %}
 <div id="rating-{{ item.pk }}" class="star-rating">
     {% for star_num in "12345" %}
         <button type="button"
@@ -6,7 +7,7 @@
                 hx-vals='{"rating": "{{ forloop.counter }}"}'
                 hx-target="#rating-{{ item.pk }}"
                 hx-swap="outerHTML"
-                title="Rate {{ forloop.counter }} star{% if forloop.counter > 1 %}s{% endif %}">
+                title="{% blocktrans count counter=forloop.counter %}Rate {{ counter }} star{% plural %}Rate {{ counter }} stars{% endblocktrans %}">
             <i class="{% if item.rating and forloop.counter <= item.rating %}fas{% else %}far{% endif %} fa-star"></i>
         </button>
     {% endfor %}
@@ -17,7 +18,7 @@
                 hx-vals='{"rating": "0"}'
                 hx-target="#rating-{{ item.pk }}"
                 hx-swap="outerHTML"
-                title="Clear rating">
+                title="{% trans 'Clear rating' %}">
             <i class="fas fa-times-circle"></i>
         </button>
     {% endif %}

--- a/user_collection/templates/user_collection/reading_history.html
+++ b/user_collection/templates/user_collection/reading_history.html
@@ -1,10 +1,10 @@
 {% extends parent_template|default:"base.html" %}
 {% load thumbnail %}
-{% load static %}
-{% block title %}Reading History - Metron{% endblock %}
+{% load static i18n %}
+{% block title %}{% trans "Reading History - Metron" %}{% endblock %}
 {% block content %}
     <header class="block has-text-centered">
-        <h1 class="title">My Reading History</h1>
+        <h1 class="title">{% trans "My Reading History" %}</h1>
     </header>
     <section class="section">
         <div class="container">
@@ -12,7 +12,7 @@
                 <div class="level-left">
                     <div class="level-item">
                         <p class="subtitle is-5">
-                            <strong>{{ page_obj.paginator.count }}</strong> issue{{ page_obj.paginator.count|pluralize }} read
+                            {% blocktrans count counter=page_obj.paginator.count %}<strong>{{ counter }}</strong> issue read{% plural %}<strong>{{ counter }}</strong> issues read{% endblocktrans %}
                         </p>
                     </div>
                 </div>
@@ -22,12 +22,12 @@
                             <a href="{% url 'user_collection:stats' %}"
                                class="button is-info ">
                                 <span class="icon"><i class="fas fa-chart-bar"></i></span>
-                                <span>View Statistics</span>
+                                <span>{% trans "View Statistics" %}</span>
                             </a>
                             <a href="{% url 'user_collection:list' %}"
                                class="button is-link ">
                                 <span class="icon"><i class="fas fa-th-list"></i></span>
-                                <span>My Collection</span>
+                                <span>{% trans "My Collection" %}</span>
                             </a>
                         </div>
                     </div>
@@ -52,7 +52,7 @@
                                             <b>{{ first_item.date_read|date:"l" }}</b> {{ first_item.date_read|date:"F j, Y" }}
                                         {% endwith %}
                                     {% else %}
-                                        Date Unknown
+                                        {% trans "Date Unknown" %}
                                     {% endif %}
                                 </span>
                             </span>
@@ -70,7 +70,7 @@
                                                         {% endthumbnail %}
                                                     {% else %}
                                                         <img src="{% static 'site/img/image-not-found.webp' %}"
-                                                             alt="No cover available"
+                                                             alt="{% trans 'No cover available' %}"
                                                              loading="lazy">
                                                     {% endif %}
                                                 </a>
@@ -80,7 +80,7 @@
                                                       style="position: absolute;
                                                              top: 0.5rem;
                                                              right: 0.5rem"
-                                                      title="Read {{ item.read_count }} times">
+                                                      title="{% blocktrans count counter=item.read_count %}Read {{ counter }} time{% plural %}Read {{ counter }} times{% endblocktrans %}">
                                                     <span class="icon is-small"><i class="fas fa-book-reader"></i></span>
                                                     <span>&times;{{ item.read_count }}</span>
                                                 </span>
@@ -118,11 +118,11 @@
                                             </div>
                                             <a href="{% url 'user_collection:detail' item.pk %}"
                                                class="button is-small is-info is-outlined is-fullwidth"
-                                               title="View Details">
+                                               title="{% trans 'View Details' %}">
                                                 <span class="icon is-small">
                                                     <i class="fas fa-eye"></i>
                                                 </span>
-                                                <span>Details</span>
+                                                <span>{% trans "Details" %}</span>
                                             </a>
                                         </div>
                                     </div>
@@ -136,12 +136,12 @@
     {% else %}
         <section class="section pt-0">
             <div class="container has-text-centered">
-                <p class="title is-4">No reading history yet</p>
-                <p class="subtitle">Start reading and marking issues as read to build your reading history!</p>
+                <p class="title is-4">{% trans "No reading history yet" %}</p>
+                <p class="subtitle">{% trans "Start reading and marking issues as read to build your reading history!" %}</p>
                 <a href="{% url 'user_collection:list' %}"
                    class="button is-primary is-large">
                     <span class="icon"><i class="fas fa-book-open"></i></span>
-                    <span>Go to My Collection</span>
+                    <span>{% trans "Go to My Collection" %}</span>
                 </a>
             </div>
         </section>

--- a/user_collection/views.py
+++ b/user_collection/views.py
@@ -11,6 +11,7 @@ from django.shortcuts import get_object_or_404, render
 from django.urls import reverse, reverse_lazy
 from django.utils import timezone
 from django.utils.dateparse import parse_datetime
+from django.utils.translation import gettext as _, ngettext
 from django.views.decorators.http import require_POST
 from django.views.generic import (
     CreateView,
@@ -111,7 +112,7 @@ class CollectionCreateView(LoginRequiredMixin, CreateView):
         if form.instance.is_read and not form.instance.read_dates.exists():
             form.instance.add_read_date()
 
-        messages.success(self.request, "Item added to your collection!")
+        messages.success(self.request, _("Item added to your collection!"))
         return response
 
     def get_success_url(self):
@@ -143,7 +144,7 @@ class CollectionUpdateView(LoginRequiredMixin, UserPassesTestMixin, UpdateView):
         if form.instance.is_read and not form.instance.read_dates.exists():
             form.instance.add_read_date()
 
-        messages.success(self.request, "Collection item updated!")
+        messages.success(self.request, _("Collection item updated!"))
         return response
 
     def get_success_url(self):
@@ -164,7 +165,7 @@ class CollectionDeleteView(LoginRequiredMixin, UserPassesTestMixin, DeleteView):
         return item.user == self.request.user
 
     def form_valid(self, form):
-        messages.success(self.request, "Item removed from your collection.")
+        messages.success(self.request, _("Item removed from your collection."))
         return super().form_valid(form)
 
 
@@ -208,12 +209,12 @@ class CollectionStatsView(LoginRequiredMixin, TemplateView):
             .order_by("-count")
         )
         publisher_dict = {
-            item["issue__series__publisher__name"] or "Unknown": item["count"]
+            item["issue__series__publisher__name"] or _("Unknown"): item["count"]
             for item in publisher_data
         }
         publisher_chart = PieChart(
             publisher_dict,
-            title="Issues by Publisher",
+            title=_("Issues by Publisher"),
             thousands=",",
             legend="bottom",
         )
@@ -225,12 +226,12 @@ class CollectionStatsView(LoginRequiredMixin, TemplateView):
             .order_by("-count")
         )
         series_type_dict = {
-            item["issue__series__series_type__name"] or "Unknown": item["count"]
+            item["issue__series__series_type__name"] or _("Unknown"): item["count"]
             for item in series_type_data
         }
         series_type_chart = PieChart(
             series_type_dict,
-            title="Issues by Series Type",
+            title=_("Issues by Series Type"),
             thousands=",",
             legend="bottom",
         )
@@ -239,12 +240,12 @@ class CollectionStatsView(LoginRequiredMixin, TemplateView):
         format_dict = {}
         for item in format_counts:
             format_name = dict(CollectionItem.BookFormat.choices).get(
-                item["book_format"], "Unknown"
+                item["book_format"], _("Unknown")
             )
             format_dict[format_name] = item["count"]
         format_chart = PieChart(
             format_dict,
-            title="Issues by Format",
+            title=_("Issues by Format"),
             thousands=",",
             legend="bottom",
         )
@@ -268,7 +269,7 @@ class CollectionStatsView(LoginRequiredMixin, TemplateView):
         }
         reading_daily_chart = ColumnChart(
             daily_dict,
-            title="Issues Read (Last 30 Days)",
+            title=_("Issues Read (Last 30 Days)"),
             thousands=",",
         )
 
@@ -281,7 +282,7 @@ class CollectionStatsView(LoginRequiredMixin, TemplateView):
         monthly_dict = {r["month"].strftime("%b %Y"): r["c"] for r in monthly_reads[::-1]}
         reading_monthly_chart = ColumnChart(
             monthly_dict,
-            title="Issues Read (Last 12 Months)",
+            title=_("Issues Read (Last 12 Months)"),
             thousands=",",
         )
 
@@ -298,7 +299,7 @@ class CollectionStatsView(LoginRequiredMixin, TemplateView):
         writers_dict = {item["creator__name"]: item["count"] for item in top_writers_data}
         top_writers_chart = BarChart(
             writers_dict,
-            title="Top Writers",
+            title=_("Top Writers"),
             thousands=",",
             library={"scales": {"x": {"ticks": {"precision": 0}}}},
         )
@@ -323,7 +324,7 @@ class CollectionStatsView(LoginRequiredMixin, TemplateView):
         artists_dict = {item["creator__name"]: item["count"] for item in top_artists_data}
         top_artists_chart = BarChart(
             artists_dict,
-            title="Top Artists",
+            title=_("Top Artists"),
             thousands=",",
             library={"scales": {"x": {"ticks": {"precision": 0}}}},
         )
@@ -448,25 +449,32 @@ class AddIssuesFromSeriesView(LoginRequiredMixin, FormView):
         if new_items:
             CollectionItem.objects.bulk_create(new_items)
             added_count = len(new_items)
-            read_status_msg = " (marked as read)" if mark_as_read else ""
+
+            added_phrase = ngettext(
+                "Added %(count)d issue to your collection",
+                "Added %(count)d issues to your collection",
+                added_count,
+            ) % {"count": added_count}
+            if mark_as_read:
+                added_phrase = _("%(phrase)s (marked as read)") % {"phrase": added_phrase}
 
             if skipped_count > 0:
-                issue_word = "issue" if added_count == 1 else "issues"
-                skipped_word = "issue" if skipped_count == 1 else "issues"
-                messages.success(
-                    self.request,
-                    f"Added {added_count} {issue_word} to your collection{read_status_msg}. "
-                    f"Skipped {skipped_count} {skipped_word} already in your collection.",
-                )
+                skipped_phrase = ngettext(
+                    "Skipped %(count)d issue already in your collection.",
+                    "Skipped %(count)d issues already in your collection.",
+                    skipped_count,
+                ) % {"count": skipped_count}
+                message = _("%(added)s. %(skipped)s") % {
+                    "added": added_phrase,
+                    "skipped": skipped_phrase,
+                }
             else:
-                messages.success(
-                    self.request,
-                    f"Added {added_count} issue{'s' if added_count != 1 else ''} "
-                    f"to your collection{read_status_msg}!",
-                )
+                message = _("%(added)s!") % {"added": added_phrase}
+            messages.success(self.request, message)
         else:
             messages.info(
-                self.request, "All issues from this series are already in your collection."
+                self.request,
+                _("All issues from this series are already in your collection."),
             )
 
         return super().form_valid(form)

--- a/users/forms.py
+++ b/users/forms.py
@@ -4,6 +4,7 @@ from typing import Any
 from django.contrib.auth.forms import UserChangeForm, UserCreationForm
 from django.core.exceptions import ValidationError
 from django.forms import ClearableFileInput, EmailField, EmailInput
+from django.utils.translation import gettext_lazy as _
 
 from users.models import CustomUser
 from users.utils import check_email_domain
@@ -14,7 +15,7 @@ LOGGER = logging.getLogger(__name__)
 class CustomUserCreationForm(UserCreationForm):
     email = EmailField(
         max_length=254,
-        help_text=(
+        help_text=_(
             "Required. Enter a valid email address. Temporary email addresses are not allowed."
         ),
         required=True,
@@ -38,32 +39,32 @@ class CustomUserCreationForm(UserCreationForm):
         email: str = self.cleaned_data.get("email")
         if email is None:
             LOGGER.error("User didn't add an email address")
-            raise ValidationError("Email address is not valid.")
+            raise ValidationError(_("Email address is not valid."))
 
         if CustomUser.objects.filter(email=email).exists():
             LOGGER.warning("'%s' already exists", email)
-            raise ValidationError("Email already exists")
+            raise ValidationError(_("Email already exists"))
 
         try:
-            _, domain = email.split("@")
+            _unused, domain = email.split("@")
         except ValueError as exc:
             LOGGER.warning("Email: %s | Error: %s", email, exc)
-            raise ValidationError("Email address is not valid.") from exc
+            raise ValidationError(_("Email address is not valid.")) from exc
 
         if domain in blocklist:
             LOGGER.warning("'%s' is a temporary email address.", email)
-            raise ValidationError("Temporary email addresses are not allowed.")
+            raise ValidationError(_("Temporary email addresses are not allowed."))
 
         if domain not in whitelist:
             resp = check_email_domain(email)
             if resp is None:
-                raise ValidationError("Error creating account. Contact the site administrator.")
+                raise ValidationError(_("Error creating account. Contact the site administrator."))
             if resp["block"] is True:
                 if resp["disposable"] is True:
                     LOGGER.warning("'%s' is a temporary email address.", email)
-                    raise ValidationError("Temporary email addresses are not allowed.")
+                    raise ValidationError(_("Temporary email addresses are not allowed."))
                 LOGGER.warning("'%s' is not a valid email address.", email)
-                raise ValidationError("Email address is not valid.")
+                raise ValidationError(_("Email address is not valid."))
         return super().clean()
 
     class Meta(UserCreationForm):
@@ -74,10 +75,10 @@ class CustomUserCreationForm(UserCreationForm):
 class CustomUserChangeForm(UserChangeForm):
     email = EmailField(
         max_length=254,
-        help_text="Required. Enter a valid email address.",
+        help_text=_("Required. Enter a valid email address."),
         required=True,
         widget=EmailInput(attrs={"class": "input"}),
-        error_messages={"required": "Please provide valid email."},
+        error_messages={"required": _("Please provide valid email.")},
     )
 
     class Meta:

--- a/users/models.py
+++ b/users/models.py
@@ -2,6 +2,7 @@ from django.contrib.auth.base_user import BaseUserManager
 from django.contrib.auth.models import AbstractUser
 from django.db import models
 from django.utils import timezone
+from django.utils.translation import gettext_lazy as _
 from knox.models import AbstractAuthToken
 from sorl.thumbnail import ImageField
 
@@ -9,10 +10,10 @@ from sorl.thumbnail import ImageField
 # tier_for_amount can return on the first match ("round down to the nearest
 # qualifying tier"). Mega Sponsor is a flat ceiling at $25+, not a per-dollar formula.
 SUPPORTER_TIERS: tuple[tuple[int, str, str, int], ...] = (
-    (2500, "mega_sponsor", "Mega Sponsor", 25000),
-    (1000, "sponsor", "Sponsor", 15000),
-    (500, "backer", "Backer", 10000),
-    (200, "friend", "Friend", 7500),
+    (2500, "mega_sponsor", _("Mega Sponsor"), 25000),
+    (1000, "sponsor", _("Sponsor"), 15000),
+    (500, "backer", _("Backer"), 10000),
+    (200, "friend", _("Friend"), 7500),
 )
 
 _SUPPORTER_TIERS_BY_SLUG = {slug: (name, limit) for _, slug, name, limit in SUPPORTER_TIERS}
@@ -99,12 +100,12 @@ class SignupSettings(models.Model):
     disabled_message = models.CharField(
         max_length=255,
         blank=True,
-        default="New account signups are temporarily disabled. Please check back later.",
+        default=_("New account signups are temporarily disabled. Please check back later."),
     )
 
     class Meta:
-        verbose_name = "Signup settings"
-        verbose_name_plural = "Signup settings"
+        verbose_name = _("Signup settings")
+        verbose_name_plural = _("Signup settings")
 
     def __str__(self):
         return "Signup settings"
@@ -144,13 +145,17 @@ class OpenCollectiveDonation(models.Model):
         related_name="opencollective_donations",
     )
     email = models.EmailField()
-    amount = models.IntegerField(help_text="Donation amount in cents.")
+    amount = models.IntegerField(help_text=_("Donation amount in cents."))
     donated_at = models.DateTimeField()
     frequency = models.CharField(
         max_length=10,
         blank=True,
-        choices=[("monthly", "Monthly"), ("yearly", "Yearly"), ("onetime", "One-time")],
-        help_text="The underlying OpenCollective order's frequency.",
+        choices=[
+            ("monthly", _("Monthly")),
+            ("yearly", _("Yearly")),
+            ("onetime", _("One-time")),
+        ],
+        help_text=_("The underlying OpenCollective order's frequency."),
     )
     created_on = models.DateTimeField(auto_now_add=True)
 

--- a/users/templates/registration/account_activation_email.html
+++ b/users/templates/registration/account_activation_email.html
@@ -1,10 +1,10 @@
-{% autoescape off %}
+{% load i18n %}{% autoescape off %}
     <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
     <html xmlns="http://www.w3.org/1999/xhtml">
         <head>
             <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
             <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-            <title>Activate Your Metron Account</title>
+            <title>{% trans "Activate Your Metron Account" %}</title>
         </head>
         <body style="margin: 0;
                      padding: 0;
@@ -45,19 +45,19 @@
                                                color: #363636;
                                                font-weight: 600;
                                                font-family: Arial, Helvetica, sans-serif">
-                                        Welcome to Metron, {{ user.username }}!
+                                        {% blocktrans with username=user.username %}Welcome to Metron, {{ username }}!{% endblocktrans %}
                                     </h2>
                                     <p style="margin: 0 0 20px 0;
                                               font-size: 16px;
                                               color: #4a4a4a;
                                               font-family: Arial, Helvetica, sans-serif">
-                                        Thank you for joining the Metron Comic Book Database community! We're excited to have you as part of our growing community of comic book enthusiasts.
+                                        {% blocktrans %}Thank you for joining the Metron Comic Book Database community! We're excited to have you as part of our growing community of comic book enthusiasts.{% endblocktrans %}
                                     </p>
                                     <p style="margin: 0 0 30px 0;
                                               font-size: 16px;
                                               color: #4a4a4a;
                                               font-family: Arial, Helvetica, sans-serif">
-                                        To complete your registration and activate your account, please click the button below:
+                                        {% trans "To complete your registration and activate your account, please click the button below:" %}
                                     </p>
                                     <!-- Button -->
                                     <table border="0" cellpadding="0" cellspacing="0" width="100%">
@@ -74,7 +74,7 @@
                                                                       font-weight: 600;
                                                                       color: #ffffff;
                                                                       text-decoration: none;
-                                                                      font-family: Arial, Helvetica, sans-serif">Activate My Account</a>
+                                                                      font-family: Arial, Helvetica, sans-serif">{% trans "Activate My Account" %}</a>
                                                         </td>
                                                     </tr>
                                                 </table>
@@ -94,7 +94,7 @@
                                                           font-size: 14px;
                                                           color: #4a4a4a;
                                                           font-family: Arial, Helvetica, sans-serif">
-                                                    <strong>Button not working?</strong> Copy and paste this link into your browser:
+                                                    <strong>{% trans "Button not working?" %}</strong> {% trans "Copy and paste this link into your browser:" %}
                                                 </p>
                                                 <p style="margin: 0;
                                                           font-size: 13px;
@@ -120,7 +120,7 @@
                                                            font-size: 16px;
                                                            color: #3273dc;
                                                            font-family: Arial, Helvetica, sans-serif">
-                                                    What you can do with your Metron account:
+                                                    {% trans "What you can do with your Metron account:" %}
                                                 </h3>
                                                 <table border="0"
                                                        cellpadding="0"
@@ -131,7 +131,7 @@
                                                                    font-size: 14px;
                                                                    color: #4a4a4a;
                                                                    font-family: Arial, Helvetica, sans-serif">
-                                                            &#8226; Contribute to the comic book database by adding and editing information
+                                                            &#8226; {% trans "Contribute to the comic book database by adding and editing information" %}
                                                         </td>
                                                     </tr>
                                                     <tr>
@@ -139,7 +139,7 @@
                                                                    font-size: 14px;
                                                                    color: #4a4a4a;
                                                                    font-family: Arial, Helvetica, sans-serif">
-                                                            &#8226; Access our comprehensive API for developers
+                                                            &#8226; {% trans "Access our comprehensive API for developers" %}
                                                         </td>
                                                     </tr>
                                                     <tr>
@@ -147,7 +147,7 @@
                                                                    font-size: 14px;
                                                                    color: #4a4a4a;
                                                                    font-family: Arial, Helvetica, sans-serif">
-                                                            &#8226; Join discussions with fellow comic book fans
+                                                            &#8226; {% trans "Join discussions with fellow comic book fans" %}
                                                         </td>
                                                     </tr>
                                                     <tr>
@@ -155,7 +155,7 @@
                                                                    font-size: 14px;
                                                                    color: #4a4a4a;
                                                                    font-family: Arial, Helvetica, sans-serif">
-                                                            &#8226; Help build the most accurate comic book database
+                                                            &#8226; {% trans "Help build the most accurate comic book database" %}
                                                         </td>
                                                     </tr>
                                                 </table>
@@ -187,7 +187,7 @@
                                                           font-size: 14px;
                                                           color: #4a4a4a;
                                                           font-family: Arial, Helvetica, sans-serif">
-                                                    <strong>This link expires in 24 hours.</strong> If you don't activate your account within this time, you'll need to sign up again.
+                                                    <strong>{% trans "This link expires in 24 hours." %}</strong> {% trans "If you don't activate your account within this time, you'll need to sign up again." %}
                                                 </p>
                                             </td>
                                         </tr>
@@ -196,7 +196,7 @@
                                               font-size: 16px;
                                               color: #4a4a4a;
                                               font-family: Arial, Helvetica, sans-serif">
-                                        If you didn't create an account with Metron, you can safely ignore this email.
+                                        {% trans "If you didn't create an account with Metron, you can safely ignore this email." %}
                                     </p>
                                 </td>
                             </tr>
@@ -207,32 +207,33 @@
                                               font-size: 14px;
                                               color: #ffffff;
                                               font-family: Arial, Helvetica, sans-serif">
-                                        <strong>Metron Comic Book Database</strong>
+                                        <strong>{% trans "Metron Comic Book Database" %}</strong>
                                     </p>
                                     <p style="margin: 0 0 15px 0;
                                               font-size: 14px;
                                               color: #b5b5b5;
                                               font-family: Arial, Helvetica, sans-serif">
-                                        A community-driven project for comic book enthusiasts
+                                        {% trans "A community-driven project for comic book enthusiasts" %}
                                     </p>
                                     <p style="margin: 0 0 10px 0;
                                               font-size: 14px;
                                               font-family: Arial, Helvetica, sans-serif">
                                         <a href="https://metron.cloud"
                                            style="color: #3273dc;
-                                                  text-decoration: none">Visit Website</a> &#8226;
+                                                  text-decoration: none">{% trans "Visit Website" %}</a> &#8226;
                                         <a href="https://github.com/Metron-Project/metron"
                                            style="color: #3273dc;
                                                   text-decoration: none">GitHub</a> &#8226;
                                         <a href="mailto:admin@metron.cloud"
                                            style="color: #3273dc;
-                                                  text-decoration: none">Contact Us</a>
+                                                  text-decoration: none">{% trans "Contact Us" %}</a>
                                     </p>
                                     <p style="margin: 15px 0 0 0;
                                               font-size: 12px;
                                               color: #7a7a7a;
                                               font-family: Arial, Helvetica, sans-serif">
-                                        &copy; {% now "Y" %} Metron Project. All rights reserved.
+                                        {% now "Y" as current_year %}
+                                        {% blocktrans %}&copy; {{ current_year }} Metron Project. All rights reserved.{% endblocktrans %}
                                     </p>
                                 </td>
                             </tr>

--- a/users/templates/registration/account_activation_email.txt
+++ b/users/templates/registration/account_activation_email.txt
@@ -1,29 +1,30 @@
-{% autoescape off %}
-Welcome to Metron, {{ user.username }}!
+{% load i18n %}{% autoescape off %}
+{% blocktrans with username=user.username %}Welcome to Metron, {{ username }}!{% endblocktrans %}
 
-Thank you for joining the Metron Comic Book Database community! We're excited to have you as part of our growing community of comic book enthusiasts.
+{% blocktrans %}Thank you for joining the Metron Comic Book Database community! We're excited to have you as part of our growing community of comic book enthusiasts.{% endblocktrans %}
 
-To complete your registration and activate your account, please visit:
+{% trans "To complete your registration and activate your account, please visit:" %}
 
 http://{{ domain }}{% url 'activate' uidb64=uid token=token %}
 
-What you can do with your Metron account:
-- Contribute to the comic book database by adding and editing information
-- Access our comprehensive API for developers
-- Join discussions with fellow comic book fans
-- Help build the most accurate comic book database
+{% trans "What you can do with your Metron account:" %}
+- {% trans "Contribute to the comic book database by adding and editing information" %}
+- {% trans "Access our comprehensive API for developers" %}
+- {% trans "Join discussions with fellow comic book fans" %}
+- {% trans "Help build the most accurate comic book database" %}
 
-IMPORTANT: This link expires in 24 hours. If you don't activate your account within this time, you'll need to sign up again.
+{% blocktrans %}IMPORTANT: This link expires in 24 hours. If you don't activate your account within this time, you'll need to sign up again.{% endblocktrans %}
 
-If you didn't create an account with Metron, you can safely ignore this email.
+{% trans "If you didn't create an account with Metron, you can safely ignore this email." %}
 
 ---
-Metron Comic Book Database
-A community-driven project for comic book enthusiasts
+{% trans "Metron Comic Book Database" %}
+{% trans "A community-driven project for comic book enthusiasts" %}
 
 Website: https://metron.cloud
 GitHub: https://github.com/Metron-Project/metron
 Contact: admin@metron.cloud
 
-(c) {% now "Y" %} Metron Project. All rights reserved.
+{% now "Y" as current_year %}
+{% blocktrans %}(c) {{ current_year }} Metron Project. All rights reserved.{% endblocktrans %}
 {% endautoescape %}

--- a/users/templates/registration/account_activation_invalid.html
+++ b/users/templates/registration/account_activation_invalid.html
@@ -1,6 +1,7 @@
 {% extends parent_template|default:"base.html" %}
+{% load i18n %}
 {% block title %}
-    Invalid Confirmation Link - Metron
+    {% trans "Invalid Confirmation Link - Metron" %}
 {% endblock title %}
 {% block content %}
     {# Error Header #}
@@ -8,7 +9,7 @@
         <span class="icon is-large has-text-danger">
             <i class="fas fa-times-circle fa-4x"></i>
         </span>
-        <h1 class="title is-3 mt-4">Invalid Confirmation Link</h1>
+        <h1 class="title is-3 mt-4">{% trans "Invalid Confirmation Link" %}</h1>
     </header>
     {# Error Message #}
     <div class="columns is-centered">
@@ -16,12 +17,12 @@
             <div class="box">
                 <article class="message is-danger">
                     <div class="message-body">
-                        <p class="mb-3">The confirmation link is invalid or has expired.</p>
-                        <p>This may have happened because:</p>
+                        <p class="mb-3">{% trans "The confirmation link is invalid or has expired." %}</p>
+                        <p>{% trans "This may have happened because:" %}</p>
                         <ul class="mt-3">
-                            <li>The link has already been used</li>
-                            <li>The link has expired (links are valid for 24 hours)</li>
-                            <li>The link was copied incorrectly</li>
+                            <li>{% trans "The link has already been used" %}</li>
+                            <li>{% trans "The link has expired (links are valid for 24 hours)" %}</li>
+                            <li>{% trans "The link was copied incorrectly" %}</li>
                         </ul>
                     </div>
                 </article>
@@ -31,13 +32,13 @@
                             <span class="icon">
                                 <i class="fas fa-home"></i>
                             </span>
-                            <span>Go to Home</span>
+                            <span>{% trans "Go to Home" %}</span>
                         </a>
                         <a class="button is-light is-medium" href="{% url 'login' %}">
                             <span class="icon">
                                 <i class="fas fa-sign-in-alt"></i>
                             </span>
-                            <span>Try Logging In</span>
+                            <span>{% trans "Try Logging In" %}</span>
                         </a>
                     </div>
                 </div>
@@ -48,31 +49,33 @@
                     <span class="icon">
                         <i class="fas fa-info-circle"></i>
                     </span>
-                    What should you do?
+                    {% trans "What should you do?" %}
                 </p>
                 <div class="content">
                     <ul>
                         <li>
-                            If your account was already activated, try <a href="{% url 'login' %}">logging in</a>
+                            {% url 'login' as login_url %}
+                            {% blocktrans %}If your account was already activated, try <a href="{{ login_url }}">logging in</a>{% endblocktrans %}
                         </li>
                         <li>
-                            If you need a new confirmation link, please <a href="{% url 'signup' %}">sign up again</a> or contact support
+                            {% url 'signup' as signup_url %}
+                            {% blocktrans %}If you need a new confirmation link, please <a href="{{ signup_url }}">sign up again</a> or contact support{% endblocktrans %}
                         </li>
-                        <li>Make sure you're using the most recent confirmation email</li>
+                        <li>{% trans "Make sure you're using the most recent confirmation email" %}</li>
                     </ul>
                 </div>
             </div>
             {# Contact Support #}
             <div class="box has-text-centered">
-                <p class="has-text-weight-bold mb-2">Still having trouble?</p>
-                <p class="mb-3">Our support team is here to help</p>
+                <p class="has-text-weight-bold mb-2">{% trans "Still having trouble?" %}</p>
+                <p class="mb-3">{% trans "Our support team is here to help" %}</p>
                 <div class="buttons is-centered">
                     <a class="button is-link is-outlined is-small"
                        href="mailto:admin@metron.cloud">
                         <span class="icon">
                             <i class="fas fa-envelope"></i>
                         </span>
-                        <span>Contact Support</span>
+                        <span>{% trans "Contact Support" %}</span>
                     </a>
                     <a class="button is-link is-outlined is-small"
                        href="https://github.com/Metron-Project/metron/issues/new/choose"
@@ -81,7 +84,7 @@
                         <span class="icon">
                             <i class="fas fa-bug"></i>
                         </span>
-                        <span>Report Issue</span>
+                        <span>{% trans "Report Issue" %}</span>
                     </a>
                 </div>
             </div>

--- a/users/templates/registration/account_activation_sent.html
+++ b/users/templates/registration/account_activation_sent.html
@@ -1,6 +1,7 @@
 {% extends parent_template|default:"base.html" %}
+{% load i18n %}
 {% block title %}
-    Confirmation Email Sent - Metron
+    {% trans "Confirmation Email Sent - Metron" %}
 {% endblock title %}
 {% block content %}
     {# Success Header #}
@@ -8,7 +9,7 @@
         <span class="icon is-large has-text-success">
             <i class="fas fa-envelope-circle-check fa-4x"></i>
         </span>
-        <h1 class="title is-3 mt-4">Check Your Email</h1>
+        <h1 class="title is-3 mt-4">{% trans "Check Your Email" %}</h1>
     </header>
     {# Success Message #}
     <div class="columns is-centered">
@@ -17,9 +18,9 @@
                 <article class="message is-success">
                     <div class="message-body">
                         <p class="mb-3">
-                            <strong>Welcome to Metron!</strong> We've sent a confirmation link to your email address.
+                            <strong>{% trans "Welcome to Metron!" %}</strong> {% trans "We've sent a confirmation link to your email address." %}
                         </p>
-                        <p>Please click the link in the email to activate your account and complete the registration process.</p>
+                        <p>{% trans "Please click the link in the email to activate your account and complete the registration process." %}</p>
                     </div>
                 </article>
                 <div class="content has-text-centered mt-5">
@@ -28,7 +29,7 @@
                             <span class="icon">
                                 <i class="fas fa-home"></i>
                             </span>
-                            <span>Go to Home</span>
+                            <span>{% trans "Go to Home" %}</span>
                         </a>
                     </div>
                 </div>
@@ -39,28 +40,28 @@
                     <span class="icon">
                         <i class="fas fa-question-circle"></i>
                     </span>
-                    Didn't receive the email?
+                    {% trans "Didn't receive the email?" %}
                 </p>
                 <div class="content">
                     <ul>
-                        <li>Check your spam or junk folder</li>
-                        <li>Make sure you entered the correct email address</li>
-                        <li>Wait a few minutes - emails can be delayed</li>
-                        <li>The confirmation link is valid for 24 hours</li>
+                        <li>{% trans "Check your spam or junk folder" %}</li>
+                        <li>{% trans "Make sure you entered the correct email address" %}</li>
+                        <li>{% trans "Wait a few minutes - emails can be delayed" %}</li>
+                        <li>{% trans "The confirmation link is valid for 24 hours" %}</li>
                     </ul>
                 </div>
             </div>
             {# Support Box #}
             <div class="box has-text-centered">
-                <p class="has-text-weight-bold mb-2">Need help?</p>
-                <p class="mb-3">If you continue to have issues, please contact us</p>
+                <p class="has-text-weight-bold mb-2">{% trans "Need help?" %}</p>
+                <p class="mb-3">{% trans "If you continue to have issues, please contact us" %}</p>
                 <div class="buttons is-centered">
                     <a class="button is-link is-outlined is-small"
                        href="mailto:admin@metron.cloud">
                         <span class="icon">
                             <i class="fas fa-envelope"></i>
                         </span>
-                        <span>Contact Support</span>
+                        <span>{% trans "Contact Support" %}</span>
                     </a>
                     <a class="button is-link is-outlined is-small"
                        href="https://github.com/Metron-Project/metron/discussions"
@@ -69,7 +70,7 @@
                         <span class="icon">
                             <i class="fab fa-github"></i>
                         </span>
-                        <span>GitHub Discussions</span>
+                        <span>{% trans "GitHub Discussions" %}</span>
                     </a>
                 </div>
             </div>

--- a/users/templates/registration/password_change_done.html
+++ b/users/templates/registration/password_change_done.html
@@ -1,6 +1,7 @@
 {% extends parent_template|default:"base.html" %}
+{% load i18n %}
 {% block title %}
-    Password Changed - Metron
+    {% trans "Password Changed - Metron" %}
 {% endblock title %}
 {% block content %}
     {# Success Header #}
@@ -8,7 +9,7 @@
         <span class="icon is-large has-text-success">
             <i class="fas fa-check-circle fa-4x"></i>
         </span>
-        <h1 class="title is-3 mt-4">Password Changed Successfully</h1>
+        <h1 class="title is-3 mt-4">{% trans "Password Changed Successfully" %}</h1>
     </header>
     {# Success Message #}
     <div class="columns is-centered">
@@ -16,8 +17,8 @@
             <div class="box">
                 <article class="message is-success">
                     <div class="message-body">
-                        <p class="mb-3">Your password has been successfully changed!</p>
-                        <p>You can now continue using your account with the new password.</p>
+                        <p class="mb-3">{% trans "Your password has been successfully changed!" %}</p>
+                        <p>{% trans "You can now continue using your account with the new password." %}</p>
                     </div>
                 </article>
                 <div class="content has-text-centered mt-5">
@@ -26,14 +27,14 @@
                             <span class="icon">
                                 <i class="fas fa-home"></i>
                             </span>
-                            <span>Go to Home</span>
+                            <span>{% trans "Go to Home" %}</span>
                         </a>
                         <a class="button is-light is-medium"
                            href="{% url 'user-detail' username=user.username %}">
                             <span class="icon">
                                 <i class="fas fa-user"></i>
                             </span>
-                            <span>View Profile</span>
+                            <span>{% trans "View Profile" %}</span>
                         </a>
                     </div>
                 </div>
@@ -44,14 +45,14 @@
                     <span class="icon">
                         <i class="fas fa-shield-alt"></i>
                     </span>
-                    Security Tip
+                    {% trans "Security Tip" %}
                 </p>
                 <div class="content">
                     <ul>
-                        <li>Keep your password secure and don't share it with anyone</li>
-                        <li>Use a unique password for Metron</li>
-                        <li>Consider using a password manager</li>
-                        <li>Change your password periodically for better security</li>
+                        <li>{% trans "Keep your password secure and don't share it with anyone" %}</li>
+                        <li>{% trans "Use a unique password for Metron" %}</li>
+                        <li>{% trans "Consider using a password manager" %}</li>
+                        <li>{% trans "Change your password periodically for better security" %}</li>
                     </ul>
                 </div>
             </div>

--- a/users/templates/registration/password_change_form.html
+++ b/users/templates/registration/password_change_form.html
@@ -1,8 +1,8 @@
 {% extends parent_template|default:"base.html" %}
 {% load bulma_tags %}
-{% load static %}
+{% load static i18n %}
 {% block title %}
-    Change Password - Metron
+    {% trans "Change Password - Metron" %}
 {% endblock title %}
 {% block content %}
     {# Page Header #}
@@ -10,8 +10,8 @@
         <span class="icon is-large has-text-warning">
             <i class="fas fa-lock fa-3x"></i>
         </span>
-        <h1 class="title is-3 mt-4">Change Your Password</h1>
-        <p class="subtitle has-text-grey">Update your account password</p>
+        <h1 class="title is-3 mt-4">{% trans "Change Your Password" %}</h1>
+        <p class="subtitle has-text-grey">{% trans "Update your account password" %}</p>
     </header>
     {# Password Change Form #}
     <div class="columns is-centered">
@@ -23,7 +23,7 @@
                     {% if form.non_field_errors %}
                         <div class="notification is-danger is-light">
                             <button class="delete"
-                                    aria-label="close"
+                                    aria-label="{% trans 'close' %}"
                                     onclick="this.parentElement.remove();"></button>
                             {% for error in form.non_field_errors %}<p>{{ error }}</p>{% endfor %}
                         </div>
@@ -50,7 +50,7 @@
                                 <span class="icon">
                                     <i class="fas fa-check"></i>
                                 </span>
-                                <span>Change Password</span>
+                                <span>{% trans "Change Password" %}</span>
                             </button>
                         </div>
                     </div>
@@ -62,14 +62,14 @@
                     <span class="icon">
                         <i class="fas fa-shield-alt"></i>
                     </span>
-                    Password Requirements:
+                    {% trans "Password Requirements:" %}
                 </p>
                 <div class="content is-small">
                     <ul>
-                        <li>Your password can't be too similar to your other personal information</li>
-                        <li>Your password must contain at least 8 characters</li>
-                        <li>Your password can't be a commonly used password</li>
-                        <li>Your password can't be entirely numeric</li>
+                        <li>{% trans "Your password can't be too similar to your other personal information" %}</li>
+                        <li>{% trans "Your password must contain at least 8 characters" %}</li>
+                        <li>{% trans "Your password can't be a commonly used password" %}</li>
+                        <li>{% trans "Your password can't be entirely numeric" %}</li>
                     </ul>
                 </div>
             </div>

--- a/users/templates/registration/signup.html
+++ b/users/templates/registration/signup.html
@@ -1,8 +1,8 @@
 {% extends parent_template|default:"base.html" %}
 {% load bulma_tags %}
-{% load static %}
+{% load static i18n %}
 {% block title %}
-    Sign Up - Metron
+    {% trans "Sign Up - Metron" %}
 {% endblock title %}
 {% block headscripts %}
     <script src="https://hcaptcha.com/1/api.js" async defer></script>
@@ -13,8 +13,8 @@
         <span class="icon is-large has-text-primary">
             <i class="fas fa-user-plus fa-3x"></i>
         </span>
-        <h1 class="title is-3 mt-4">Join Metron</h1>
-        <p class="subtitle has-text-grey">Create an account to contribute to the comic book database</p>
+        <h1 class="title is-3 mt-4">{% trans "Join Metron" %}</h1>
+        <p class="subtitle has-text-grey">{% trans "Create an account to contribute to the comic book database" %}</p>
     </header>
     {# Sign Up Form #}
     <div class="columns is-centered">
@@ -27,7 +27,7 @@
                     {% if form.non_field_errors %}
                         <div class="notification is-danger is-light">
                             <button class="delete"
-                                    aria-label="close"
+                                    aria-label="{% trans 'close' %}"
                                     onclick="this.parentElement.remove();"></button>
                             {% for error in form.non_field_errors %}<p>{{ error }}</p>{% endfor %}
                         </div>
@@ -66,28 +66,28 @@
                                 <span class="icon">
                                     <i class="fas fa-user-plus"></i>
                                 </span>
-                                <span>Create Account</span>
+                                <span>{% trans "Create Account" %}</span>
                             </button>
                         </div>
                     </div>
                     {# Additional Links #}
                     <div class="field mt-4">
                         <p class="has-text-centered">
-                            Already have an account?
-                            <a href="{% url 'login' %}" class="has-text-link has-text-weight-bold">Log in here</a>
+                            {% trans "Already have an account?" %}
+                            <a href="{% url 'login' %}" class="has-text-link has-text-weight-bold">{% trans "Log in here" %}</a>
                         </p>
                     </div>
                 </form>
             </div>
             {# Information Box #}
             <div class="notification is-info is-light">
-                <p class="has-text-weight-bold mb-2">Why create an account?</p>
+                <p class="has-text-weight-bold mb-2">{% trans "Why create an account?" %}</p>
                 <div class="content">
                     <ul>
-                        <li>Contribute to the comic book database</li>
-                        <li>Add and edit comic information</li>
-                        <li>Access the API for developers</li>
-                        <li>Join our community of comic enthusiasts</li>
+                        <li>{% trans "Contribute to the comic book database" %}</li>
+                        <li>{% trans "Add and edit comic information" %}</li>
+                        <li>{% trans "Access the API for developers" %}</li>
+                        <li>{% trans "Join our community of comic enthusiasts" %}</li>
                     </ul>
                 </div>
             </div>

--- a/users/templates/registration/signup_rate_limited.html
+++ b/users/templates/registration/signup_rate_limited.html
@@ -1,13 +1,14 @@
 {% extends parent_template|default:"base.html" %}
+{% load i18n %}
 {% block title %}
-    Too Many Signups - Metron
+    {% trans "Too Many Signups - Metron" %}
 {% endblock title %}
 {% block content %}
     <header class="block has-text-centered mt-6">
         <span class="icon is-large has-text-warning">
             <i class="fas fa-hourglass-half fa-4x"></i>
         </span>
-        <h1 class="title is-3 mt-4">Too Many Signups</h1>
+        <h1 class="title is-3 mt-4">{% trans "Too Many Signups" %}</h1>
     </header>
     <div class="columns is-centered">
         <div class="column is-half">
@@ -15,18 +16,18 @@
                 <article class="message is-warning">
                     <div class="message-body">
                         <p>
-                            Too many accounts have recently been created from your network. Please try again later.
+                            {% trans "Too many accounts have recently been created from your network. Please try again later." %}
                         </p>
                     </div>
                 </article>
                 <div class="content has-text-centered mt-5">
                     <div class="buttons is-centered">
-                        <a class="button is-link is-medium" href="{% url 'login' %}">Log In</a>
+                        <a class="button is-link is-medium" href="{% url 'login' %}">{% trans "Log In" %}</a>
                         <a class="button is-link is-medium is-outlined" href="{% url 'home' %}">
                             <span class="icon">
                                 <i class="fas fa-home"></i>
                             </span>
-                            <span>Go to Home</span>
+                            <span>{% trans "Go to Home" %}</span>
                         </a>
                     </div>
                 </div>

--- a/users/templates/registration/signups_disabled.html
+++ b/users/templates/registration/signups_disabled.html
@@ -1,13 +1,14 @@
 {% extends parent_template|default:"base.html" %}
+{% load i18n %}
 {% block title %}
-    Signups Disabled - Metron
+    {% trans "Signups Disabled - Metron" %}
 {% endblock title %}
 {% block content %}
     <header class="block has-text-centered mt-6">
         <span class="icon is-large has-text-warning">
             <i class="fas fa-user-slash fa-4x"></i>
         </span>
-        <h1 class="title is-3 mt-4">Signups Disabled</h1>
+        <h1 class="title is-3 mt-4">{% trans "Signups Disabled" %}</h1>
     </header>
     <div class="columns is-centered">
         <div class="column is-half">
@@ -19,12 +20,12 @@
                 </article>
                 <div class="content has-text-centered mt-5">
                     <div class="buttons is-centered">
-                        <a class="button is-link is-medium" href="{% url 'login' %}">Log In</a>
+                        <a class="button is-link is-medium" href="{% url 'login' %}">{% trans "Log In" %}</a>
                         <a class="button is-link is-medium is-outlined" href="{% url 'home' %}">
                             <span class="icon">
                                 <i class="fas fa-home"></i>
                             </span>
-                            <span>Go to Home</span>
+                            <span>{% trans "Go to Home" %}</span>
                         </a>
                     </div>
                 </div>

--- a/users/templates/users/api_token.html
+++ b/users/templates/users/api_token.html
@@ -1,6 +1,7 @@
 {% extends parent_template|default:"base.html" %}
+{% load i18n %}
 {% block title %}
-    API Tokens - Metron
+    {% trans "API Tokens - Metron" %}
 {% endblock title %}
 {% block content %}
     {# Page Header #}
@@ -8,8 +9,8 @@
         <span class="icon is-large has-text-info">
             <i class="fas fa-key fa-3x"></i>
         </span>
-        <h1 class="title is-3 mt-4">API Tokens</h1>
-        <p class="subtitle has-text-grey">Manage the tokens used to authenticate scripts and apps against the Metron API</p>
+        <h1 class="title is-3 mt-4">{% trans "API Tokens" %}</h1>
+        <p class="subtitle has-text-grey">{% trans "Manage the tokens used to authenticate scripts and apps against the Metron API" %}</p>
     </header>
     <div class="columns is-centered">
         <div class="column is-two-thirds">
@@ -20,7 +21,7 @@
                         <span class="icon">
                             <i class="fas fa-exclamation-circle"></i>
                         </span>
-                        Copy your new token now — it won't be shown again
+                        {% trans "Copy your new token now — it won't be shown again" %}
                     </p>
                     <div class="field has-addons">
                         <div class="control is-expanded">
@@ -35,12 +36,12 @@
                             <button type="button"
                                     class="button copy-id"
                                     data-copy="{{ new_token }}"
-                                    title="Copy token"
-                                    aria-label="Copy token">
+                                    title="{% trans 'Copy token' %}"
+                                    aria-label="{% trans 'Copy token' %}">
                                 <span class="icon">
                                     <i class="fas fa-copy"></i>
                                 </span>
-                                <span>Copy</span>
+                                <span>{% trans "Copy" %}</span>
                             </button>
                         </div>
                     </div>
@@ -48,7 +49,7 @@
             {% endif %}
             {# Create Token Form #}
             <div class="box">
-                <h2 class="title is-5">Generate a New Token</h2>
+                <h2 class="title is-5">{% trans "Generate a New Token" %}</h2>
                 <form method="post">
                     {% csrf_token %}
                     <div class="field has-addons">
@@ -57,32 +58,33 @@
                                    type="text"
                                    name="name"
                                    maxlength="64"
-                                   placeholder="Optional label, e.g. &quot;Mokkari script&quot;">
+                                   placeholder="{% trans 'Optional label, e.g. &quot;Mokkari script&quot;' %}">
                         </div>
                         <div class="control">
                             <button class="button is-primary" type="submit">
                                 <span class="icon">
                                     <i class="fas fa-plus"></i>
                                 </span>
-                                <span>Generate Token</span>
+                                <span>{% trans "Generate Token" %}</span>
                             </button>
                         </div>
                     </div>
                 </form>
                 <p class="help">
-                    Send it as <code>Authorization: Bearer &lt;token&gt;</code>. Tokens don't expire by default — revoke one below if you no longer need it.
+                    {% blocktrans %}Send it as <code>Authorization: Bearer &lt;token&gt;</code>. Tokens don't expire by default — revoke one below if you no longer need it.{% endblocktrans %}
                 </p>
             </div>
             {# Existing Tokens #}
             <div class="box">
-                <h2 class="title is-5">Your Tokens</h2>
+                <h2 class="title is-5">{% trans "Your Tokens" %}</h2>
                 {% if tokens %}
+                    {% trans "Never" as never_text %}
                     <table class="table is-fullwidth is-hoverable">
                         <thead>
                             <tr>
-                                <th>Name</th>
-                                <th>Created</th>
-                                <th>Expires</th>
+                                <th>{% trans "Name" %}</th>
+                                <th>{% trans "Created" %}</th>
+                                <th>{% trans "Expires" %}</th>
                                 <th></th>
                             </tr>
                         </thead>
@@ -91,17 +93,17 @@
                                 <tr>
                                     <td>{{ token.name|default:"—" }}</td>
                                     <td>{{ token.created|date:"N j, Y" }}</td>
-                                    <td>{{ token.expiry|date:"N j, Y"|default:"Never" }}</td>
+                                    <td>{{ token.expiry|date:"N j, Y"|default:never_text }}</td>
                                     <td class="has-text-right">
                                         <form method="post"
                                               action="{% url 'revoke_api_token' digest=token.digest %}"
-                                              onsubmit="return confirm('Revoke this token? Any application using it will stop working immediately.');">
+                                              onsubmit="return confirm('{% filter escapejs %}{% trans "Revoke this token? Any application using it will stop working immediately." %}{% endfilter %}');">
                                             {% csrf_token %}
                                             <button class="button is-small is-danger is-outlined" type="submit">
                                                 <span class="icon">
                                                     <i class="fas fa-trash-alt"></i>
                                                 </span>
-                                                <span>Revoke</span>
+                                                <span>{% trans "Revoke" %}</span>
                                             </button>
                                         </form>
                                     </td>
@@ -110,7 +112,7 @@
                         </tbody>
                     </table>
                 {% else %}
-                    <p class="has-text-grey">You don't have any API tokens yet.</p>
+                    <p class="has-text-grey">{% trans "You don't have any API tokens yet." %}</p>
                 {% endif %}
             </div>
             {# Cancel Link #}
@@ -120,7 +122,7 @@
                     <span class="icon is-small">
                         <i class="fas fa-arrow-left"></i>
                     </span>
-                    <span>Back to Profile</span>
+                    <span>{% trans "Back to Profile" %}</span>
                 </a>
             </p>
         </div>
@@ -135,7 +137,7 @@
                     const value = this.getAttribute('data-copy');
                     navigator.clipboard.writeText(value).then(() => {
                         const originalText = this.innerHTML;
-                        this.innerHTML = '<span class="icon"><i class="fas fa-check"></i></span><span>Copied</span>';
+                        this.innerHTML = '<span class="icon"><i class="fas fa-check"></i></span><span>{% filter escapejs %}{% trans "Copied" %}{% endfilter %}</span>';
                         setTimeout(() => {
                             this.innerHTML = originalText;
                         }, 2000);

--- a/users/templates/users/change_profile.html
+++ b/users/templates/users/change_profile.html
@@ -1,8 +1,8 @@
 {% extends parent_template|default:"base.html" %}
 {% load bulma_tags %}
-{% load static %}
+{% load static i18n %}
 {% block title %}
-    Edit Profile - Metron
+    {% trans "Edit Profile - Metron" %}
 {% endblock title %}
 {% block content %}
     {# Page Header #}
@@ -10,8 +10,8 @@
         <span class="icon is-large has-text-info">
             <i class="fas fa-user-edit fa-3x"></i>
         </span>
-        <h1 class="title is-3 mt-4">Edit Your Profile</h1>
-        <p class="subtitle has-text-grey">Update your account information and preferences</p>
+        <h1 class="title is-3 mt-4">{% trans "Edit Your Profile" %}</h1>
+        <p class="subtitle has-text-grey">{% trans "Update your account information and preferences" %}</p>
     </header>
     {# Profile Edit Form #}
     <div class="columns is-centered">
@@ -23,7 +23,7 @@
                     {% if form.non_field_errors %}
                         <div class="notification is-danger is-light">
                             <button class="delete"
-                                    aria-label="close"
+                                    aria-label="{% trans 'close' %}"
                                     onclick="this.parentElement.remove();"></button>
                             {% for error in form.non_field_errors %}<p>{{ error }}</p>{% endfor %}
                         </div>
@@ -89,14 +89,14 @@
                     {% endfor %}
                     {# Password Change Link #}
                     <div class="field">
-                        <label class="label">Password</label>
+                        <label class="label">{% trans "Password" %}</label>
                         <div class="notification is-light">
                             <p>
                                 <span class="icon">
                                     <i class="fas fa-lock"></i>
                                 </span>
-                                To change your password, please use the
-                                <a href="{% url 'change_password' %}" class="has-text-weight-bold">password change form</a>.
+                                {% trans "To change your password, please use the" %}
+                                <a href="{% url 'change_password' %}" class="has-text-weight-bold">{% trans "password change form" %}</a>.
                             </p>
                         </div>
                     </div>
@@ -108,7 +108,7 @@
                                 <span class="icon">
                                     <i class="fas fa-save"></i>
                                 </span>
-                                <span>Save Changes</span>
+                                <span>{% trans "Save Changes" %}</span>
                             </button>
                         </div>
                         <div class="control">
@@ -117,7 +117,7 @@
                                 <span class="icon">
                                     <i class="fas fa-times"></i>
                                 </span>
-                                <span>Cancel</span>
+                                <span>{% trans "Cancel" %}</span>
                             </a>
                         </div>
                     </div>
@@ -129,14 +129,14 @@
                     <span class="icon">
                         <i class="fas fa-info-circle"></i>
                     </span>
-                    Profile Tips:
+                    {% trans "Profile Tips:" %}
                 </p>
                 <div class="content is-small">
                     <ul>
-                        <li>Your username is visible to other users in the community</li>
-                        <li>Adding a profile image helps others recognize you</li>
-                        <li>Your bio is displayed on your public profile page</li>
-                        <li>Email address is used for notifications and account recovery</li>
+                        <li>{% trans "Your username is visible to other users in the community" %}</li>
+                        <li>{% trans "Adding a profile image helps others recognize you" %}</li>
+                        <li>{% trans "Your bio is displayed on your public profile page" %}</li>
+                        <li>{% trans "Email address is used for notifications and account recovery" %}</li>
                     </ul>
                 </div>
             </div>

--- a/users/templates/users/customuser_detail.html
+++ b/users/templates/users/customuser_detail.html
@@ -2,13 +2,13 @@
 {% load bulma_tags %}
 {% load humanize %}
 {% load thumbnail %}
-{% load static %}
+{% load static i18n %}
 {% block title %}
-    {{ customuser.username }} - Metron
+    {% blocktrans with username=customuser.username %}{{ username }} - Metron{% endblocktrans %}
 {% endblock title %}
 {% block sitedesc %}
     <meta name="description"
-          content="Profile page for {{ customuser.username }} on Metron Comic Book Database.">
+          content="{% blocktrans with username=customuser.username %}Profile page for {{ username }} on Metron Comic Book Database.{% endblocktrans %}">
 {% endblock %}
 {% block content %}
     {# Action Buttons #}
@@ -16,35 +16,35 @@
         <div class="buttons is-right mb-5">
             <a class="button is-primary"
                href="{% url 'change_profile' %}"
-               title="Edit your profile">
+               title="{% trans 'Edit your profile' %}">
                 <span class="icon">
                     <i class="fas fa-edit"></i>
                 </span>
-                <span>Edit Profile</span>
+                <span>{% trans "Edit Profile" %}</span>
             </a>
             <a class="button is-light"
                href="{% url 'change_password' %}"
-               title="Change your password">
+               title="{% trans 'Change your password' %}">
                 <span class="icon">
                     <i class="fas fa-lock"></i>
                 </span>
-                <span>Change Password</span>
+                <span>{% trans "Change Password" %}</span>
             </a>
             <a class="button is-light"
                href="{% url 'api_tokens' %}"
-               title="Manage your API tokens">
+               title="{% trans 'Manage your API tokens' %}">
                 <span class="icon">
                     <i class="fas fa-key"></i>
                 </span>
-                <span>API Tokens</span>
+                <span>{% trans "API Tokens" %}</span>
             </a>
             <a class="button is-danger is-outlined"
                href="{% url 'delete_account' %}"
-               title="Delete your account">
+               title="{% trans 'Delete your account' %}">
                 <span class="icon">
                     <i class="fas fa-trash-alt"></i>
                 </span>
-                <span>Delete Account</span>
+                <span>{% trans "Delete Account" %}</span>
             </a>
         </div>
     {% endif %}
@@ -60,13 +60,13 @@
                                  src="{{ im.url }}"
                                  width="{{ im.width }}"
                                  height="{{ im.height }}"
-                                 alt="Profile picture of {{ customuser.username }}"
+                                 alt="{% blocktrans with username=customuser.username %}Profile picture of {{ username }}{% endblocktrans %}"
                                  loading="lazy">
                         {% endthumbnail %}
                     {% else %}
                         <img class="is-rounded"
                              src="{% static 'site/img/user-not-found.webp' %}"
-                             alt="Default profile picture for {{ customuser.username }}"
+                             alt="{% blocktrans with username=customuser.username %}Default profile picture for {{ username }}{% endblocktrans %}"
                              loading="lazy">
                     {% endif %}
                 </figure>
@@ -80,27 +80,27 @@
                             <span class="is-block-mobile">{{ customuser.get_full_name }}</span>
                             <span class="is-block-mobile mt-2-mobile">
                                 {% if customuser.is_superuser %}
-                                    <span class="tag is-primary" title="Site Administrator">
+                                    <span class="tag is-primary" title="{% trans 'Site Administrator' %}">
                                         <span class="icon is-small">
                                             <i class="fas fa-crown"></i>
                                         </span>
-                                        <span>Admin</span>
+                                        <span>{% trans "Admin" %}</span>
                                     </span>
                                 {% endif %}
                                 {% for group in customuser.groups.all %}
                                     {% if group.name == "editor" %}
-                                        <span class="tag is-info" title="Database Editor">
+                                        <span class="tag is-info" title="{% trans 'Database Editor' %}">
                                             <span class="icon is-small">
                                                 <i class="fas fa-pen"></i>
                                             </span>
-                                            <span>Editor</span>
+                                            <span>{% trans "Editor" %}</span>
                                         </span>
                                     {% elif group.name == "reading list editor" %}
-                                        <span class="tag is-success" title="Reading List Editor">
+                                        <span class="tag is-success" title="{% trans 'Reading List Editor' %}">
                                             <span class="icon is-small">
                                                 <i class="fas fa-book-reader"></i>
                                             </span>
-                                            <span>List Editor</span>
+                                            <span>{% trans "List Editor" %}</span>
                                         </span>
                                     {% endif %}
                                 {% endfor %}
@@ -112,27 +112,27 @@
                             <span class="is-block-mobile">{{ customuser.username }}</span>
                             <span class="is-block-mobile mt-2-mobile">
                                 {% if customuser.is_superuser %}
-                                    <span class="tag is-primary" title="Site Administrator">
+                                    <span class="tag is-primary" title="{% trans 'Site Administrator' %}">
                                         <span class="icon is-small">
                                             <i class="fas fa-crown"></i>
                                         </span>
-                                        <span>Admin</span>
+                                        <span>{% trans "Admin" %}</span>
                                     </span>
                                 {% endif %}
                                 {% for group in customuser.groups.all %}
                                     {% if group.name == "editor" %}
-                                        <span class="tag is-info" title="Database Editor">
+                                        <span class="tag is-info" title="{% trans 'Database Editor' %}">
                                             <span class="icon is-small">
                                                 <i class="fas fa-pen"></i>
                                             </span>
-                                            <span>Editor</span>
+                                            <span>{% trans "Editor" %}</span>
                                         </span>
                                     {% elif group.name == "reading list editor" %}
-                                        <span class="tag is-success" title="Reading List Editor">
+                                        <span class="tag is-success" title="{% trans 'Reading List Editor' %}">
                                             <span class="icon is-small">
                                                 <i class="fas fa-book-reader"></i>
                                             </span>
-                                            <span>List Editor</span>
+                                            <span>{% trans "List Editor" %}</span>
                                         </span>
                                     {% endif %}
                                 {% endfor %}
@@ -143,7 +143,7 @@
                     <div class="level is-mobile mb-4">
                         <div class="level-item has-text-centered">
                             <div>
-                                <p class="heading is-size-7-mobile">Member Since</p>
+                                <p class="heading is-size-7-mobile">{% trans "Member Since" %}</p>
                                 <p class="title is-6 is-size-7-mobile">
                                     <span class="icon has-text-grey is-small" aria-hidden="true">
                                         <i class="fas fa-calendar-alt"></i>
@@ -156,7 +156,7 @@
                         {% if customuser.last_login %}
                             <div class="level-item has-text-centered">
                                 <div>
-                                    <p class="heading is-size-7-mobile">Last Active</p>
+                                    <p class="heading is-size-7-mobile">{% trans "Last Active" %}</p>
                                     <p class="title is-6 is-size-7-mobile">
                                         <span class="icon has-text-grey is-small" aria-hidden="true">
                                             <i class="fas fa-clock"></i>
@@ -175,7 +175,7 @@
                                 <span class="icon has-text-info" aria-hidden="true">
                                     <i class="fas fa-user"></i>
                                 </span>
-                                About
+                                {% trans "About" %}
                             </p>
                             <p class="has-text-dark">{{ customuser.bio }}</p>
                         </div>
@@ -186,8 +186,8 @@
                                     <span class="icon" aria-hidden="true">
                                         <i class="fas fa-info-circle"></i>
                                     </span>
-                                    You haven't added a bio yet.
-                                    <a href="{% url 'change_profile' %}">Add one now</a> to tell others about yourself!
+                                    {% trans "You haven't added a bio yet." %}
+                                    <a href="{% url 'change_profile' %}">{% trans "Add one now" %}</a> {% trans "to tell others about yourself!" %}
                                 </p>
                             </div>
                         {% endif %}
@@ -204,9 +204,9 @@
                     <span class="icon has-text-primary" aria-hidden="true">
                         <i class="fas fa-chart-line"></i>
                     </span>
-                    Database Contributions
+                    {% trans "Database Contributions" %}
                 </h3>
-                <p class="subtitle is-7 has-text-grey mb-4">Items created by this user</p>
+                <p class="subtitle is-7 has-text-grey mb-4">{% trans "Items created by this user" %}</p>
                 {% if stats %}
                     <div class="content">
                         <table class="table is-fullwidth is-hoverable is-narrow-mobile">
@@ -216,7 +216,7 @@
                                         <span class="icon has-text-info" aria-hidden="true">
                                             <i class="fas fa-building"></i>
                                         </span>
-                                        <strong>Publishers</strong>
+                                        <strong>{% trans "Publishers" %}</strong>
                                     </td>
                                     <td class="has-text-right">
                                         <span class="tag is-info is-light stat-tag">{{ stats.publishers|intcomma }}</span>
@@ -227,7 +227,7 @@
                                         <span class="icon has-text-info" aria-hidden="true">
                                             <i class="fas fa-list"></i>
                                         </span>
-                                        <strong>Series</strong>
+                                        <strong>{% trans "Series" %}</strong>
                                     </td>
                                     <td class="has-text-right">
                                         <span class="tag is-info is-light stat-tag">{{ stats.series|intcomma }}</span>
@@ -238,7 +238,7 @@
                                         <span class="icon has-text-info" aria-hidden="true">
                                             <i class="fas fa-book"></i>
                                         </span>
-                                        <strong>Issues</strong>
+                                        <strong>{% trans "Issues" %}</strong>
                                     </td>
                                     <td class="has-text-right">
                                         <span class="tag is-info is-light stat-tag">{{ stats.issues|intcomma }}</span>
@@ -249,7 +249,7 @@
                                         <span class="icon has-text-info" aria-hidden="true">
                                             <i class="fas fa-mask"></i>
                                         </span>
-                                        <strong>Characters</strong>
+                                        <strong>{% trans "Characters" %}</strong>
                                     </td>
                                     <td class="has-text-right">
                                         <span class="tag is-info is-light stat-tag">{{ stats.characters|intcomma }}</span>
@@ -260,7 +260,7 @@
                                         <span class="icon has-text-info" aria-hidden="true">
                                             <i class="fas fa-pencil-alt"></i>
                                         </span>
-                                        <strong>Creators</strong>
+                                        <strong>{% trans "Creators" %}</strong>
                                     </td>
                                     <td class="has-text-right">
                                         <span class="tag is-info is-light stat-tag">{{ stats.creators|intcomma }}</span>
@@ -271,7 +271,7 @@
                                         <span class="icon has-text-info" aria-hidden="true">
                                             <i class="fas fa-users"></i>
                                         </span>
-                                        <strong>Teams</strong>
+                                        <strong>{% trans "Teams" %}</strong>
                                     </td>
                                     <td class="has-text-right">
                                         <span class="tag is-info is-light stat-tag">{{ stats.teams|intcomma }}</span>
@@ -282,7 +282,7 @@
                                         <span class="icon has-text-info" aria-hidden="true">
                                             <i class="fas fa-bookmark"></i>
                                         </span>
-                                        <strong>Imprints</strong>
+                                        <strong>{% trans "Imprints" %}</strong>
                                     </td>
                                     <td class="has-text-right">
                                         <span class="tag is-info is-light stat-tag">{{ stats.imprints|intcomma }}</span>
@@ -293,7 +293,7 @@
                                         <span class="icon has-text-info" aria-hidden="true">
                                             <i class="fas fa-project-diagram"></i>
                                         </span>
-                                        <strong>Arcs</strong>
+                                        <strong>{% trans "Arcs" %}</strong>
                                     </td>
                                     <td class="has-text-right">
                                         <span class="tag is-info is-light stat-tag">{{ stats.arcs|intcomma }}</span>
@@ -304,7 +304,7 @@
                                         <span class="icon has-text-info" aria-hidden="true">
                                             <i class="fas fa-globe"></i>
                                         </span>
-                                        <strong>Universes</strong>
+                                        <strong>{% trans "Universes" %}</strong>
                                     </td>
                                     <td class="has-text-right">
                                         <span class="tag is-info is-light stat-tag">{{ stats.universes|intcomma }}</span>
@@ -320,7 +320,7 @@
                                 <i class="fas fa-chart-bar fa-2x"></i>
                             </span>
                         </p>
-                        <p class="mt-3">No contribution statistics available.</p>
+                        <p class="mt-3">{% trans "No contribution statistics available." %}</p>
                     </div>
                 {% endif %}
             </div>
@@ -332,14 +332,14 @@
                         <span class="icon has-text-info" aria-hidden="true">
                             <i class="fas fa-cog"></i>
                         </span>
-                        Account Settings
+                        {% trans "Account Settings" %}
                     </h3>
                     <div class="content">
                         <p class="mb-3">
                             <span class="icon" aria-hidden="true">
                                 <i class="fas fa-envelope"></i>
                             </span>
-                            <strong>Email:</strong> {{ customuser.email }}
+                            <strong>{% trans "Email:" %}</strong> {{ customuser.email }}
                         </p>
                         <p class="mb-3">
                             <span class="icon" aria-hidden="true">
@@ -349,11 +349,11 @@
                                     <i class="fas fa-exclamation-circle has-text-warning"></i>
                                 {% endif %}
                             </span>
-                            <strong>Email Status:</strong>
+                            <strong>{% trans "Email Status:" %}</strong>
                             {% if customuser.email_confirmed %}
-                                <span class="tag is-success is-light">Confirmed</span>
+                                <span class="tag is-success is-light">{% trans "Confirmed" %}</span>
                             {% else %}
-                                <span class="tag is-warning is-light">Not Confirmed</span>
+                                <span class="tag is-warning is-light">{% trans "Not Confirmed" %}</span>
                             {% endif %}
                         </p>
                         {% if rate_limit %}
@@ -362,14 +362,14 @@
                                     <span class="icon" aria-hidden="true">
                                         <i class="fas fa-tachometer-alt"></i>
                                     </span>
-                                    <strong>Daily API Usage:</strong>
+                                    <strong>{% trans "Daily API Usage:" %}</strong>
                                     {{ rate_limit.used|intcomma }} / {{ rate_limit.limit|intcomma }}
-                                    <span class="has-text-grey is-size-7">({{ rate_limit.remaining|intcomma }} remaining)</span>
+                                    <span class="has-text-grey is-size-7">{% blocktrans with remaining=rate_limit.remaining|intcomma %}({{ remaining }} remaining){% endblocktrans %}</span>
                                 </p>
                                 <progress class="progress {% if rate_limit.percent_used >= 90 %}is-danger{% elif rate_limit.percent_used >= 70 %}is-warning{% else %}is-info{% endif %} is-small"
                                           value="{{ rate_limit.used }}"
                                           max="{{ rate_limit.limit }}"
-                                          title="{{ rate_limit.percent_used }}% used">
+                                          title="{% blocktrans with pct=rate_limit.percent_used %}{{ pct }}% used{% endblocktrans %}">
                                     {{ rate_limit.percent_used }}%
                                 </progress>
                             </div>
@@ -379,9 +379,9 @@
                                 <span class="icon" aria-hidden="true">
                                     <i class="fas fa-heart has-text-danger"></i>
                                 </span>
-                                <strong>Supporter Status:</strong>
+                                <strong>{% trans "Supporter Status:" %}</strong>
                                 <span class="tag is-success is-light">{{ supporter_tier_display }}</span>
-                                <span class="has-text-grey is-size-7">(elevated rate limit until {{ supporter_until|date:"N j, Y" }})</span>
+                                <span class="has-text-grey is-size-7">{% blocktrans with until=supporter_until|date:"N j, Y" %}(elevated rate limit until {{ until }}){% endblocktrans %}</span>
                             </p>
                         {% endif %}
                         <div class="buttons mt-4">
@@ -390,7 +390,7 @@
                                 <span class="icon">
                                     <i class="fas fa-user-cog"></i>
                                 </span>
-                                <span>Manage Settings</span>
+                                <span>{% trans "Manage Settings" %}</span>
                             </a>
                         </div>
                     </div>
@@ -408,7 +408,7 @@
                             <span class="icon has-text-info" aria-hidden="true">
                                 <i class="fas fa-book-open"></i>
                             </span>
-                            Recent Reading Activity
+                            {% trans "Recent Reading Activity" %}
                         </h3>
                     </div>
                 </div>
@@ -420,7 +420,7 @@
                                 <span class="icon is-small">
                                     <i class="fas fa-history"></i>
                                 </span>
-                                <span>View Full History</span>
+                                <span>{% trans "View Full History" %}</span>
                             </a>
                         </div>
                     </div>
@@ -439,7 +439,7 @@
                                             {% endthumbnail %}
                                         {% else %}
                                             <img src="{% static 'site/img/image-not-found.webp' %}"
-                                                 alt="No cover available"
+                                                 alt="{% trans 'No cover available' %}"
                                                  loading="lazy">
                                         {% endif %}
                                     </a>
@@ -483,24 +483,24 @@
     {% if customuser.pk == request.user.pk and not customuser.bio %}
         <div class="notification is-primary is-light">
             <button class="delete"
-                    aria-label="close"
+                    aria-label="{% trans 'close' %}"
                     onclick="this.parentElement.remove();"></button>
             <p class="has-text-weight-bold mb-2">
                 <span class="icon">
                     <i class="fas fa-star"></i>
                 </span>
-                Welcome to Metron!
+                {% trans "Welcome to Metron!" %}
             </p>
             <div class="content">
-                <p>Here are some helpful resources to get you started:</p>
+                <p>{% trans "Here are some helpful resources to get you started:" %}</p>
                 <ul>
                     <li>
-                        <a href="{% url 'wiki:root' %}">Wiki</a> - Learn how to contribute to the database and explore our developer API
+                        <a href="{% url 'wiki:root' %}">{% trans "Wiki" %}</a> - {% trans "Learn how to contribute to the database and explore our developer API" %}
                     </li>
                     <li>
                         <a href="https://github.com/Metron-Project/metron/discussions"
                            target="_blank"
-                           rel="noopener noreferrer">Community Discussions</a> - Join the conversation
+                           rel="noopener noreferrer">{% trans "Community Discussions" %}</a> - {% trans "Join the conversation" %}
                     </li>
                 </ul>
             </div>

--- a/users/templates/users/customuser_list.html
+++ b/users/templates/users/customuser_list.html
@@ -1,21 +1,20 @@
 {% extends parent_template|default:"base.html" %}
 {% load humanize %}
 {% load thumbnail %}
-{% load static %}
+{% load static i18n %}
 {% block title %}
-    Users - Metron
+    {% trans "Users - Metron" %}
 {% endblock title %}
 {% block content %}
     <header class="block has-text-centered">
-        <h1 class="title">Users</h1>
+        <h1 class="title">{% trans "Users" %}</h1>
     </header>
     <section>
-        <nav class="level" aria-label="List navigation and actions">
+        <nav class="level" aria-label="{% trans 'List navigation and actions' %}">
             <div class="level-left">
                 <div class="level-item">
                     <p class="subtitle is-5">
-                        <strong>{{ page_obj.paginator.count|intcomma }}</strong>
-                        User{{ page_obj.paginator.count|pluralize }}
+                        {% blocktrans count counter=page_obj.paginator.count with formatted_count=page_obj.paginator.count|intcomma %}<strong>{{ formatted_count }}</strong> User{% plural %}<strong>{{ formatted_count }}</strong> Users{% endblocktrans %}
                     </p>
                 </div>
                 <div class="level-item">
@@ -23,23 +22,23 @@
                           method="get"
                           accept-charset="utf-8"
                           role="search"
-                          aria-label="Search users">
+                          aria-label="{% trans 'Search users' %}">
                         <div class="field has-addons">
                             <div class="control">
-                                <label for="search-input-user" class="is-sr-only">Search Users</label>
+                                <label for="search-input-user" class="is-sr-only">{% trans "Search Users" %}</label>
                                 <input id="search-input-user"
                                        class="input"
                                        name="q"
                                        type="search"
-                                       placeholder="Find a user"
-                                       aria-label="Find a user">
+                                       placeholder="{% trans 'Find a user' %}"
+                                       aria-label="{% trans 'Find a user' %}">
                             </div>
                             <div class="control">
-                                <button class="button" type="submit" aria-label="Search">
+                                <button class="button" type="submit" aria-label="{% trans 'Search' %}">
                                     <span class="icon" aria-hidden="true">
                                         <i class="fas fa-search"></i>
                                     </span>
-                                    <span>Search</span>
+                                    <span>{% trans "Search" %}</span>
                                 </button>
                             </div>
                         </div>
@@ -62,13 +61,13 @@
                                                      src="{{ im.url }}"
                                                      width="{{ im.width }}"
                                                      height="{{ im.height }}"
-                                                     alt="Profile picture of {{ user.username }}"
+                                                     alt="{% blocktrans with username=user.username %}Profile picture of {{ username }}{% endblocktrans %}"
                                                      loading="lazy">
                                             {% endthumbnail %}
                                         {% else %}
                                             <img class="is-rounded"
                                                  src="{% static 'site/img/user-not-found.webp' %}"
-                                                 alt="Default profile picture"
+                                                 alt="{% trans 'Default profile picture' %}"
                                                  loading="lazy">
                                         {% endif %}
                                     </figure>
@@ -80,7 +79,7 @@
                                         <span class="icon is-small">
                                             <i class="fas fa-calendar-alt"></i>
                                         </span>
-                                        Joined {{ user.date_joined|date:"M Y" }}
+                                        {% blocktrans with joined=user.date_joined|date:"M Y" %}Joined {{ joined }}{% endblocktrans %}
                                     </p>
                                 </div>
                             </article>
@@ -95,7 +94,7 @@
                         <i class="fas fa-users fa-2x"></i>
                     </span>
                 </p>
-                <p class="mt-3">No users found.</p>
+                <p class="mt-3">{% trans "No users found." %}</p>
             </div>
         {% endif %}
     </section>

--- a/users/templates/users/delete_account.html
+++ b/users/templates/users/delete_account.html
@@ -1,6 +1,7 @@
 {% extends parent_template|default:"base.html" %}
+{% load i18n %}
 {% block title %}
-    Delete Account - Metron
+    {% trans "Delete Account - Metron" %}
 {% endblock title %}
 {% block content %}
     <div class="columns is-centered mt-5">
@@ -10,16 +11,16 @@
                     <span class="icon is-large has-text-danger">
                         <i class="fas fa-exclamation-triangle fa-3x"></i>
                     </span>
-                    <h1 class="title is-3 mt-4">Delete Your Account</h1>
-                    <p class="subtitle has-text-grey">This action cannot be undone</p>
+                    <h1 class="title is-3 mt-4">{% trans "Delete Your Account" %}</h1>
+                    <p class="subtitle has-text-grey">{% trans "This action cannot be undone" %}</p>
                 </header>
                 <div class="notification is-danger is-light mb-5">
-                    <p class="has-text-weight-bold mb-2">Warning: Permanent deletion</p>
+                    <p class="has-text-weight-bold mb-2">{% trans "Warning: Permanent deletion" %}</p>
                     <div class="content is-small">
                         <ul>
-                            <li>Your account and all personal data will be permanently deleted</li>
-                            <li>Your reading list and collection data will be removed</li>
-                            <li>Database contributions (issues, creators, etc.) will remain but will no longer be attributed to you</li>
+                            <li>{% trans "Your account and all personal data will be permanently deleted" %}</li>
+                            <li>{% trans "Your reading list and collection data will be removed" %}</li>
+                            <li>{% trans "Database contributions (issues, creators, etc.) will remain but will no longer be attributed to you" %}</li>
                         </ul>
                     </div>
                 </div>
@@ -31,7 +32,7 @@
                                 <span class="icon">
                                     <i class="fas fa-trash-alt"></i>
                                 </span>
-                                <span>Delete My Account</span>
+                                <span>{% trans "Delete My Account" %}</span>
                             </button>
                         </div>
                         <div class="control">
@@ -40,7 +41,7 @@
                                 <span class="icon">
                                     <i class="fas fa-times"></i>
                                 </span>
-                                <span>Cancel</span>
+                                <span>{% trans "Cancel" %}</span>
                             </a>
                         </div>
                     </div>

--- a/users/views.py
+++ b/users/views.py
@@ -16,6 +16,7 @@ from django.urls import reverse, reverse_lazy
 from django.utils.encoding import force_bytes, force_str
 from django.utils.http import urlsafe_base64_decode, urlsafe_base64_encode
 from django.utils.safestring import mark_safe
+from django.utils.translation import gettext as _, gettext_lazy as _lazy
 from django.views.generic import DetailView, ListView
 
 # Import models for counting
@@ -124,9 +125,14 @@ def activate(request, uidb64, token):
         extra={"username": user.username, "ip": ip},
     )
     # Add a message asking the user to star the repository.
-    msg = mark_safe(
-        "If you are planning on adding new information to the database, please refer to the "
-        "<a href='/wiki/editing-guidelines/'>Editing Guidelines</a>."
+    link = f"<a href='/wiki/editing-guidelines/'>{_('Editing Guidelines')}</a>"
+    # Interpolated content is our own translation catalog text, not user input.
+    msg = mark_safe(  # noqa: S308
+        _(
+            "If you are planning on adding new information to the database, please refer "
+            "to the %(link)s."
+        )
+        % {"link": link}
     )
     messages.success(request, msg)
 
@@ -157,7 +163,7 @@ def signup(request):  # sourcery skip: extract-method
                 user.save()
                 _record_signup(request, user.username)
                 current_site = get_current_site(request)
-                subject = "Activate Your Metron Account"
+                subject = _("Activate Your Metron Account")
                 context = {
                     "user": user,
                     "domain": current_site.domain,
@@ -195,7 +201,7 @@ def signup(request):  # sourcery skip: extract-method
 
 class ChangePasswordView(SuccessMessageMixin, PasswordChangeView):
     template_name = "users/change_password.html"
-    success_message = "Successfully Changed Your Password"
+    success_message = _lazy("Successfully Changed Your Password")
     success_url = reverse_lazy("home")
 
 
@@ -207,9 +213,9 @@ def change_profile(request):
         if form.is_valid():
             user = form.save()
             update_session_auth_hash(request, user)  # Important!
-            messages.success(request, "Your profile was successfully updated!")
+            messages.success(request, _("Your profile was successfully updated!"))
             return redirect("user-detail", username=request.user.username)
-        messages.error(request, "Please correct the error below.")
+        messages.error(request, _("Please correct the error below."))
     else:
         form = CustomUserChangeForm(instance=request.user)
     return render(request, "users/change_profile.html", {"form": form})
@@ -222,7 +228,7 @@ def delete_account(request):
         user = request.user
         logout(request)
         user.delete()
-        messages.success(request, "Your account has been deleted.")
+        messages.success(request, _("Your account has been deleted."))
         return redirect("home")
     return render(request, "users/delete_account.html")
 
@@ -236,7 +242,8 @@ def api_tokens(request):
         name = request.POST.get("name", "").strip()
         _instance, new_token = ApiToken.objects.create(user=request.user, name=name)
         messages.success(
-            request, "New API token created. Copy it now — you won't be able to see it again."
+            request,
+            _("New API token created. Copy it now — you won't be able to see it again."),
         )
 
     context = {
@@ -252,7 +259,7 @@ def revoke_api_token(request, digest):
     token = get_object_or_404(ApiToken, digest=digest, user=request.user)
     if request.method == "POST":
         token.delete()
-        messages.success(request, "API token revoked.")
+        messages.success(request, _("API token revoked."))
     return redirect("api_tokens")
 
 

--- a/wish_list/forms.py
+++ b/wish_list/forms.py
@@ -1,4 +1,5 @@
 from django import forms
+from django.utils.translation import gettext_lazy as _
 from djmoney.forms.fields import MoneyField
 
 from comicsdb.autocomplete import IssueAutocomplete
@@ -21,7 +22,7 @@ class WishListItemForm(forms.ModelForm):
             "issue": SafeAutocompleteWidget(
                 ac_class=IssueAutocomplete,
                 attrs={
-                    "placeholder": "Search for an issue...",
+                    "placeholder": _("Search for an issue..."),
                     "class": "input",
                 },
             ),
@@ -37,20 +38,20 @@ class WishListItemForm(forms.ModelForm):
             ),
             "notes": forms.Textarea(
                 attrs={
-                    "placeholder": "Notes about this item (optional)",
+                    "placeholder": _("Notes about this item (optional)"),
                     "rows": 4,
                 }
             ),
         }
         labels = {
-            "desired_grade": "Minimum Grade",
-            "max_price": "Maximum Price",
-            "priority": "Priority (1=Highest)",
+            "desired_grade": _("Minimum Grade"),
+            "max_price": _("Maximum Price"),
+            "priority": _("Priority (1=Highest)"),
         }
         help_texts = {
-            "issue": "Search using 'Series Name (Year) #Number' format.",
-            "desired_grade": "Leave blank if any condition is acceptable.",
-            "priority": "1 is highest priority, 5 is lowest.",
+            "issue": _("Search using 'Series Name (Year) #Number' format."),
+            "desired_grade": _("Leave blank if any condition is acceptable."),
+            "priority": _("1 is highest priority, 5 is lowest."),
         }
 
 
@@ -63,25 +64,25 @@ class AcquireWishListItemForm(forms.Form):
                 "data-bulma-calendar": "on",
             }
         ),
-        label="Purchase Date",
+        label=_("Purchase Date"),
     )
     purchase_price = MoneyField(
         required=False,
         min_value=0,
         decimal_places=2,
         default_currency="USD",
-        label="Price Paid",
+        label=_("Price Paid"),
     )
     purchase_store = forms.CharField(
         max_length=255,
         required=False,
-        widget=forms.TextInput(attrs={"placeholder": "Local Comic Shop"}),
-        label="Store/Vendor",
+        widget=forms.TextInput(attrs={"placeholder": _("Local Comic Shop")}),
+        label=_("Store/Vendor"),
     )
     notes = forms.CharField(
         required=False,
-        widget=forms.Textarea(attrs={"placeholder": "Additional notes", "rows": 3}),
-        label="Notes",
+        widget=forms.Textarea(attrs={"placeholder": _("Additional notes"), "rows": 3}),
+        label=_("Notes"),
     )
 
     def __init__(self, *args, **kwargs):

--- a/wish_list/models.py
+++ b/wish_list/models.py
@@ -1,6 +1,7 @@
 from django.db import models
 from django.db.models.functions import Now
 from django.urls import reverse
+from django.utils.translation import gettext_lazy as _
 from djmoney.models.fields import MoneyField
 
 from comicsdb.models.issue import Issue
@@ -19,8 +20,8 @@ class WishList(models.Model):
 
     class Meta:
         ordering = ["user"]
-        verbose_name = "Wish List"
-        verbose_name_plural = "Wish Lists"
+        verbose_name = _("Wish List")
+        verbose_name_plural = _("Wish Lists")
 
     def __str__(self) -> str:
         return f"{self.user.username}'s Wish List"
@@ -31,9 +32,9 @@ class WishList(models.Model):
 
 class WishListItem(models.Model):
     class Status(models.TextChoices):
-        WANTED = "WANTED", "Wanted"
-        FOUND = "FOUND", "Found"
-        ACQUIRED = "ACQUIRED", "Acquired"
+        WANTED = "WANTED", _("Wanted")
+        FOUND = "FOUND", _("Found")
+        ACQUIRED = "ACQUIRED", _("Acquired")
 
     wish_list = models.ForeignKey(
         WishList,
@@ -62,7 +63,7 @@ class WishListItem(models.Model):
         choices=GRADE_CHOICES,
     )
     max_price = MoneyField(
-        "Maximum Price",
+        _("Maximum Price"),
         max_digits=7,
         decimal_places=2,
         blank=True,
@@ -79,8 +80,8 @@ class WishListItem(models.Model):
             models.Index(fields=["wish_list", "status"], name="wish_list_status_idx"),
             models.Index(fields=["wish_list", "priority"], name="wish_list_priority_idx"),
         ]
-        verbose_name = "Wish List Item"
-        verbose_name_plural = "Wish List Items"
+        verbose_name = _("Wish List Item")
+        verbose_name_plural = _("Wish List Items")
 
     def __str__(self) -> str:
         return f"{self.wish_list.user.username}: {self.issue} ({self.get_status_display()})"

--- a/wish_list/templates/wish_list/partials/wish_list_button.html
+++ b/wish_list/templates/wish_list/partials/wish_list_button.html
@@ -1,11 +1,12 @@
+{% load i18n %}
 <button id="wish-list-btn"
         class="button {% if on_wish_list %}is-warning{% else %}is-light{% endif %}"
         hx-post="{% url 'wish-list:toggle' issue.slug %}"
         hx-target="#wish-list-btn"
         hx-swap="outerHTML"
-        title="{% if on_wish_list %}Remove from wish list{% else %}Add to wish list{% endif %}">
+        title="{% if on_wish_list %}{% trans 'Remove from wish list' %}{% else %}{% trans 'Add to wish list' %}{% endif %}">
     <span class="icon is-small">
         <i class="{% if on_wish_list %}fas{% else %}far{% endif %} fa-bookmark" aria-hidden="true"></i>
     </span>
-    <span>Wish List</span>
+    <span>{% trans "Wish List" %}</span>
 </button>

--- a/wish_list/templates/wish_list/wishlist_acquire_form.html
+++ b/wish_list/templates/wish_list/wishlist_acquire_form.html
@@ -1,10 +1,10 @@
 {% extends parent_template|default:"base.html" %}
-{% load static bulma_tags %}
-{% block title %}Acquire {{ item.issue }} - Metron{% endblock %}
+{% load static bulma_tags i18n %}
+{% block title %}{% blocktrans with issue=item.issue %}Acquire {{ issue }} - Metron{% endblocktrans %}{% endblock %}
 {% block content %}
     <header class="block has-text-centered">
-        <h1 class="title">Acquire Item</h1>
-        <p class="subtitle">Mark <strong>{{ item.issue }}</strong> as acquired</p>
+        <h1 class="title">{% trans "Acquire Item" %}</h1>
+        <p class="subtitle">{% blocktrans with issue=item.issue %}Mark <strong>{{ issue }}</strong> as acquired{% endblocktrans %}</p>
     </header>
     <section class="section">
         <div class="container">
@@ -12,8 +12,7 @@
                 <div class="column is-half">
                     <div class="box">
                         <p class="mb-4">
-                            This will mark <strong>{{ item.issue }}</strong> as acquired on your wish list
-                            and add it to your collection. You can optionally record purchase details below.
+                            {% blocktrans with issue=item.issue %}This will mark <strong>{{ issue }}</strong> as acquired on your wish list and add it to your collection. You can optionally record purchase details below.{% endblocktrans %}
                         </p>
                         <form method="post">
                             {% csrf_token %}
@@ -35,10 +34,10 @@
                             {% endfor %}
                             <div class="field is-grouped is-grouped-right mt-5">
                                 <div class="control">
-                                    <a href="{% url 'wish-list:detail' %}" class="button">Cancel</a>
+                                    <a href="{% url 'wish-list:detail' %}" class="button">{% trans "Cancel" %}</a>
                                 </div>
                                 <div class="control">
-                                    <button type="submit" class="button is-success">Mark as Acquired</button>
+                                    <button type="submit" class="button is-success">{% trans "Mark as Acquired" %}</button>
                                 </div>
                             </div>
                         </form>

--- a/wish_list/templates/wish_list/wishlist_detail.html
+++ b/wish_list/templates/wish_list/wishlist_detail.html
@@ -1,13 +1,13 @@
 {% extends parent_template|default:"base.html" %}
-{% load static %}
-{% block title %}{{ wish_list }} - Metron{% endblock %}
+{% load static i18n %}
+{% block title %}{% blocktrans with name=wish_list %}{{ name }} - Metron{% endblocktrans %}{% endblock %}
 {% block content %}
     <header class="block">
         <h1 class="title">{{ wish_list }}</h1>
     </header>
     {% if is_owner %}
         <div class="box mb-5">
-            <h2 class="title is-5">Add an Issue</h2>
+            <h2 class="title is-5">{% trans "Add an Issue" %}</h2>
             <form method="post">
                 {% csrf_token %}
                 {% if form.non_field_errors %}
@@ -61,7 +61,7 @@
                     <div class="control">
                         <button type="submit" class="button is-primary ">
                             <span class="icon is-small"><i class="fas fa-plus"></i></span>
-                            <span>Add to Wish List</span>
+                            <span>{% trans "Add to Wish List" %}</span>
                         </button>
                     </div>
                 </div>
@@ -70,18 +70,20 @@
     {% endif %}
 
     <div class="box">
-        <h2 class="title is-5">Items ({{ wish_list_items|length }})</h2>
+        <h2 class="title is-5">
+            {% blocktrans with count=wish_list_items|length %}Items ({{ count }}){% endblocktrans %}
+        </h2>
         {% if wish_list_items %}
             <div class="table-container">
                 <table class="table is-fullwidth is-striped is-hoverable">
                     <thead>
                         <tr>
-                            <th>Priority</th>
-                            <th>Issue</th>
-                            <th>Series</th>
-                            <th>Status</th>
-                            <th>Min Grade</th>
-                            <th>Max Price</th>
+                            <th>{% trans "Priority" %}</th>
+                            <th>{% trans "Issue" %}</th>
+                            <th>{% trans "Series" %}</th>
+                            <th>{% trans "Status" %}</th>
+                            <th>{% trans "Min Grade" %}</th>
+                            <th>{% trans "Max Price" %}</th>
                             {% if is_owner %}<th></th>{% endif %}
                         </tr>
                     </thead>
@@ -112,18 +114,18 @@
                                             {% if item.status != 'ACQUIRED' %}
                                                 <a href="{% url 'wish-list:item-acquire' item.pk %}"
                                                    class="button is-success is-outlined"
-                                                   title="Acquire">
+                                                   title="{% trans 'Acquire' %}">
                                                     <span class="icon is-small"><i class="fas fa-shopping-cart"></i></span>
                                                 </a>
                                             {% endif %}
                                             <a href="{% url 'wish-list:item-update' item.pk %}"
                                                class="button is-primary is-outlined"
-                                               title="Edit">
+                                               title="{% trans 'Edit' %}">
                                                 <span class="icon is-small"><i class="fas fa-edit"></i></span>
                                             </a>
                                             <a href="{% url 'wish-list:item-delete' item.pk %}"
                                                class="button is-danger is-outlined"
-                                               title="Remove">
+                                               title="{% trans 'Remove' %}">
                                                 <span class="icon is-small"><i class="fas fa-trash"></i></span>
                                             </a>
                                         </div>
@@ -135,7 +137,7 @@
                 </table>
             </div>
         {% else %}
-            <p class="has-text-grey">No items on this wish list yet.</p>
+            <p class="has-text-grey">{% trans "No items on this wish list yet." %}</p>
         {% endif %}
     </div>
 {% endblock %}

--- a/wish_list/templates/wish_list/wishlist_item_confirm_delete.html
+++ b/wish_list/templates/wish_list/wishlist_item_confirm_delete.html
@@ -1,9 +1,9 @@
 {% extends parent_template|default:"base.html" %}
-{% load static %}
-{% block title %}Remove from Wish List - Metron{% endblock %}
+{% load static i18n %}
+{% block title %}{% trans "Remove from Wish List - Metron" %}{% endblock %}
 {% block content %}
     <header class="block has-text-centered">
-        <h1 class="title">Remove from Wish List</h1>
+        <h1 class="title">{% trans "Remove from Wish List" %}</h1>
     </header>
     <section class="section">
         <div class="container">
@@ -12,23 +12,21 @@
                     <div class="box">
                         <article class="message is-danger">
                             <div class="message-header">
-                                <p>Warning</p>
+                                <p>{% trans "Warning" %}</p>
                             </div>
                             <div class="message-body">
-                                <p>Are you sure you want to remove
-                                    <strong>{{ object.issue }}</strong>
-                                    from your wish list?</p>
-                                <p class="mt-2">This action cannot be undone.</p>
+                                <p>{% blocktrans with issue=object.issue %}Are you sure you want to remove <strong>{{ issue }}</strong> from your wish list?{% endblocktrans %}</p>
+                                <p class="mt-2">{% trans "This action cannot be undone." %}</p>
                             </div>
                         </article>
                         <form method="post">
                             {% csrf_token %}
                             <div class="field is-grouped is-grouped-right">
                                 <div class="control">
-                                    <a href="{% url 'wish-list:detail' %}" class="button">Cancel</a>
+                                    <a href="{% url 'wish-list:detail' %}" class="button">{% trans "Cancel" %}</a>
                                 </div>
                                 <div class="control">
-                                    <button type="submit" class="button is-danger">Remove</button>
+                                    <button type="submit" class="button is-danger">{% trans "Remove" %}</button>
                                 </div>
                             </div>
                         </form>

--- a/wish_list/templates/wish_list/wishlist_item_form.html
+++ b/wish_list/templates/wish_list/wishlist_item_form.html
@@ -1,9 +1,9 @@
 {% extends parent_template|default:"base.html" %}
-{% load static bulma_tags %}
-{% block title %}Edit Wish List Item - Metron{% endblock %}
+{% load static bulma_tags i18n %}
+{% block title %}{% trans "Edit Wish List Item - Metron" %}{% endblock %}
 {% block content %}
     <header class="block has-text-centered">
-        <h1 class="title">Edit Wish List Item</h1>
+        <h1 class="title">{% trans "Edit Wish List Item" %}</h1>
     </header>
     <section class="section">
         <div class="container">
@@ -47,10 +47,10 @@
                             {% endfor %}
                             <div class="field is-grouped is-grouped-right mt-5">
                                 <div class="control">
-                                    <a href="{% url 'wish-list:detail' %}" class="button">Cancel</a>
+                                    <a href="{% url 'wish-list:detail' %}" class="button">{% trans "Cancel" %}</a>
                                 </div>
                                 <div class="control">
-                                    <button type="submit" class="button is-primary">Save Changes</button>
+                                    <button type="submit" class="button is-primary">{% trans "Save Changes" %}</button>
                                 </div>
                             </div>
                         </form>

--- a/wish_list/views.py
+++ b/wish_list/views.py
@@ -3,6 +3,7 @@ from django.contrib.auth.decorators import login_required
 from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse, reverse_lazy
+from django.utils.translation import gettext as _
 from django.views.decorators.http import require_POST
 from django.views.generic import DeleteView, FormView, UpdateView
 
@@ -13,7 +14,7 @@ from wish_list.models import WishList, WishListItem
 
 
 def get_or_create_wish_list(user):
-    wish_list, _ = WishList.objects.get_or_create(user=user)
+    wish_list, _created = WishList.objects.get_or_create(user=user)
     return wish_list
 
 
@@ -30,12 +31,14 @@ class WishListDetailView(LoginRequiredMixin, FormView):
         wish_list = self.get_wish_list()
         issue = form.cleaned_data["issue"]
         if WishListItem.objects.filter(wish_list=wish_list, issue=issue).exists():
-            messages.info(self.request, f"{issue} is already on your wish list.")
+            messages.info(
+                self.request, _("%(issue)s is already on your wish list.") % {"issue": issue}
+            )
             return redirect(self.get_success_url())
         item = form.save(commit=False)
         item.wish_list = wish_list
         item.save()
-        messages.success(self.request, f"Added {issue} to your wish list.")
+        messages.success(self.request, _("Added %(issue)s to your wish list.") % {"issue": issue})
         return redirect(self.get_success_url())
 
     def get_success_url(self):
@@ -63,7 +66,7 @@ class WishListItemUpdateView(LoginRequiredMixin, UserPassesTestMixin, UpdateView
         return self.get_object().wish_list.user == self.request.user
 
     def form_valid(self, form):
-        messages.success(self.request, f"Updated {self.object.issue}.")
+        messages.success(self.request, _("Updated %(issue)s.") % {"issue": self.object.issue})
         return super().form_valid(form)
 
 
@@ -76,7 +79,10 @@ class WishListItemDeleteView(LoginRequiredMixin, UserPassesTestMixin, DeleteView
         return self.get_object().wish_list.user == self.request.user
 
     def form_valid(self, form):
-        messages.success(self.request, f"Removed {self.object.issue} from your wish list.")
+        messages.success(
+            self.request,
+            _("Removed %(issue)s from your wish list.") % {"issue": self.object.issue},
+        )
         return super().form_valid(form)
 
 
@@ -93,7 +99,7 @@ class AcquireWishListItemView(LoginRequiredMixin, UserPassesTestMixin, FormView)
 
     def form_valid(self, form):
         item = self.wish_list_item
-        _, created = CollectionItem.objects.get_or_create(
+        _obj, created = CollectionItem.objects.get_or_create(
             user=self.request.user,
             issue=item.issue,
             defaults={
@@ -106,11 +112,15 @@ class AcquireWishListItemView(LoginRequiredMixin, UserPassesTestMixin, FormView)
         )
         item.status = WishListItem.Status.ACQUIRED
         item.save(update_fields=["status", "modified"])
-        action = "Added to" if created else "Already in"
-        messages.success(
-            self.request,
-            f"{item.issue} marked as acquired! {action} your collection.",
-        )
+        if created:
+            message = _("%(issue)s marked as acquired! Added to your collection.") % {
+                "issue": item.issue
+            }
+        else:
+            message = _("%(issue)s marked as acquired! Already in your collection.") % {
+                "issue": item.issue
+            }
+        messages.success(self.request, message)
         return redirect(self.get_success_url())
 
     def get_success_url(self):
@@ -126,7 +136,7 @@ class AcquireWishListItemView(LoginRequiredMixin, UserPassesTestMixin, FormView)
 @require_POST
 def toggle_wish_list_item(request, slug):
     issue = get_object_or_404(Issue, slug=slug)
-    wish_list, _ = WishList.objects.get_or_create(user=request.user)
+    wish_list, _created = WishList.objects.get_or_create(user=request.user)
     item, created = WishListItem.objects.get_or_create(wish_list=wish_list, issue=issue)
     if not created:
         item.delete()


### PR DESCRIPTION
## Summary

Completes Phase 2 of the internationalization effort (#593), building on the Phase 0/1 infrastructure and pilot slice from #594. Marks up every remaining app for translation and expands the Italian catalog from the pilot's ~108 entries to 1,419 fully translated, zero-fuzzy entries.

**Batches (2a–2h), smallest app first:**
- `timeline`, `api` — incl. 6 DRF serializer `ValidationError`s
- `polls`, `pull_list`
- `wish_list`, `user_collection`
- `users` — incl. the account activation email
- `reading_lists`
- Remaining global `templates/` — error pages, form widget overrides
- `comicsdb` — the whole app: models, forms, views, and all 58 templates
- `api` throttle notice/enforcement emails — deliberately saved for last as the hardest case, restructuring nested `pluralize`/`if` conditionals into proper `ngettext`-style `blocktrans count` blocks

**Notable fixes found along the way:**
- `Series.Status` used Django's auto-generated choice labels, which aren't translatable without an explicit `gettext`-wrapped label — fixed in `comicsdb/models/series.py`.
- `issue_detail.html`/`issue_form.html` had their Python side (model/form/view) marked up in Phase 1 but the templates themselves were never touched — closed that gap here.
- A `blocktrans count` block with mismatched singular/plural placeholder names is a fatal `xgettext` error, not a silent failure — caught and fixed.
- `{% trans %}` doesn't support multi-line string literals the way `{% blocktrans %}` does; it silently renders the tag literally instead of raising. Standardized on `{% blocktrans %}` for any wrapped string.
