### PR TITLE
Add PR template reminding contributors to wrap translatable strings

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+## Description
+
+<!-- What does this PR do, and why? -->
+
+## Checklist
+
+- [ ] Tests pass locally (`pytest`)
+- [ ] Linted (`ruff check . --fix && ruff format .`)
+- [ ] New/changed user-facing strings in templates, forms, and views are
+      wrapped for translation (`{% trans %}`/`{% blocktrans %}` in templates,
+      `gettext`/`gettext_lazy` in Python), and `django-admin makemessages -a`
+      was run to update `locale/*/LC_MESSAGES/django.po` for existing
+      languages
+- [ ] Migrations included, if models changed (`python manage.py makemigrations`)


### PR DESCRIPTION
Closes out the last code-related item on #593 (i18n rollout): a checklist reminder to wrap new user-facing strings for translation and run `makemessages -a` before opening a PR.