### PR TITLE
Grant superusers the Mega Sponsor rate-limit tier by default

### DIFF
--- a/tests/api/test_throttle.py
+++ b/tests/api/test_throttle.py
@@ -156,6 +156,17 @@ def test_supporter_with_blank_tier_falls_back_to_lowest_tier_limit(create_user, 
 
 
 @pytest.mark.django_db
+def test_superuser_gets_mega_sponsor_sustained_limit(create_user, api_client):
+    user = create_user(is_superuser=True)
+    api_client.force_authenticate(user=user)
+
+    resp = api_client.get(reverse("api:arc-list"))
+
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp["X-RateLimit-Sustained-Limit"] == "25000"
+
+
+@pytest.mark.django_db
 def test_non_supporter_gets_default_sustained_limit(api_client_with_credentials):
     resp = api_client_with_credentials.get(reverse("api:arc-list"))
 

--- a/tests/users/test_models.py
+++ b/tests/users/test_models.py
@@ -148,3 +148,22 @@ def test_supporter_daily_limit_falls_back_to_lowest_tier_when_blank(create_user)
     assert user.supporter_tier == ""
     assert user.supporter_daily_limit == SUPPORTER_TIERS[-1][3]
     assert user.supporter_tier_display == SUPPORTER_TIERS[-1][2]
+
+
+def test_superuser_is_mega_sponsor_by_default(create_user):
+    user = create_user(is_superuser=True)
+    assert user.supporter_until is None
+    assert user.supporter_tier == ""
+    assert user.is_supporter is True
+    assert user.supporter_daily_limit == 25000
+    assert user.supporter_tier_display == "Mega Sponsor"
+
+
+def test_superuser_stays_mega_sponsor_regardless_of_real_donation(create_user):
+    """A superuser's real supporter_tier/supporter_until is ignored: the
+    superuser floor always wins."""
+    user = create_user(is_superuser=True)
+    user.supporter_until = timezone.now() + timedelta(days=1)
+    user.supporter_tier = "backer"
+    assert user.supporter_daily_limit == 25000
+    assert user.supporter_tier_display == "Mega Sponsor"

--- a/users/models.py
+++ b/users/models.py
@@ -73,24 +73,32 @@ class CustomUser(AbstractUser):
 
     @property
     def is_supporter(self):
+        if self.is_superuser:
+            return True
         return bool(self.supporter_until and self.supporter_until > timezone.now())
 
     @property
-    def supporter_daily_limit(self) -> int | None:
+    def _effective_tier(self) -> tuple[str, int] | None:
+        """(display_name, daily_limit) for the active tier, or None."""
         if not self.is_supporter:
             return None
+        if self.is_superuser:
+            return _SUPPORTER_TIERS_BY_SLUG["mega_sponsor"]
         tier = _SUPPORTER_TIERS_BY_SLUG.get(self.supporter_tier)
         # Defensive fallback: is_supporter True but supporter_tier blank/unrecognized
         # shouldn't normally happen (the sync command always sets both together), but
         # fail open to the lowest tier (Friend) rather than silently granting nothing.
-        return tier[1] if tier else SUPPORTER_TIERS[-1][3]
+        return tier or _SUPPORTER_TIERS_BY_SLUG[SUPPORTER_TIERS[-1][1]]
+
+    @property
+    def supporter_daily_limit(self) -> int | None:
+        tier = self._effective_tier
+        return tier[1] if tier else None
 
     @property
     def supporter_tier_display(self) -> str | None:
-        if not self.is_supporter:
-            return None
-        tier = _SUPPORTER_TIERS_BY_SLUG.get(self.supporter_tier)
-        return tier[0] if tier else SUPPORTER_TIERS[-1][2]
+        tier = self._effective_tier
+        return tier[0] if tier else None
 
 
 class SignupSettings(models.Model):

--- a/users/templates/users/customuser_detail.html
+++ b/users/templates/users/customuser_detail.html
@@ -381,7 +381,9 @@
                                 </span>
                                 <strong>{% trans "Supporter Status:" %}</strong>
                                 <span class="tag is-success is-light">{{ supporter_tier_display }}</span>
-                                <span class="has-text-grey is-size-7">{% blocktrans with until=supporter_until|date:"N j, Y" %}(elevated rate limit until {{ until }}){% endblocktrans %}</span>
+                                {% if supporter_until %}
+                                    <span class="has-text-grey is-size-7">{% blocktrans with until=supporter_until|date:"N j, Y" %}(elevated rate limit until {{ until }}){% endblocktrans %}</span>
+                                {% endif %}
                             </p>
                         {% endif %}
                         <div class="buttons mt-4">


### PR DESCRIPTION
## Summary
- Superusers now automatically qualify for the top-tier ("Mega Sponsor", 25,000 requests/day) API rate limit, without needing a fake OpenCollective donation record on file.
- `CustomUser.is_supporter` treats `is_superuser` as automatically qualifying; a new `_effective_tier` helper centralizes tier resolution so `supporter_daily_limit` and `supporter_tier_display` stay in sync.
- A superuser's real `supporter_tier`/`supporter_until` (if they also happen to be a genuine donor) is ignored while `is_superuser` is `True` — the superuser floor always wins, since Mega Sponsor is already the highest tier.
- Profile page: the "Supporter Status" badge now hides the "(elevated rate limit until ...)" text when there's no real expiry date, so superusers get a clean "Mega Sponsor" badge instead of a dangling blank date.
- No migration needed — this is pure property logic; the `sync_opencollective_donors` command is unaffected since it only writes the raw fields.
