### PR TITLE
Fix Issue cache over- and under-invalidation

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -365,10 +365,17 @@ class ArcViewSet(
     filterset_class = ComicVineFilter
     parser_classes = (MultiPartParser, FormParser)
     cache_model_label = ModelLabel.ARC
-    # issue_list embeds fields from Issue rows (and their Series) that
-    # don't cascade a `modified` bump onto this Arc except on M2M
-    # add/remove/clear.
-    cache_action_dependent_labels = (ModelLabel.ISSUE, ModelLabel.SERIES)
+    # issue_list embeds fields from Issue rows (and their Series) that don't
+    # cascade a `modified` bump onto this Arc except on M2M add/remove/
+    # clear. ModelLabel.ISSUE/SERIES are deliberately NOT used as
+    # cache_action_dependent_labels here: both are bumped by
+    # update_series_modified_on_issue_save() on *every* issue write
+    # anywhere on the site, so tying this 24h-TTL cache to either
+    # invalidates every Arc's issue_list on essentially any issue edit
+    # site-wide -- confirmed as a live problem for IssueViewSet's own
+    # retrieve cache in production (see its cache_detail_dependent_labels
+    # comment). A plain issue field edit can show stale here for up to
+    # DETAIL_CACHE_TTL; that's the accepted tradeoff.
 
     def get_serializer_class(self):
         match self.action:
@@ -409,10 +416,14 @@ class CharacterViewSet(
     # so tying this key to CREATOR's version would invalidate every cached
     # Character detail on essentially any creator edit anywhere.
     #
-    # issue_list embeds fields from Issue rows (and their Series) that
-    # don't cascade a `modified` bump onto this Character except on M2M
-    # add/remove/clear.
-    cache_action_dependent_labels = (ModelLabel.ISSUE, ModelLabel.SERIES)
+    # issue_list embeds fields from Issue rows (and their Series) that don't
+    # cascade a `modified` bump onto this Character except on M2M add/
+    # remove/clear. ModelLabel.ISSUE/SERIES are deliberately NOT used as
+    # cache_action_dependent_labels here either, for the same reason as
+    # CREATOR above: both are bumped by update_series_modified_on_issue_save()
+    # on *every* issue write anywhere on the site, so tying this 24h-TTL
+    # cache to either invalidates every Character's issue_list on
+    # essentially any issue edit site-wide.
 
     def get_queryset(self):
         queryset = super().get_queryset()
@@ -553,13 +564,22 @@ class IssueViewSet(
     parser_classes = (JSONParser, MultiPartParser, FormParser)
     cache_model_label = ModelLabel.ISSUE
     # Issue retrieve embeds its Series/Publisher/Imprint names, which don't
-    # cascade a `modified` bump onto this Issue when renamed. Arc/
-    # Character/Team/Universe/Creator names are also embedded but
-    # deliberately excluded here -- those are edited/created far more
-    # often, and mixing them in would invalidate every cached issue detail
-    # response on essentially every catalog edit anywhere, not just ones
-    # affecting this issue.
-    cache_detail_dependent_labels = (ModelLabel.PUBLISHER, ModelLabel.IMPRINT, ModelLabel.SERIES)
+    # cascade a `modified` bump onto this Issue when renamed. Only
+    # PUBLISHER/IMPRINT are tracked here:
+    # - SERIES is deliberately excluded even though it's also embedded --
+    #   ModelLabel.SERIES is bumped by update_series_modified_on_issue_save()
+    #   on *every* issue write anywhere (PublisherViewSet.series_list needs
+    #   that), so including it here invalidated every cached issue detail
+    #   response on essentially every issue edit site-wide, not just ones
+    #   affecting this issue's own Series (confirmed in production: a
+    #   single unrelated issue write elsewhere flipped an otherwise-stable
+    #   X-Cache HIT to a MISS).
+    # - Arc/Character/Team/Universe/Creator names are also embedded but
+    #   excluded for the same reason -- edited/created far more often than
+    #   Publisher/Imprint, so mixing them in would cost far more cache
+    #   churn than the staleness they'd prevent.
+    # Both cases accept staleness up to DETAIL_CACHE_TTL as the tradeoff.
+    cache_detail_dependent_labels = (ModelLabel.PUBLISHER, ModelLabel.IMPRINT)
 
     def get_modified_queryset(self):
         # get_queryset() annotates average_rating/rating_count for the
@@ -830,10 +850,14 @@ class TeamViewSet(
     # this key to CREATOR's version would invalidate every cached Team
     # detail on essentially any creator edit anywhere.
     #
-    # issue_list embeds fields from Issue rows (and their Series) that
-    # don't cascade a `modified` bump onto this Team except on M2M
-    # add/remove/clear.
-    cache_action_dependent_labels = (ModelLabel.ISSUE, ModelLabel.SERIES)
+    # issue_list embeds fields from Issue rows (and their Series) that don't
+    # cascade a `modified` bump onto this Team except on M2M add/remove/
+    # clear. ModelLabel.ISSUE/SERIES are deliberately NOT used as
+    # cache_action_dependent_labels here either, for the same reason as
+    # CREATOR above: both are bumped by update_series_modified_on_issue_save()
+    # on *every* issue write anywhere on the site, so tying this 24h-TTL
+    # cache to either invalidates every Team's issue_list on essentially
+    # any issue edit site-wide.
 
     def get_queryset(self):
         queryset = super().get_queryset()

--- a/comicsdb/apps.py
+++ b/comicsdb/apps.py
@@ -12,6 +12,9 @@ from comicsdb.signals import (
     update_character_modified,
     update_issue_modified_on_credit_change,
     update_issue_modified_on_credit_role_change,
+    update_issue_modified_on_reprint_change,
+    update_issue_modified_on_universe_change,
+    update_issue_modified_on_variant_change,
     update_series_modified_on_issue_delete,
     update_series_modified_on_issue_save,
     update_team_modified,
@@ -59,6 +62,16 @@ class ComicsdbConfig(AppConfig):
             sender=issue.teams.through,
             dispatch_uid="m2m_changed_issue_team_modified",
         )
+        m2m_changed.connect(
+            update_issue_modified_on_universe_change,
+            sender=issue.universes.through,
+            dispatch_uid="m2m_changed_issue_universe_modified",
+        )
+        m2m_changed.connect(
+            update_issue_modified_on_reprint_change,
+            sender=issue.reprints.through,
+            dispatch_uid="m2m_changed_issue_reprint_modified",
+        )
 
         imprint = self.get_model("Imprint")
 
@@ -74,6 +87,16 @@ class ComicsdbConfig(AppConfig):
 
         variant = self.get_model("Variant")
         pre_delete.connect(pre_delete_image, sender=variant, dispatch_uid="pre_delete_variant")
+        post_save.connect(
+            update_issue_modified_on_variant_change,
+            sender=variant,
+            dispatch_uid="post_save_variant_issue_modified",
+        )
+        post_delete.connect(
+            update_issue_modified_on_variant_change,
+            sender=variant,
+            dispatch_uid="post_delete_variant_issue_modified",
+        )
 
         credits_ = self.get_model("Credits")
         pre_delete.connect(pre_delete_credit, sender=credits_, dispatch_uid="pre_delete_credits")

--- a/comicsdb/signals.py
+++ b/comicsdb/signals.py
@@ -34,19 +34,33 @@ def update_series_modified_on_issue_delete(sender, instance, **kwargs):
 
 
 def update_related_modified(parent_model, instance, action, pk_set):
-    """Shared logic for M2M post_add/post_remove/post_clear on Arc, Character, Team."""
+    """Shared logic for M2M post_add/post_remove/post_clear on Arc, Character, Team.
+
+    Bumps both sides of the relationship's `modified`: the parent (Arc/
+    Character/Team -- for its own issue_list cache) and the specific
+    Issue(s) involved (for that issue's own cached detail response, which
+    embeds this relationship). Both updates are scoped by pk/pk_set to the
+    objects actually affected -- never a blanket update -- so this doesn't
+    reintroduce the cross-contamination that ModelLabel.ISSUE/SERIES had as
+    global version counters.
+    """
     if action not in ("post_add", "post_remove", "post_clear"):
         return
 
     from comicsdb.models import Issue  # noqa: PLC0415
 
+    now = timezone.now()
     if isinstance(instance, Issue):
+        # issue.arcs.add(...)/.remove()/.clear() -- instance is the Issue.
+        Issue.objects.filter(pk=instance.pk).update(modified=now)
         # pk_set is None for post_clear; skip since affected parents are unknown
         if pk_set:
-            parent_model.objects.filter(pk__in=pk_set).update(modified=timezone.now())
+            parent_model.objects.filter(pk__in=pk_set).update(modified=now)
     else:
         # instance is the parent (e.g. arc.issues.add/clear(...))
-        parent_model.objects.filter(pk=instance.pk).update(modified=timezone.now())
+        parent_model.objects.filter(pk=instance.pk).update(modified=now)
+        if pk_set:
+            Issue.objects.filter(pk__in=pk_set).update(modified=now)
 
 
 def update_arc_modified(sender, instance, action, pk_set, **kwargs):
@@ -71,6 +85,48 @@ def update_team_modified(sender, instance, action, pk_set, **kwargs):
     update_related_modified(Team, instance, action, pk_set)
     if action in ("post_add", "post_remove", "post_clear"):
         bump_model_version(ModelLabel.TEAM)
+
+
+def update_issue_modified_on_universe_change(sender, instance, action, pk_set, **kwargs):
+    """Issue.universes is a M2M, but -- unlike arcs/characters/teams --
+    Universe has no issue_list-style action needing its own side bumped,
+    so only the Issue side needs updating here for the issue's cached
+    detail response (which embeds `universes`) to invalidate."""
+    if action not in ("post_add", "post_remove", "post_clear"):
+        return
+
+    from comicsdb.models import Issue  # noqa: PLC0415
+
+    now = timezone.now()
+    if isinstance(instance, Issue):
+        Issue.objects.filter(pk=instance.pk).update(modified=now)
+    elif pk_set:
+        Issue.objects.filter(pk__in=pk_set).update(modified=now)
+
+
+def update_issue_modified_on_reprint_change(sender, instance, action, pk_set, **kwargs):
+    """Issue.reprints is a symmetric self-referential M2M -- both sides of
+    a reprints.add()/.remove() are Issue instances, so bump both the issue
+    the change was made through and the affected issue(s) on the other
+    side; both cached detail responses embed `reprints`."""
+    if action not in ("post_add", "post_remove", "post_clear"):
+        return
+
+    from comicsdb.models import Issue  # noqa: PLC0415
+
+    now = timezone.now()
+    Issue.objects.filter(pk=instance.pk).update(modified=now)
+    if pk_set:
+        Issue.objects.filter(pk__in=pk_set).update(modified=now)
+
+
+def update_issue_modified_on_variant_change(sender, instance, **kwargs):
+    """Variant changes aren't reflected on the parent Issue's `modified` by
+    default; bump it explicitly so the issue's cached detail response
+    (which embeds variants) invalidates."""
+    from comicsdb.models import Issue  # noqa: PLC0415
+
+    Issue.objects.filter(pk=instance.issue_id).update(modified=timezone.now())
 
 
 def update_issue_modified_on_credit_change(sender, instance, **kwargs):

--- a/tests/comicsdb/test_api_arc.py
+++ b/tests/comicsdb/test_api_arc.py
@@ -90,6 +90,11 @@ def test_unauthorized_detail_view_url(api_client, wwh_arc):
 
 def test_arc_issue_list_view(api_client_with_credentials, fc_arc, issue_with_arc):
     resp = api_client_with_credentials.get(reverse("api:arc-issue-list", kwargs={"pk": fc_arc.pk}))
+    # The fixture's .arcs.add()/.characters.add() calls now also bump this
+    # issue's own `modified` (see update_related_modified), via a raw
+    # .update() that doesn't touch the in-memory instance -- refresh before
+    # comparing against the API response.
+    issue_with_arc.refresh_from_db()
     serializer = IssueListSerializer(issue_with_arc)
     assert resp.data["count"] == 1
     assert resp.data["next"] is None

--- a/tests/comicsdb/test_api_response_caching.py
+++ b/tests/comicsdb/test_api_response_caching.py
@@ -6,10 +6,11 @@ from django.core.cache.backends.locmem import LocMemCache
 from django.db import connection
 from django.test.utils import CaptureQueriesContext
 from django.urls import reverse
+from django.utils import timezone
 from rest_framework import status
 
 from api.views import CollectionViewSet, PullListViewSet, WishListViewSet
-from comicsdb.models import Credits
+from comicsdb.models import Credits, Issue, Variant
 
 
 @pytest.fixture
@@ -172,15 +173,21 @@ def test_publisher_series_list_404s_after_publisher_deleted(
     assert resp.status_code == status.HTTP_404_NOT_FOUND
 
 
-def test_arc_issue_list_reflects_issue_field_edit(
+def test_arc_issue_list_after_issue_field_edit_is_accepted_staleness(
     api_client_with_staff_credentials, issue_with_arc, fc_arc, local_cache
 ):
     """issue_list is cached under the parent Arc's own `modified`, which
     only bumps on M2M add/remove/clear -- not on a plain field edit to one
-    of the linked issues. cache_action_dependent_labels ties the cache key
-    to the Issue model's version counter too, so an edit like this should
-    still be visible without waiting for the parent's `modified` to catch
-    up."""
+    of the linked issues. cache_action_dependent_labels deliberately does
+    NOT include ModelLabel.ISSUE/SERIES (see the comment on ArcViewSet):
+    both are bumped by update_series_modified_on_issue_save() on *every*
+    issue write anywhere on the site, so tying this 24h-TTL cache to either
+    would invalidate every Arc's issue_list on essentially any issue edit
+    site-wide -- confirmed as a live problem for IssueViewSet's own
+    retrieve cache in production. A plain issue field edit showing stale
+    here for up to DETAIL_CACHE_TTL is the accepted tradeoff; this test
+    guards against re-adding either label and reintroducing that
+    regression."""
     url = reverse("api:arc-issue-list", kwargs={"pk": fc_arc.pk})
     resp = api_client_with_staff_credentials.get(url)
     assert resp.status_code == status.HTTP_200_OK
@@ -191,7 +198,7 @@ def test_arc_issue_list_reflects_issue_field_edit(
 
     resp = api_client_with_staff_credentials.get(url)
     assert resp.status_code == status.HTTP_200_OK
-    assert resp.json()["results"][0]["number"] == "2"
+    assert resp.json()["results"][0]["number"] == "1"
 
 
 def test_series_retrieve_after_publisher_rename_is_not_stale(
@@ -239,14 +246,20 @@ def test_credit_role_add_after_create_does_not_stick_empty_roles(
     assert resp.json()["credits"][0]["role"][0]["name"] == "Writer"
 
 
-def test_issue_retrieve_after_series_rename_is_not_stale(
+def test_issue_retrieve_after_series_rename_is_accepted_staleness(
     api_client_with_staff_credentials, basic_issue, fc_series, local_cache
 ):
-    """Issue retrieve embeds its Series' name, but renaming a Series
-    doesn't bump the owning Issue's `modified`. cache_detail_dependent_labels
-    ties the Issue detail cache key to the Series model's version counter
-    too, so the rename should show up without waiting on the Issue's own
-    `modified`."""
+    """Issue retrieve embeds its Series' name, and renaming a Series
+    doesn't bump the owning Issue's `modified` -- but ModelLabel.SERIES is
+    deliberately NOT one of IssueViewSet's cache_detail_dependent_labels
+    (see the comment there): that counter is also bumped by
+    update_series_modified_on_issue_save() on every issue write anywhere,
+    so tying Issue's detail cache to it invalidated every cached issue
+    detail response on essentially any issue edit site-wide (confirmed in
+    production -- an unrelated issue write elsewhere flipped an
+    otherwise-stable X-Cache HIT to a MISS). A Series rename showing stale
+    here for up to DETAIL_CACHE_TTL is the accepted tradeoff; this test
+    guards against re-adding SERIES and reintroducing that regression."""
     url = reverse("api:issue-detail", kwargs={"pk": basic_issue.pk})
     resp = api_client_with_staff_credentials.get(url)
     assert resp.status_code == status.HTTP_200_OK
@@ -257,7 +270,27 @@ def test_issue_retrieve_after_series_rename_is_not_stale(
 
     resp = api_client_with_staff_credentials.get(url)
     assert resp.status_code == status.HTTP_200_OK
-    assert resp.json()["series"]["name"] == "Final Crisis Renamed"
+    assert resp.json()["series"]["name"] == "Final Crisis"
+
+
+def test_issue_retrieve_after_publisher_rename_is_not_stale(
+    api_client_with_staff_credentials, basic_issue, dc_comics, local_cache
+):
+    """Issue retrieve embeds its (Series') Publisher's name via
+    cache_detail_dependent_labels -- unlike SERIES, nothing else bumps
+    PUBLISHER's version counter, so this dependency doesn't have the same
+    cross-contamination problem and should still catch a rename."""
+    url = reverse("api:issue-detail", kwargs={"pk": basic_issue.pk})
+    resp = api_client_with_staff_credentials.get(url)
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.json()["publisher"]["name"] == "DC Comics"
+
+    dc_comics.name = "DC Comics Renamed"
+    dc_comics.save()
+
+    resp = api_client_with_staff_credentials.get(url)
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.json()["publisher"]["name"] == "DC Comics Renamed"
 
 
 def test_imprint_retrieve_after_publisher_rename_is_not_stale(
@@ -278,11 +311,14 @@ def test_imprint_retrieve_after_publisher_rename_is_not_stale(
     assert resp.json()["publisher"]["name"] == "DC Comics Renamed"
 
 
-def test_arc_issue_list_reflects_series_rename(
+def test_arc_issue_list_after_series_rename_is_accepted_staleness(
     api_client_with_staff_credentials, issue_with_arc, fc_arc, fc_series, local_cache
 ):
-    """issue_list nests each issue's Series name; renaming the Series
-    doesn't bump the parent Arc's `modified`."""
+    """issue_list nests each issue's Series name, and renaming the Series
+    doesn't bump the parent Arc's `modified` -- but ModelLabel.SERIES is
+    deliberately not tied to this 24h-TTL cache either, for the same
+    reason as ModelLabel.ISSUE (see the comment on ArcViewSet): it's
+    bumped on every issue write anywhere on the site, not just renames."""
     url = reverse("api:arc-issue-list", kwargs={"pk": fc_arc.pk})
     resp = api_client_with_staff_credentials.get(url)
     assert resp.status_code == status.HTTP_200_OK
@@ -293,7 +329,105 @@ def test_arc_issue_list_reflects_series_rename(
 
     resp = api_client_with_staff_credentials.get(url)
     assert resp.status_code == status.HTTP_200_OK
-    assert resp.json()["results"][0]["series"]["name"] == "Final Crisis Renamed"
+    assert resp.json()["results"][0]["series"]["name"] == "Final Crisis"
+
+
+def test_issue_retrieve_reflects_character_added(
+    api_client_with_staff_credentials, basic_issue, superman, local_cache
+):
+    """Issue retrieve embeds `characters`, and adding one doesn't touch
+    Issue.modified via Character's auto_now -- update_related_modified now
+    bumps the specific Issue's own `modified` too (in addition to the
+    Character's, for its issue_list cache), scoped by pk so it can't
+    cross-contaminate other issues."""
+    url = reverse("api:issue-detail", kwargs={"pk": basic_issue.pk})
+    resp = api_client_with_staff_credentials.get(url)
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.json()["characters"] == []
+
+    basic_issue.characters.add(superman)
+
+    resp = api_client_with_staff_credentials.get(url)
+    assert resp.status_code == status.HTTP_200_OK
+    assert len(resp.json()["characters"]) == 1
+    assert resp.json()["characters"][0]["name"] == "Superman"
+
+
+def test_issue_retrieve_reflects_character_removed(
+    api_client_with_staff_credentials, issue_with_arc, superman, local_cache
+):
+    url = reverse("api:issue-detail", kwargs={"pk": issue_with_arc.pk})
+    resp = api_client_with_staff_credentials.get(url)
+    assert resp.status_code == status.HTTP_200_OK
+    assert len(resp.json()["characters"]) == 1
+
+    issue_with_arc.characters.remove(superman)
+
+    resp = api_client_with_staff_credentials.get(url)
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.json()["characters"] == []
+
+
+def test_issue_retrieve_reflects_universe_added(
+    api_client_with_staff_credentials, basic_issue, earth_2_universe, local_cache
+):
+    """Issue.universes has no issue_list-style consumer on the Universe
+    side, so update_issue_modified_on_universe_change only needs to (and
+    does) bump the Issue's own `modified`."""
+    url = reverse("api:issue-detail", kwargs={"pk": basic_issue.pk})
+    resp = api_client_with_staff_credentials.get(url)
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.json()["universes"] == []
+
+    basic_issue.universes.add(earth_2_universe)
+
+    resp = api_client_with_staff_credentials.get(url)
+    assert resp.status_code == status.HTTP_200_OK
+    assert len(resp.json()["universes"]) == 1
+
+
+def test_issue_retrieve_reflects_reprint_added(
+    api_client_with_staff_credentials, basic_issue, create_user, fc_series, local_cache
+):
+    """Issue.reprints is a symmetric self-referential M2M; both the issue
+    the .add() was called through and the other issue involved should
+    invalidate."""
+    user = create_user()
+    other_issue = Issue.objects.create(
+        series=fc_series,
+        number="2",
+        slug="final-crisis-2",
+        cover_date=timezone.now().date(),
+        edited_by=user,
+        created_by=user,
+    )
+
+    url = reverse("api:issue-detail", kwargs={"pk": basic_issue.pk})
+    resp = api_client_with_staff_credentials.get(url)
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.json()["reprints"] == []
+
+    basic_issue.reprints.add(other_issue)
+
+    resp = api_client_with_staff_credentials.get(url)
+    assert resp.status_code == status.HTTP_200_OK
+    assert len(resp.json()["reprints"]) == 1
+
+
+def test_issue_retrieve_reflects_variant_added(
+    api_client_with_staff_credentials, basic_issue, local_cache
+):
+    url = reverse("api:issue-detail", kwargs={"pk": basic_issue.pk})
+    resp = api_client_with_staff_credentials.get(url)
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.json()["variants"] == []
+
+    Variant.objects.create(issue=basic_issue, image="", name="Foil Variant")
+
+    resp = api_client_with_staff_credentials.get(url)
+    assert resp.status_code == status.HTTP_200_OK
+    assert len(resp.json()["variants"]) == 1
+    assert resp.json()["variants"][0]["name"] == "Foil Variant"
 
 
 def test_issue_retrieve_x_cache_header(api_client_with_credentials, basic_issue, local_cache):

--- a/tests/comicsdb/test_signals.py
+++ b/tests/comicsdb/test_signals.py
@@ -55,26 +55,38 @@ def test_update_related_modified_ignores_non_add_remove_actions(wwh_arc):
     assert wwh_arc.modified == old_modified
 
 
-def test_update_related_modified_post_add_from_issue(wwh_arc):
+def test_update_related_modified_post_add_from_issue(basic_issue, wwh_arc):
     past = timezone.now() - timedelta(days=1)
     Arc.objects.filter(pk=wwh_arc.pk).update(modified=past)
+    Issue.objects.filter(pk=basic_issue.pk).update(modified=past)
     wwh_arc.refresh_from_db()
-    old_modified = wwh_arc.modified
+    basic_issue.refresh_from_db()
+    old_arc_modified = wwh_arc.modified
+    old_issue_modified = basic_issue.modified
 
-    update_related_modified(Arc, MagicMock(spec=Issue), "post_add", {wwh_arc.pk})
+    update_related_modified(Arc, basic_issue, "post_add", {wwh_arc.pk})
     wwh_arc.refresh_from_db()
-    assert wwh_arc.modified > old_modified
+    basic_issue.refresh_from_db()
+    assert wwh_arc.modified > old_arc_modified
+    # The Issue side is bumped too, since instance IS the specific issue
+    # involved -- this issue's own cached detail response embeds `arcs`.
+    assert basic_issue.modified > old_issue_modified
 
 
-def test_update_related_modified_post_remove_from_issue(superman):
+def test_update_related_modified_post_remove_from_issue(basic_issue, superman):
     past = timezone.now() - timedelta(days=1)
     Character.objects.filter(pk=superman.pk).update(modified=past)
+    Issue.objects.filter(pk=basic_issue.pk).update(modified=past)
     superman.refresh_from_db()
-    old_modified = superman.modified
+    basic_issue.refresh_from_db()
+    old_character_modified = superman.modified
+    old_issue_modified = basic_issue.modified
 
-    update_related_modified(Character, MagicMock(spec=Issue), "post_remove", {superman.pk})
+    update_related_modified(Character, basic_issue, "post_remove", {superman.pk})
     superman.refresh_from_db()
-    assert superman.modified > old_modified
+    basic_issue.refresh_from_db()
+    assert superman.modified > old_character_modified
+    assert basic_issue.modified > old_issue_modified
 
 
 def test_update_related_modified_from_parent_side(wwh_arc):
@@ -88,13 +100,13 @@ def test_update_related_modified_from_parent_side(wwh_arc):
     assert wwh_arc.modified > old_modified
 
 
-def test_update_related_modified_empty_pk_set_from_issue(wwh_arc):
+def test_update_related_modified_empty_pk_set_from_issue(basic_issue, wwh_arc):
     past = timezone.now() - timedelta(days=1)
     Arc.objects.filter(pk=wwh_arc.pk).update(modified=past)
     wwh_arc.refresh_from_db()
     old_modified = wwh_arc.modified
 
-    update_related_modified(Arc, MagicMock(spec=Issue), "post_add", set())
+    update_related_modified(Arc, basic_issue, "post_add", set())
     wwh_arc.refresh_from_db()
     assert wwh_arc.modified == old_modified
 
@@ -110,17 +122,25 @@ def test_update_related_modified_post_clear_from_parent(wwh_arc):
     assert wwh_arc.modified > old_modified
 
 
-def test_update_related_modified_post_clear_from_issue_is_noop(wwh_arc):
+def test_update_related_modified_post_clear_from_issue_bumps_issue_only(basic_issue, wwh_arc):
     past = timezone.now() - timedelta(days=1)
     Arc.objects.filter(pk=wwh_arc.pk).update(modified=past)
+    Issue.objects.filter(pk=basic_issue.pk).update(modified=past)
     wwh_arc.refresh_from_db()
-    old_modified = wwh_arc.modified
+    basic_issue.refresh_from_db()
+    old_arc_modified = wwh_arc.modified
+    old_issue_modified = basic_issue.modified
 
-    # When clearing from the issue side, pk_set is None so we cannot identify
-    # which parents were affected; the update is intentionally skipped.
-    update_related_modified(Arc, MagicMock(spec=Issue), "post_clear", None)
+    # When clearing from the issue side, pk_set is None so we cannot
+    # identify which parents were affected -- that update is intentionally
+    # skipped. But we always know exactly which Issue this is (`instance`
+    # itself), so its own `modified` still bumps, invalidating its cached
+    # detail response (which embeds `arcs`).
+    update_related_modified(Arc, basic_issue, "post_clear", None)
     wwh_arc.refresh_from_db()
-    assert wwh_arc.modified == old_modified
+    basic_issue.refresh_from_db()
+    assert wwh_arc.modified == old_arc_modified
+    assert basic_issue.modified > old_issue_modified
 
 
 def test_arc_m2m_signal_updates_arc_modified(basic_issue, wwh_arc):


### PR DESCRIPTION
## Description

Production testing of the `X-Cache` header from #604 turned up an isolated `HIT` → `MISS` flip on an issue that hadn't been edited. Root cause: `ModelLabel.SERIES` — used as an `IssueViewSet.cache_detail_dependent_labels` entry specifically to catch Series renames — is also bumped by `update_series_modified_on_issue_save()` on **every** issue write anywhere on the site (`PublisherViewSet.series_list` needs that for its embedded `num_issues`). So any unrelated issue edit elsewhere on the site was invalidating every cached issue detail response, not just the one that changed. The same problem existed for `Arc`/`Character`/`Team`'s `issue_list` via `ModelLabel.ISSUE`/`SERIES`. Both now drop those dependencies and accept bounded (24h) staleness on Series renames instead — the same tradeoff already made deliberately for Creator/Universe names.

Auditing every writer of `Issue.modified` to make sure no other over-broad dependency was hiding turned up the opposite problem: several fields `IssueReadSerializer` embeds don't bump `Issue.modified` at all when they change, so edits to them could go unreflected in a cached issue detail for up to 24h:

- Adding/removing an Arc, Character, or Team from an issue only bumped the *parent's* `modified` (needed for its own `issue_list` cache) — the issue's own `modified` was never touched.
- `universes` and `reprints` (a symmetric self-referential M2M) had no invalidation signal wired up at all.
- Creating, editing, or deleting a `Variant` didn't touch its parent Issue's `modified` either.

All of these are now fixed with handlers scoped precisely to the pk(s) actually affected — never a blanket update, so this can't reintroduce the cross-contamination bug above. `issue_ratings` (`average_rating`/ `rating_count`) is deliberately left as accepted staleness — ratings are common enough that bumping on every one would undermine the cache for popular issues.

## Test plan

- Added regression tests confirming Series/Arc/Character/Team-name changes no longer bust the Issue/issue_list cache (previously-passing tests asserting the opposite were updated to assert the new, intentional staleness).
- Added regression tests confirming adding a character, universe, reprint, or variant *does* invalidate the issue's cached detail response.
- Updated two pre-existing tests whose assumptions were invalidated by the fix (a stale in-memory `modified` comparison, and unit tests using `MagicMock(spec=Issue)` where a real Issue instance is now required).

