### PR TITLE
Fix cache-key collision between detail and issue_list actions

### DIFF
--- a/api/cache.py
+++ b/api/cache.py
@@ -40,11 +40,20 @@ class ModelLabel(StrEnum):
     UNIVERSE = "universe"
 
 
-def detail_cache_key(model_label: str, pk: Any, modified, *dependent_labels: str) -> str:
+def detail_cache_key(
+    model_label: str, action: str, pk: Any, modified, *dependent_labels: str
+) -> str:
     """Cache key for a single object's serialized detail response.
 
     Self-invalidating: a change to `modified` produces a new key, so old
     entries are simply orphaned and expire via TTL.
+
+    `action` (e.g. "retrieve", "issue_list") distinguishes different
+    endpoints hanging off the same object -- without it, retrieve and a
+    detail-scoped action like issue_list produce the exact same key
+    whenever their dependent_labels happen to match (the common case: both
+    default to no dependent labels), so whichever response was cached first
+    gets served back for the other, wrong shape and all.
 
     `dependent_labels` (optional) mix in other models' version counters, for
     responses that embed data from a related object whose own edits don't
@@ -52,7 +61,7 @@ def detail_cache_key(model_label: str, pk: Any, modified, *dependent_labels: str
     its Publisher's name, but renaming the Publisher doesn't touch the
     Series row).
     """
-    key = f"api:detail:{model_label}:{pk}:{modified.timestamp()}"
+    key = f"api:detail:{model_label}:{action}:{pk}:{modified.timestamp()}"
     if dependent_labels:
         version_map = get_model_versions(dependent_labels)
         versions = "-".join(str(version_map[lbl]) for lbl in dependent_labels)

--- a/api/views.py
+++ b/api/views.py
@@ -224,7 +224,7 @@ class ConditionalRetrieveModelMixin(CachedObjectMixin, mixins.RetrieveModelMixin
             return mixins.RetrieveModelMixin.retrieve(self, request, *args, **kwargs)
 
         key = detail_cache_key(
-            self.cache_model_label, pk, modified, *self.cache_detail_dependent_labels
+            self.cache_model_label, "retrieve", pk, modified, *self.cache_detail_dependent_labels
         )
         cached = cache.get(key)
         if cached is not None:
@@ -294,7 +294,11 @@ class CachedDetailActionMixin(CachedObjectMixin):
         key = None
         if self.cache_model_label and modified is not None:
             key = detail_cache_key(
-                self.cache_model_label, pk, modified, *self.cache_action_dependent_labels
+                self.cache_model_label,
+                self.action,
+                pk,
+                modified,
+                *self.cache_action_dependent_labels,
             )
             cached = cache.get(key)
             if cached is not None:

--- a/tests/comicsdb/test_api_response_caching.py
+++ b/tests/comicsdb/test_api_response_caching.py
@@ -465,6 +465,61 @@ def test_arc_issue_list_x_cache_header(
     assert resp["X-Cache"] == "HIT"
 
 
+def test_arc_retrieve_does_not_poison_issue_list_cache(
+    api_client_with_credentials, issue_with_arc, fc_arc, local_cache
+):
+    """retrieve and issue_list are both cached via detail_cache_key() keyed
+    on (cache_model_label, pk, modified, *dependent_labels). ArcViewSet sets
+    neither cache_detail_dependent_labels nor cache_action_dependent_labels,
+    so without an action discriminator in the key, the two endpoints would
+    collide on the same Redis entry -- whichever ran first would get served
+    back for the other, wrong response shape and all (confirmed live: a
+    /issue_list/ request returning the arc's own detail payload)."""
+    detail_url = reverse("api:arc-detail", kwargs={"pk": fc_arc.pk})
+    resp = api_client_with_credentials.get(detail_url)
+    assert resp.status_code == status.HTTP_200_OK
+
+    issue_list_url = reverse("api:arc-issue-list", kwargs={"pk": fc_arc.pk})
+    resp = api_client_with_credentials.get(issue_list_url)
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp["X-Cache"] == "MISS"
+    body = resp.json()
+    assert "results" in body
+    assert body["results"][0]["number"] == "1"
+
+
+def test_character_retrieve_does_not_poison_issue_list_cache(
+    api_client_with_credentials, issue_with_arc, superman, local_cache
+):
+    detail_url = reverse("api:character-detail", kwargs={"pk": superman.pk})
+    resp = api_client_with_credentials.get(detail_url)
+    assert resp.status_code == status.HTTP_200_OK
+
+    issue_list_url = reverse("api:character-issue-list", kwargs={"pk": superman.pk})
+    resp = api_client_with_credentials.get(issue_list_url)
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp["X-Cache"] == "MISS"
+    body = resp.json()
+    assert "results" in body
+    assert body["results"][0]["number"] == "1"
+
+
+def test_team_retrieve_does_not_poison_issue_list_cache(
+    api_client_with_credentials, multi_story_issue, teen_titans, local_cache
+):
+    detail_url = reverse("api:team-detail", kwargs={"pk": teen_titans.pk})
+    resp = api_client_with_credentials.get(detail_url)
+    assert resp.status_code == status.HTTP_200_OK
+
+    issue_list_url = reverse("api:team-issue-list", kwargs={"pk": teen_titans.pk})
+    resp = api_client_with_credentials.get(issue_list_url)
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp["X-Cache"] == "MISS"
+    body = resp.json()
+    assert "results" in body
+    assert body["results"][0]["number"] == "3"
+
+
 def test_publisher_series_list_x_cache_header(
     api_client_with_credentials, dc_comics, fc_series, local_cache
 ):


### PR DESCRIPTION
## Summary
- `detail_cache_key()` built keys from `(model_label, pk, modified, *dependent_labels)` with nothing identifying which endpoint produced the response. `retrieve` and a detail-scoped action like `issue_list` share the same `cache_model_label`/pk/modified, so whenever their dependent-label tuples also matched -- the default case for `ArcViewSet`/`CharacterViewSet`/`TeamViewSet`, none of which set `cache_detail_dependent_labels` or `cache_action_dependent_labels` -- both computed the identical Redis key. Whichever ran first got cached under it, and the other was served that response back verbatim (e.g. `/api/character/<id>/issue_list/` returning the character's own detail payload instead of its issues).
- Added an `action` discriminator to `detail_cache_key()` (`api/cache.py`) so `retrieve` and any detail-scoped action always land in distinct keys, regardless of dependent-label configuration.
- `PublisherViewSet.series_list` was never affected (keyed via `list_cache_key` with an explicit scope, a different namespace). `SeriesViewSet.issue_list` also wasn't, but only because its non-empty `cache_detail_dependent_labels` happened to produce a differently-shaped key -- verified by reverting the fix and testing both live.

## Tests
- [x] Added `test_arc_retrieve_does_not_poison_issue_list_cache`, `test_character_retrieve_does_not_poison_issue_list_cache`, `test_team_retrieve_does_not_poison_issue_list_cache` to `tests/comicsdb/test_api_response_caching.py`
- [x] Confirmed all three fail on the pre-fix code and pass with the fix
