### PR TITLE
Fix response-cache key collisions on pagination and request host

### DIFF
--- a/api/cache.py
+++ b/api/cache.py
@@ -16,7 +16,7 @@ Two independent invalidation schemes are used, depending on endpoint shape:
 import hashlib
 from collections.abc import Iterable
 from enum import StrEnum
-from typing import Any
+from typing import Any, Protocol
 
 from django.core.cache import cache
 
@@ -40,14 +40,47 @@ class ModelLabel(StrEnum):
     UNIVERSE = "universe"
 
 
+class _CacheKeyRequest(Protocol):
+    """The subset of DRF's Request that cache-key builders need -- narrowed
+    so cache.py doesn't have to import rest_framework.request.Request just
+    to type-hint it."""
+
+    scheme: str
+
+    def get_host(self) -> str: ...
+
+    @property
+    def query_params(self) -> Any: ...
+
+
+def _request_digest(request: _CacheKeyRequest) -> str:
+    """Hash of everything about the request, beyond the object/model being
+    served, that the cached response's content depends on:
+
+    * origin (`{scheme}://{host}`) -- every cached serializer embeds a
+      `resource_url` built via `request.build_absolute_uri()`, so a
+      response cached while serving one scheme/host must not be served
+      back to a request against another.
+    * query params -- required for any paginated endpoint (list, or a
+      detail-scoped action like issue_list), otherwise `?page=1` and
+      `?page=2` compute the same digest and whichever page was cached
+      first gets served back for both. Harmless to include unconditionally
+      for unpaginated endpoints too, since those are never requested with
+      params that change the response.
+    """
+    normalized = f"origin={request.scheme}://{request.get_host()}"
+    query = request.query_params.lists()
+    normalized += "&" + "&".join(f"{k}={v}" for k, v in sorted(query))
+    return hashlib.sha256(normalized.encode()).hexdigest()[:16]
+
+
 def detail_cache_key(
     model_label: str,
     action: str,
     pk: Any,
     modified,
     *dependent_labels: str,
-    origin: str,
-    query: Iterable[tuple[str, list[str]]] | None = None,
+    request: _CacheKeyRequest,
 ) -> str:
     """Cache key for a single object's serialized detail response, or a
     paginated detail-scoped action response (e.g. issue_list).
@@ -68,27 +101,14 @@ def detail_cache_key(
     its Publisher's name, but renaming the Publisher doesn't touch the
     Series row).
 
-    `origin` should be `{request.scheme}://{request.get_host()}` -- every
-    cached serializer embeds a `resource_url` built from the request via
-    `build_absolute_uri()`, so a response cached under one scheme/host would
-    otherwise get served back verbatim, wrong host and all, to a request
-    against another.
-
-    `query` (optional) should come from `request.query_params.lists()`, same
-    as `list_cache_key()` -- required for any paginated action (e.g.
-    issue_list), otherwise `?page=1` and `?page=2` compute the same key and
-    whichever page was cached first gets served back for both. Plain
-    retrieve isn't paginated and omits it.
+    `request` supplies origin and query params -- see `_request_digest()`.
     """
     key = f"api:detail:{model_label}:{action}:{pk}:{modified.timestamp()}"
     if dependent_labels:
         version_map = get_model_versions(dependent_labels)
         versions = "-".join(str(version_map[lbl]) for lbl in dependent_labels)
         key = f"{key}:{versions}"
-    normalized = f"origin={origin}"
-    if query:
-        normalized += "&" + "&".join(f"{k}={v}" for k, v in sorted(query))
-    digest = hashlib.sha256(normalized.encode()).hexdigest()[:16]
+    digest = _request_digest(request)
     return f"{key}:{digest}"
 
 
@@ -134,26 +154,18 @@ def bump_model_version(model_label: str) -> None:
 def list_cache_key(
     model_label: str,
     *dependent_labels: str,
-    query: Iterable[tuple[str, list[str]]],
-    origin: str,
+    request: _CacheKeyRequest,
     scope: str = "",
 ) -> str:
     """Cache key for a list-type response: one or more model versions plus a
-    normalized hash of the request's query params.
-
-    `query` should come from `request.query_params.lists()` (multi-value),
+    normalized hash of the request's origin and query params -- see
+    `_request_digest()`. Uses `request.query_params.lists()` (multi-value),
     not `.dict()` -- `.dict()` silently drops all-but-the-last value for
     repeated params (e.g. IssueFilter's `role_id`), which would let distinct
     multi-value requests collide on the same key.
-
-    `origin` should be `{request.scheme}://{request.get_host()}` -- see
-    `detail_cache_key()`'s docstring; every cached list response nests
-    serialized objects whose `resource_url` is equally request-host-
-    dependent.
     """
     labels = (model_label, *dependent_labels)
     version_map = get_model_versions(labels)
     versions = "-".join(str(version_map[lbl]) for lbl in labels)
-    normalized = f"origin={origin}&" + "&".join(f"{k}={v}" for k, v in sorted(query))
-    digest = hashlib.sha256(normalized.encode()).hexdigest()[:16]
+    digest = _request_digest(request)
     return f"api:list:{model_label}:{scope}:{versions}:{digest}"

--- a/api/cache.py
+++ b/api/cache.py
@@ -41,9 +41,16 @@ class ModelLabel(StrEnum):
 
 
 def detail_cache_key(
-    model_label: str, action: str, pk: Any, modified, *dependent_labels: str
+    model_label: str,
+    action: str,
+    pk: Any,
+    modified,
+    *dependent_labels: str,
+    origin: str,
+    query: Iterable[tuple[str, list[str]]] | None = None,
 ) -> str:
-    """Cache key for a single object's serialized detail response.
+    """Cache key for a single object's serialized detail response, or a
+    paginated detail-scoped action response (e.g. issue_list).
 
     Self-invalidating: a change to `modified` produces a new key, so old
     entries are simply orphaned and expire via TTL.
@@ -60,13 +67,29 @@ def detail_cache_key(
     cascade a `modified` bump onto this one (e.g. a Series response embeds
     its Publisher's name, but renaming the Publisher doesn't touch the
     Series row).
+
+    `origin` should be `{request.scheme}://{request.get_host()}` -- every
+    cached serializer embeds a `resource_url` built from the request via
+    `build_absolute_uri()`, so a response cached under one scheme/host would
+    otherwise get served back verbatim, wrong host and all, to a request
+    against another.
+
+    `query` (optional) should come from `request.query_params.lists()`, same
+    as `list_cache_key()` -- required for any paginated action (e.g.
+    issue_list), otherwise `?page=1` and `?page=2` compute the same key and
+    whichever page was cached first gets served back for both. Plain
+    retrieve isn't paginated and omits it.
     """
     key = f"api:detail:{model_label}:{action}:{pk}:{modified.timestamp()}"
     if dependent_labels:
         version_map = get_model_versions(dependent_labels)
         versions = "-".join(str(version_map[lbl]) for lbl in dependent_labels)
         key = f"{key}:{versions}"
-    return key
+    normalized = f"origin={origin}"
+    if query:
+        normalized += "&" + "&".join(f"{k}={v}" for k, v in sorted(query))
+    digest = hashlib.sha256(normalized.encode()).hexdigest()[:16]
+    return f"{key}:{digest}"
 
 
 def get_model_version(model_label: str) -> int:
@@ -112,6 +135,7 @@ def list_cache_key(
     model_label: str,
     *dependent_labels: str,
     query: Iterable[tuple[str, list[str]]],
+    origin: str,
     scope: str = "",
 ) -> str:
     """Cache key for a list-type response: one or more model versions plus a
@@ -121,10 +145,15 @@ def list_cache_key(
     not `.dict()` -- `.dict()` silently drops all-but-the-last value for
     repeated params (e.g. IssueFilter's `role_id`), which would let distinct
     multi-value requests collide on the same key.
+
+    `origin` should be `{request.scheme}://{request.get_host()}` -- see
+    `detail_cache_key()`'s docstring; every cached list response nests
+    serialized objects whose `resource_url` is equally request-host-
+    dependent.
     """
     labels = (model_label, *dependent_labels)
     version_map = get_model_versions(labels)
     versions = "-".join(str(version_map[lbl]) for lbl in labels)
-    normalized = "&".join(f"{k}={v}" for k, v in sorted(query))
+    normalized = f"origin={origin}&" + "&".join(f"{k}={v}" for k, v in sorted(query))
     digest = hashlib.sha256(normalized.encode()).hexdigest()[:16]
     return f"api:list:{model_label}:{scope}:{versions}:{digest}"

--- a/api/views.py
+++ b/api/views.py
@@ -119,14 +119,6 @@ class ReadingListItemsPagination(PageNumberPagination):
     page_size = 50
 
 
-def _request_origin(request) -> str:
-    """`{scheme}://{host}` for the incoming request -- mixed into every
-    cache key because every cached serializer embeds a `resource_url` built
-    via `request.build_absolute_uri()`, so a response cached under one
-    scheme/host must not be served back to a request against another."""
-    return f"{request.scheme}://{request.get_host()}"
-
-
 def _mark_cache_status(response: Response, *, hit: bool) -> Response:
     """Tag a response with whether it came from the Redis response cache,
     so cache behavior can be checked in production with `curl -I` instead
@@ -237,7 +229,7 @@ class ConditionalRetrieveModelMixin(CachedObjectMixin, mixins.RetrieveModelMixin
             pk,
             modified,
             *self.cache_detail_dependent_labels,
-            origin=_request_origin(request),
+            request=request,
         )
         cached = cache.get(key)
         if cached is not None:
@@ -274,8 +266,7 @@ class CachedListModelMixin(mixins.ListModelMixin):
         key = list_cache_key(
             self.cache_model_label,
             *self.cache_dependent_labels,
-            query=request.query_params.lists(),
-            origin=_request_origin(request),
+            request=request,
         )
         cached = cache.get(key)
         if cached is not None:
@@ -313,8 +304,7 @@ class CachedDetailActionMixin(CachedObjectMixin):
                 pk,
                 modified,
                 *self.cache_action_dependent_labels,
-                origin=_request_origin(self.request),
-                query=self.request.query_params.lists(),
+                request=self.request,
             )
             cached = cache.get(key)
             if cached is not None:
@@ -713,8 +703,7 @@ class PublisherViewSet(
         key = list_cache_key(
             ModelLabel.SERIES,
             ModelLabel.ISSUE,
-            query=self.request.query_params.lists(),
-            origin=_request_origin(request),
+            request=request,
             scope=f"publisher:{pk}:series_list",
         )
         cached = cache.get(key)

--- a/api/views.py
+++ b/api/views.py
@@ -119,6 +119,14 @@ class ReadingListItemsPagination(PageNumberPagination):
     page_size = 50
 
 
+def _request_origin(request) -> str:
+    """`{scheme}://{host}` for the incoming request -- mixed into every
+    cache key because every cached serializer embeds a `resource_url` built
+    via `request.build_absolute_uri()`, so a response cached under one
+    scheme/host must not be served back to a request against another."""
+    return f"{request.scheme}://{request.get_host()}"
+
+
 def _mark_cache_status(response: Response, *, hit: bool) -> Response:
     """Tag a response with whether it came from the Redis response cache,
     so cache behavior can be checked in production with `curl -I` instead
@@ -224,7 +232,12 @@ class ConditionalRetrieveModelMixin(CachedObjectMixin, mixins.RetrieveModelMixin
             return mixins.RetrieveModelMixin.retrieve(self, request, *args, **kwargs)
 
         key = detail_cache_key(
-            self.cache_model_label, "retrieve", pk, modified, *self.cache_detail_dependent_labels
+            self.cache_model_label,
+            "retrieve",
+            pk,
+            modified,
+            *self.cache_detail_dependent_labels,
+            origin=_request_origin(request),
         )
         cached = cache.get(key)
         if cached is not None:
@@ -262,6 +275,7 @@ class CachedListModelMixin(mixins.ListModelMixin):
             self.cache_model_label,
             *self.cache_dependent_labels,
             query=request.query_params.lists(),
+            origin=_request_origin(request),
         )
         cached = cache.get(key)
         if cached is not None:
@@ -299,6 +313,8 @@ class CachedDetailActionMixin(CachedObjectMixin):
                 pk,
                 modified,
                 *self.cache_action_dependent_labels,
+                origin=_request_origin(self.request),
+                query=self.request.query_params.lists(),
             )
             cached = cache.get(key)
             if cached is not None:
@@ -698,6 +714,7 @@ class PublisherViewSet(
             ModelLabel.SERIES,
             ModelLabel.ISSUE,
             query=self.request.query_params.lists(),
+            origin=_request_origin(request),
             scope=f"publisher:{pk}:series_list",
         )
         cached = cache.get(key)

--- a/api/views.py
+++ b/api/views.py
@@ -229,7 +229,7 @@ class ConditionalRetrieveModelMixin(CachedObjectMixin, mixins.RetrieveModelMixin
             pk,
             modified,
             *self.cache_detail_dependent_labels,
-            request=request,
+            request=self.request,
         )
         cached = cache.get(key)
         if cached is not None:

--- a/tests/comicsdb/test_api_response_caching.py
+++ b/tests/comicsdb/test_api_response_caching.py
@@ -8,6 +8,7 @@ from django.test.utils import CaptureQueriesContext
 from django.urls import reverse
 from django.utils import timezone
 from rest_framework import status
+from rest_framework.pagination import PageNumberPagination
 
 from api.views import CollectionViewSet, PullListViewSet, WishListViewSet
 from comicsdb.models import Credits, Issue, Variant
@@ -489,11 +490,15 @@ def test_arc_retrieve_does_not_poison_issue_list_cache(
 
 
 def test_arc_issue_list_pagination_is_not_poisoned_across_pages(
-    api_client_with_credentials, issue_with_arc, fc_arc, fc_series, settings, local_cache
+    api_client_with_credentials, issue_with_arc, fc_arc, fc_series, monkeypatch, local_cache
 ):
     """issue_list's cache key must include the request's query string, since
     ?page=1 and ?page=2 return different data for the same (pk, modified)."""
-    settings.REST_FRAMEWORK = {**settings.REST_FRAMEWORK, "PAGE_SIZE": 1}
+    # PageNumberPagination.page_size is read from api_settings.PAGE_SIZE at
+    # class-definition time, not per-request, so overriding
+    # settings.REST_FRAMEWORK here wouldn't affect it -- patch the class
+    # attribute directly instead.
+    monkeypatch.setattr(PageNumberPagination, "page_size", 1)
 
     second_issue = Issue.objects.create(
         series=fc_series,

--- a/tests/comicsdb/test_api_response_caching.py
+++ b/tests/comicsdb/test_api_response_caching.py
@@ -488,6 +488,55 @@ def test_arc_retrieve_does_not_poison_issue_list_cache(
     assert body["results"][0]["number"] == "1"
 
 
+def test_arc_issue_list_pagination_is_not_poisoned_across_pages(
+    api_client_with_credentials, issue_with_arc, fc_arc, fc_series, settings, local_cache
+):
+    """issue_list's cache key must include the request's query string, since
+    ?page=1 and ?page=2 return different data for the same (pk, modified)."""
+    settings.REST_FRAMEWORK = {**settings.REST_FRAMEWORK, "PAGE_SIZE": 1}
+
+    second_issue = Issue.objects.create(
+        series=fc_series,
+        number="2",
+        slug="final-crisis-2",
+        cover_date=timezone.now().date(),
+        edited_by=issue_with_arc.edited_by,
+        created_by=issue_with_arc.created_by,
+    )
+    second_issue.arcs.add(fc_arc)
+
+    url = reverse("api:arc-issue-list", kwargs={"pk": fc_arc.pk})
+    page_one = api_client_with_credentials.get(url, {"page": 1})
+    assert page_one.status_code == status.HTTP_200_OK
+    assert [r["number"] for r in page_one.json()["results"]] == ["1"]
+
+    page_two = api_client_with_credentials.get(url, {"page": 2})
+    assert page_two.status_code == status.HTTP_200_OK
+    assert [r["number"] for r in page_two.json()["results"]] == ["2"]
+
+
+def test_arc_retrieve_resource_url_is_not_poisoned_across_hosts(
+    api_client_with_credentials, fc_arc, settings, local_cache
+):
+    """resource_url is built from request.build_absolute_uri(), so the
+    cache key must include the request's scheme/host -- otherwise a
+    response cached while serving one hostname gets that hostname baked
+    into resource_url for every other hostname the API is also reachable
+    under."""
+    settings.ALLOWED_HOSTS = [*settings.ALLOWED_HOSTS, "other.example"]
+    url = reverse("api:arc-detail", kwargs={"pk": fc_arc.pk})
+
+    resp = api_client_with_credentials.get(url, HTTP_HOST="testserver")
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp["X-Cache"] == "MISS"
+    assert resp.json()["resource_url"].startswith("http://testserver/")
+
+    resp = api_client_with_credentials.get(url, HTTP_HOST="other.example")
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp["X-Cache"] == "MISS"
+    assert resp.json()["resource_url"].startswith("http://other.example/")
+
+
 def test_character_retrieve_does_not_poison_issue_list_cache(
     api_client_with_credentials, issue_with_arc, superman, local_cache
 ):


### PR DESCRIPTION
## Description

  Fixes two response-cache key collisions found while auditing the recent Redis-backed API caching work (following on from #606's detail/action key collision fix):

  1. **Pagination**: `issue_list` (Arc/Character/Series/Team) is a paginated action, but its cache key was built purely from `(cache_model_label, action, pk, modified, *dependent_labels)`, with no component for the request's query string. `?page=1` and `?page=2` computed the identical Redis key, so whichever page was requested first got served back for both — wrong `results`, wrong `next`/`previous` links — until the parent object's `modified` changed or the 24h TTL expired.

  2. **Request host/scheme**: every cached serializer embeds a `resource_url` built via `request.build_absolute_uri()`, but no cache key varied by the request's scheme/host. A response cached while served under one hostname (`ALLOWED_HOSTS` can list more than one — apex + `www`, an internal health-check host, etc.) had that hostname baked into `resource_url` for every other hostname, for up to `DETAIL_CACHE_TTL`/`LIST_CACHE_TTL`.

  ## Checklist

  - [x] Tests pass locally (`pytest`)
  - [x] Linted (`ruff check . --fix && ruff format .`)
  - [x] New/changed user-facing strings in templates, forms, and views are wrapped for translation (`{% trans %}`/`{% blocktrans %}` in templates, `gettext`/`gettext_lazy` in Python), and `django-admin makemessages -a` was run to update `locale/*/LC_MESSAGES/django.po` for existing languages
  - [x] Migrations included, if models changed (`python manage.py makemigrations`)