### PR TITLE
Fix request shadowing in condition()-wrapped viewset methods

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -194,8 +194,14 @@ class ConditionalRetrieveModelMixin(CachedObjectMixin, mixins.RetrieveModelMixin
     cache_detail_dependent_labels: tuple[str, ...] = ()
 
     def retrieve(self, request, *args, **kwargs):
+        # _cached_retrieve must be passed unbound: rest_framework_condition's
+        # condition() re-supplies `self` itself (it's built to decorate a
+        # plain function via Python's descriptor protocol). Passing an
+        # already-bound method here double-supplies `self`, silently
+        # rebinding _cached_retrieve's `request` param to the ViewSet
+        # instance instead of the real DRF request.
         retrieve = last_modified(last_modified_func=self._retrieve_last_modified)(
-            self._cached_retrieve
+            type(self)._cached_retrieve
         )
 
         return retrieve(self, request, *args, **kwargs)
@@ -335,8 +341,10 @@ class IssueListMixin(CachedDetailActionMixin):
     @extend_schema(responses={200: IssueListSerializer(many=True)}, filters=False)
     @action(detail=True)
     def issue_list(self, request, *args, **kwargs):
+        # See the comment in ConditionalRetrieveModelMixin.retrieve: _issue_list
+        # must be passed unbound for the same reason.
         issue_list = last_modified(last_modified_func=self._issue_list_last_modified)(
-            self._issue_list
+            type(self)._issue_list
         )
 
         return issue_list(self, request, *args, **kwargs)

--- a/tests/comicsdb/test_api_response_caching.py
+++ b/tests/comicsdb/test_api_response_caching.py
@@ -9,7 +9,9 @@ from django.urls import reverse
 from django.utils import timezone
 from rest_framework import status
 from rest_framework.pagination import PageNumberPagination
+from rest_framework.request import Request
 
+from api import views as api_views
 from api.views import CollectionViewSet, PullListViewSet, WishListViewSet
 from comicsdb.models import Credits, Issue, Variant
 
@@ -594,6 +596,35 @@ def test_uncached_viewset_gets_no_x_cache_header(api_client_with_credentials, lo
     resp = api_client_with_credentials.get(reverse("api:pull_list-list"))
     assert resp.status_code == status.HTTP_200_OK
     assert "X-Cache" not in resp
+
+
+def test_cached_retrieve_receives_real_request_object(
+    api_client_with_credentials, basic_issue, local_cache, monkeypatch
+):
+    """ConditionalRetrieveModelMixin.retrieve wraps _cached_retrieve with
+    rest_framework_condition's condition() decorator, which is designed to
+    decorate a plain function and have Python's descriptor protocol supply
+    `self` -- it re-supplies `self` itself internally. Passing an
+    already-bound method there double-supplies `self`, silently rebinding
+    _cached_retrieve's `request` param to the ViewSet instance instead of
+    the real DRF Request (confirmed live: this exact bug was introduced and
+    then papered over with a `self.request` workaround in the commits
+    immediately preceding this test). Guard directly against that
+    regressing by capturing what actually reaches
+    mixins.RetrieveModelMixin.retrieve's `request` argument."""
+    captured = {}
+    original = api_views.mixins.RetrieveModelMixin.retrieve
+
+    def spy(self, request, *args, **kwargs):
+        captured["request"] = request
+        return original(self, request, *args, **kwargs)
+
+    monkeypatch.setattr(api_views.mixins.RetrieveModelMixin, "retrieve", spy)
+
+    url = reverse("api:issue-detail", kwargs={"pk": basic_issue.pk})
+    resp = api_client_with_credentials.get(url)
+    assert resp.status_code == status.HTTP_200_OK
+    assert isinstance(captured["request"], Request)
 
 
 def test_user_scoped_viewsets_are_not_list_cached():


### PR DESCRIPTION
## Summary
- `rest_framework_condition`'s `condition()` decorator is designed to wrap a plain unbound function — it re-supplies `self` internally, expecting Python's descriptor protocol to have not already bound it.
- `ConditionalRetrieveModelMixin.retrieve` and `IssueListMixin.issue_list` instead wrapped an already-bound method (`self._cached_retrieve` / `self._issue_list`), so `self` got supplied twice: the `request` param inside those methods was silently rebound to the ViewSet instance instead of the real DRF request.
- This is the exact bug that was hit and papered over with a `self.request` workaround in #607 (`77415b57` → `6a4e2cd9`) — the workaround masked the symptom but left the underlying footgun in place for the next caller who reaches for the local `request` param.
- Fix: pass the unbound method (`type(self)._cached_retrieve` / `type(self)._issue_list`) so `self` binds correctly through the decorator.

## Test plan
- [x] Added `test_cached_retrieve_receives_real_request_object`, which monkeypatches `mixins.RetrieveModelMixin.retrieve` to capture the `request` it actually receives — fails on the pre-fix code (captures the `IssueViewSet` instance instead of a `Request`) and passes with the fix.
