### PR TITLE
Add average series rating to series detail view

### DIFF
--- a/comicsdb/templates/comicsdb/series_detail.html
+++ b/comicsdb/templates/comicsdb/series_detail.html
@@ -26,6 +26,7 @@
                 <span class="has-text-grey">&middot;</span>
                 <a href="{% url 'imprint:detail' series.imprint.slug %}">{{ series.imprint }}</a>
             {% endif %}
+            {% include "partials/rating_summary.html" with rated_object=series average_rating=series.average_rating rating_count=series.rating_count %}
         </p>
     </header>
     {# Navigation Bar #}

--- a/comicsdb/views/series.py
+++ b/comicsdb/views/series.py
@@ -2,7 +2,7 @@ import logging
 
 from django.conf import global_settings
 from django.contrib.auth.mixins import LoginRequiredMixin, PermissionRequiredMixin
-from django.db.models import Count, OuterRef, Subquery
+from django.db.models import Avg, Count, DecimalField, OuterRef, Subquery
 from django.shortcuts import get_object_or_404
 from django.urls import reverse_lazy
 from django.views.generic import DetailView, ListView
@@ -21,6 +21,7 @@ from comicsdb.views.mixins import (
     SlugRedirectView,
 )
 from comicsdb.views.series_list_helpers import build_active_filters
+from issue_ratings.models import IssueRating
 from pull_list.models import PullListSeries
 
 LOGGER = logging.getLogger(__name__)
@@ -28,6 +29,20 @@ LOGGER = logging.getLogger(__name__)
 _issue_count_sq = (
     Issue.objects.filter(series=OuterRef("pk"))
     .values("series")
+    .annotate(count=Count("pk"))
+    .values("count")
+)
+
+_series_average_rating_sq = (
+    IssueRating.objects.filter(issue__series=OuterRef("pk"))
+    .values("issue__series")
+    .annotate(avg=Avg("rating", output_field=DecimalField(max_digits=3, decimal_places=2)))
+    .values("avg")
+)
+
+_series_rating_count_sq = (
+    IssueRating.objects.filter(issue__series=OuterRef("pk"))
+    .values("issue__series")
     .annotate(count=Count("pk"))
     .values("count")
 )
@@ -81,7 +96,11 @@ class SeriesDetail(DetailView):
     queryset = (
         Series.objects.select_related("publisher", "imprint", "edited_by", "series_type")
         .prefetch_related("issues")
-        .annotate(issue_count=Subquery(_issue_count_sq))
+        .annotate(
+            issue_count=Subquery(_issue_count_sq),
+            average_rating=Subquery(_series_average_rating_sq),
+            rating_count=Subquery(_series_rating_count_sq),
+        )
     )
 
     def get_context_data(self, **kwargs):

--- a/tests/comicsdb/test_series_views.py
+++ b/tests/comicsdb/test_series_views.py
@@ -1,10 +1,13 @@
 import pytest
 from django.urls import reverse
+from django.utils import timezone
 from pytest_django.asserts import assertTemplateUsed
 
 from comicsdb.forms.series import SeriesForm
 from comicsdb.models import Genre, Imprint, Publisher, Series, SeriesType
 from comicsdb.models.attribution import Attribution
+from comicsdb.models.issue import Issue
+from issue_ratings.models import IssueRating
 from pull_list.models import PullList, PullListSeries
 
 HTML_OK_CODE = 200
@@ -60,6 +63,43 @@ def test_series_detail_on_pull_list_true_when_on_list(sandman_series, auto_login
     resp = client.get(f"/series/{sandman_series.slug}/")
     assert resp.status_code == HTML_OK_CODE
     assert resp.context["on_pull_list"] is True
+
+
+def test_series_detail_average_rating_no_ratings(sandman_series, auto_login_user):
+    client, _ = auto_login_user()
+    resp = client.get(f"/series/{sandman_series.slug}/")
+    assert resp.status_code == HTML_OK_CODE
+    assert resp.context["series"].average_rating is None
+    assert resp.context["series"].rating_count is None
+
+
+def test_series_detail_average_rating_across_issues(sandman_series, auto_login_user, create_user):
+    client, user = auto_login_user()
+    other_user = create_user(username="other_rater")
+
+    issue_one = Issue.objects.create(
+        series=sandman_series,
+        number="1",
+        slug="sandman-1",
+        cover_date=timezone.now().date(),
+        edited_by=user,
+        created_by=user,
+    )
+    issue_two = Issue.objects.create(
+        series=sandman_series,
+        number="2",
+        slug="sandman-2",
+        cover_date=timezone.now().date(),
+        edited_by=user,
+        created_by=user,
+    )
+    IssueRating.objects.create(issue=issue_one, user=user, rating=4)
+    IssueRating.objects.create(issue=issue_two, user=other_user, rating=2)
+
+    resp = client.get(f"/series/{sandman_series.slug}/")
+    assert resp.status_code == HTML_OK_CODE
+    assert resp.context["series"].average_rating == 3.0
+    assert resp.context["series"].rating_count == 2
 
 
 def test_series_search_view_url_exists_at_desired_location(auto_login_user):


### PR DESCRIPTION
## Summary
- Annotate `SeriesDetail`'s queryset with `average_rating`/`rating_count`, computed across all `IssueRating`s for the series' issues, via a subquery following the existing `issue_count` pattern.
- Surface the aggregate in the series detail page header using the existing `partials/rating_summary.html` (stars + count), matching how issue detail already shows its own average rating.
- No new "rate this series" widget — ratings remain per-issue; this only displays the read-only aggregate.