### PR TITLE
Show fractional star fill for decimal average ratings

### DIFF
--- a/comicsdb/templatetags/rating_tags.py
+++ b/comicsdb/templatetags/rating_tags.py
@@ -1,0 +1,12 @@
+from django import template
+
+register = template.Library()
+
+
+@register.filter
+def star_fill_percent(average_rating, star_num):
+    """Fill percentage (0-100) for star position `star_num` (1-5) given an average rating."""
+    if not average_rating:
+        return 0
+    fill = float(average_rating) - (int(star_num) - 1)
+    return round(max(0.0, min(1.0, fill)) * 100)

--- a/templates/partials/rating_summary.html
+++ b/templates/partials/rating_summary.html
@@ -1,4 +1,4 @@
-{% load i18n %}
+{% load i18n rating_tags %}
 {% comment %}
 Compact average-rating summary (stars + count), used in page headers.
 
@@ -16,9 +16,15 @@ Required context:
       {% if oob %}hx-swap-oob="true"{% endif %}>
     {% if average_rating %}
         <span class="has-text-grey">&middot;</span>
-        <span style="color: #ffce54;">
+        <span class="rating-summary-stars">
             {% for star_num in "12345" %}
-                <i class="{% if star_num|add:'0' <= average_rating %}fas{% else %}far{% endif %} fa-star"></i>
+                <span class="rating-summary-star">
+                    <i class="far fa-star" style="color: #dbdbdb;"></i>
+                    <span class="rating-summary-star-fill"
+                          style="width: {{ average_rating|star_fill_percent:star_num }}%;">
+                        <i class="fas fa-star" style="color: #ffce54;"></i>
+                    </span>
+                </span>
             {% endfor %}
         </span>
         <span class="has-text-grey ml-1">
@@ -26,3 +32,18 @@ Required context:
         </span>
     {% endif %}
 </span>
+<style>
+    .rating-summary-star {
+        position: relative;
+        display: inline-block;
+    }
+
+    .rating-summary-star-fill {
+        position: absolute;
+        top: 0;
+        left: 0;
+        display: inline-block;
+        overflow: hidden;
+        white-space: nowrap;
+    }
+</style>

--- a/templates/partials/rating_widget.html
+++ b/templates/partials/rating_widget.html
@@ -1,4 +1,4 @@
-{% load i18n %}
+{% load i18n rating_tags %}
 {% comment %}
 Generic 1-5 star rating widget, shared by reading_lists and issue_ratings.
 
@@ -20,8 +20,13 @@ Required context:
             {% if average_rating %}
                 <span class="rating-stars">
                     {% for star_num in "12345" %}
-                        <i class="{% if star_num|add:'0' <= average_rating %}fas{% else %}far{% endif %} fa-star"
-                           style="color: #ffd700"></i>
+                        <span class="rating-widget-star">
+                            <i class="far fa-star" style="color: #dbdbdb;"></i>
+                            <span class="rating-widget-star-fill"
+                                  style="width: {{ average_rating|star_fill_percent:star_num }}%;">
+                                <i class="fas fa-star" style="color: #ffd700;"></i>
+                            </span>
+                        </span>
                     {% endfor %}
                 </span>
                 <span class="rating-value">
@@ -113,6 +118,20 @@ Required context:
         .rating-widget .rating-value {
             margin-left: 0.5rem;
             color: #4a4a4a;
+        }
+
+        .rating-widget .rating-widget-star {
+            position: relative;
+            display: inline-block;
+        }
+
+        .rating-widget .rating-widget-star-fill {
+            position: absolute;
+            top: 0;
+            left: 0;
+            display: inline-block;
+            overflow: hidden;
+            white-space: nowrap;
         }
     </style>
 {% endif %}


### PR DESCRIPTION
## Summary
- Average ratings (e.g. 3.2) previously rendered whole stars only, rounding down and coloring 3 of 5 stars for a 3.2 average with no visual indication of the remaining .2
- Adds a `star_fill_percent` template filter (`comicsdb/templatetags/rating_tags.py`) that computes a 0-100% fill for each star position given a decimal average
- Updates `partials/rating_summary.html` (issue/series detail headers) and the "Average Rating" display in `partials/rating_widget.html` (issue detail page) to render each star as a grey outline with a gold overlay clipped to that percentage, so a 3.2 average now shows stars 1-3 fully filled, star 4 at ~20%, and star 5 empty
- The interactive "Your Rating" stars in `rating_widget.html` are unchanged — user ratings are always whole integers (1-5)
