### PR TITLE
Add STATIC_ROOT and MEDIA_ROOT to .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,11 @@ SECRET_KEY=<Your Secret Key>
 DEBUG=True
 ALLOWED_HOSTS=.localhost,127.0.0.1
 
+# Read when DEBUG is on, i.e. when static and media are served locally
+# rather than from Spaces.
+STATIC_ROOT=staticfiles
+MEDIA_ROOT=media
+
 # ── DigitalOcean Spaces (static + media storage) ──────────────────────────────
 DO_ACCESS_KEY_ID=<DO Access Key ID>
 DO_SECRET_ACCESS_KEY=<DO Secret Access Key>

--- a/.gitignore
+++ b/.gitignore
@@ -82,6 +82,10 @@ celerybeat-schedule
 # dotenv
 .env
 
+# Local static/media (STATIC_ROOT/MEDIA_ROOT)
+staticfiles/
+media/
+
 # virtualenv
 .venv
 venv/


### PR DESCRIPTION
## What happens

`.env.example` opens with `# Copy this file to .env and fill in all values.` Doing exactly that and running `manage.py` fails before anything else:

```
$ cp .env.example .env
$ python -c "from decouple import config; config('STATIC_ROOT')"
UndefinedValueError: STATIC_ROOT not found. Declare it as envvar or define a default value.
```

The example sets `DEBUG=True`, `settings.py:354` branches on `if not DEBUG`, and the local-storage branch reads `config("STATIC_ROOT")` and `config("MEDIA_ROOT")` with no default. Neither name is in the example.

## Why declaring them rather than defaulting them

Of the 19 variables `settings.py` requires without a default, these two were the only ones the example did not declare. The project keeps the example complete, so this follows that rather than adding defaults to `settings.py`.

The values are the conventional Django ones and match how the S3 branch names things.

## Alternative

If you would rather the development path work with no `.env` editing at all, `config("STATIC_ROOT", default=BASE_DIR / "staticfiles")` does that instead, and I can send it that way.
