### PR TITLE
Fix 500 error on API detail lookup with invalid pk

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -1,4 +1,5 @@
 from django.core.cache import cache
+from django.core.exceptions import ValidationError
 from django.db import models
 from django.db.models import (
     Avg,
@@ -175,12 +176,20 @@ class CachedObjectMixin:
                 # Model.objects, so this still respects per-viewset row
                 # scoping (e.g. CollectionViewSet/PullListViewSet/
                 # WishListViewSet filtering by user).
-                row = (
-                    self.filter_queryset(self.get_modified_queryset())
-                    .filter(**{self.lookup_field: pk})
-                    .values_list(self.lookup_field, "modified")
-                    .first()
-                )
+                try:
+                    row = (
+                        self.filter_queryset(self.get_modified_queryset())
+                        .filter(**{self.lookup_field: pk})
+                        .values_list(self.lookup_field, "modified")
+                        .first()
+                    )
+                except ValueError, TypeError, ValidationError:
+                    # Mirrors get_object_or_404()'s handling of a lookup value
+                    # that can't be coerced to the field's type (e.g. a
+                    # non-numeric value against an integer pk) -- treat it as
+                    # "not found" rather than a 500, and let get_object()'s
+                    # own get_object_or_404() raise the real Http404 below.
+                    row = None
                 self._cached_object_modified = row if row else (None, None)
 
         return self._cached_object_modified

--- a/tests/comicsdb/test_api_series.py
+++ b/tests/comicsdb/test_api_series.py
@@ -144,6 +144,13 @@ def test_unauthorized_detail_view_url(api_client, fc_series):
     assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
 
+def test_get_detail_with_non_numeric_pk_returns_404(api_client_with_credentials):
+    resp = api_client_with_credentials.get(
+        reverse("api:series-detail", kwargs={"pk": "does-not-exist-9999"})
+    )
+    assert resp.status_code == status.HTTP_404_NOT_FOUND
+
+
 def test_series_search(api_client_with_credentials, bat_sups_series, fc_series):
     search_term = "batman superman"
     resp = api_client_with_credentials.get(f"/api/series/?name={quote_plus(search_term)}")


### PR DESCRIPTION
## Summary
- Hitting a detail endpoint with a non-numeric pk (e.g. `/api/series/does-not-exist-9999/`) raised an uncaught `ValueError` and returned a 500 instead of a 404.
- `get_object_modified()`'s cheap `(pk, modified)` lookup filtered the queryset directly with the raw URL kwarg, bypassing the exception handling that DRF's `get_object_or_404()` normally provides on the full `get_object()` path.
- Wrap that lookup in `try/except (ValueError, TypeError, ValidationError)` and treat a coercion failure as "not found," falling through to the existing `get_object_or_404()` path so it raises a proper `Http404`.