### PR TITLE
Add cv_id and gcd_id to the series list endpoint

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -670,6 +670,8 @@ Comic book series.
   "year_end": null,
   "volume": 1,
   "issue_count": 900,
+  "cv_id": 18693,
+  "gcd_id": 621,
   "modified": "2025-01-15T10:30:00Z"
 }
 ```
@@ -684,8 +686,6 @@ Comic book series.
     - `desc` - Description
     - `genres` - Array of genre objects
     - `associated` - Associated series
-    - `cv_id` - Comic Vine ID
-    - `gcd_id` - Grand Comics Database ID
     - `resource_url` - Link to web UI
 
 **Series Status Choices:**

--- a/api/v1_0/serializers/__init__.py
+++ b/api/v1_0/serializers/__init__.py
@@ -29,6 +29,7 @@ from api.v1_0.serializers.issue import (
 from api.v1_0.serializers.rating import RatingSerializer
 from api.v1_0.serializers.series import (
     AssociatedSeriesSerializer,
+    PublisherSeriesListSerializer,
     SeriesListSerializer,
     SeriesReadSerializer,
     SeriesSerializer,
@@ -93,6 +94,7 @@ __all__ = [
     "MissingSeriesSerializer",
     "PublisherListSerializer",
     "PublisherSerializer",
+    "PublisherSeriesListSerializer",
     "RatingSerializer",
     "ReadingListItemSerializer",
     "ReadingListListSerializer",

--- a/api/v1_0/serializers/series.py
+++ b/api/v1_0/serializers/series.py
@@ -12,6 +12,21 @@ class SeriesListSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Series
+        fields = (
+            "id",
+            "series",
+            "year_began",
+            "year_end",
+            "volume",
+            "issue_count",
+            "cv_id",
+            "gcd_id",
+            "modified",
+        )
+
+
+class PublisherSeriesListSerializer(SeriesListSerializer):
+    class Meta(SeriesListSerializer.Meta):
         fields = ("id", "series", "year_began", "year_end", "volume", "issue_count", "modified")
 
 

--- a/api/views.py
+++ b/api/views.py
@@ -55,6 +55,7 @@ from api.v1_0.serializers import (
     MissingSeriesSerializer,
     PublisherListSerializer,
     PublisherSerializer,
+    PublisherSeriesListSerializer,
     ReadingListItemSerializer,
     ReadingListListSerializer,
     ReadingListReadSerializer,
@@ -687,11 +688,11 @@ class PublisherViewSet(
             case "list":
                 return PublisherListSerializer
             case "series_list":
-                return SeriesListSerializer
+                return PublisherSeriesListSerializer
             case _:
                 return PublisherSerializer
 
-    @extend_schema(responses={200: SeriesListSerializer(many=True)}, filters=False)
+    @extend_schema(responses={200: PublisherSeriesListSerializer(many=True)}, filters=False)
     @action(detail=True)
     def series_list(self, request, pk=None):
         """
@@ -726,7 +727,7 @@ class PublisherViewSet(
         page = self.paginate_queryset(queryset)
         if page is None:
             raise Http404
-        serializer = SeriesListSerializer(page, many=True, context={"request": request})
+        serializer = PublisherSeriesListSerializer(page, many=True, context={"request": request})
         response = self.get_paginated_response(serializer.data)
         cache.set(key, response.data, LIST_CACHE_TTL)
         return _mark_cache_status(response, hit=False)

--- a/tests/comicsdb/test_api_publisher.py
+++ b/tests/comicsdb/test_api_publisher.py
@@ -3,7 +3,7 @@ from django.db.models import Count
 from django.urls import reverse
 from rest_framework import status
 
-from api.v1_0.serializers import SeriesListSerializer
+from api.v1_0.serializers import PublisherSeriesListSerializer
 from comicsdb.models import Series
 
 
@@ -199,7 +199,7 @@ def test_publisher_series_list_view(api_client_with_credentials, dc_comics, fc_s
         .annotate(num_issues=Count("issues", distinct=True))
         .first()
     )
-    serializer = SeriesListSerializer(series)
+    serializer = PublisherSeriesListSerializer(series)
     assert resp.data["count"] == 1
     assert resp.data["next"] is None
     assert resp.data["previous"] is None


### PR DESCRIPTION
## Summary
- Add `cv_id` and `gcd_id` to `SeriesListSerializer`, so `GET /api/series/` now returns each series' external Comic Vine / GCD IDs in the list response
- Split off `PublisherSeriesListSerializer` (same fields as before) for the `GET /api/publisher/{id}/series_list/` action, since it shared the same serializer — this keeps that endpoint's response unchanged and scopes the new fields to the top-level series list
- Update `api/README.md`'s series list example accordingly
