### PR TITLE
Close remaining API cache staleness gaps

### DIFF
--- a/api/cache.py
+++ b/api/cache.py
@@ -20,7 +20,7 @@ from typing import Any, Protocol
 
 from django.core.cache import cache
 
-DETAIL_CACHE_TTL = 60 * 60 * 24  # 24h safety net; live keys self-invalidate on write.
+DETAIL_CACHE_TTL = 60 * 60 * 48  # 48h safety net; live keys self-invalidate on write.
 LIST_CACHE_TTL = 60 * 2  # 2min; bounds staleness from nested-object changes we don't chase.
 
 _VERSION_KEY_PREFIX = "cachever"

--- a/api/views.py
+++ b/api/views.py
@@ -436,18 +436,19 @@ class CharacterViewSet(
     filterset_class = ComicVineFilter
     parser_classes = (MultiPartParser, FormParser)
     cache_model_label = ModelLabel.CHARACTER
-    # retrieve also embeds Creator/Universe names (CharacterReadSerializer)
+    # retrieve also embeds Creator/Team/Universe names (CharacterReadSerializer)
     # that don't cascade a `modified` bump onto this Character either.
-    # UNIVERSE is tracked here: only ~180 rows site-wide and genuinely
-    # low-churn (~1.03 saves/row historically), so tying the key to it costs
-    # little. CREATOR is deliberately NOT tracked -- ~17.8k rows and ~100x
-    # UNIVERSE's total write volume (measured via historical save counts),
-    # so tying this key to CREATOR's version would invalidate every cached
-    # Character detail on essentially any creator create/edit/delete
-    # anywhere on the site, reproducing the same cache-thrashing problem
-    # already confirmed in production for ModelLabel.SERIES (see IssueViewSet).
-    # Creator-rename staleness stays bounded (TTL-limited) as the tradeoff.
-    cache_detail_dependent_labels = (ModelLabel.UNIVERSE,)
+    # TEAM and UNIVERSE are tracked here: low-to-moderate row counts and
+    # write volume (measured via historical save counts: ~3.1k saves for
+    # Team, ~180 for Universe), so tying the key to either costs little.
+    # CREATOR is deliberately NOT tracked -- ~17.8k rows and ~100x
+    # UNIVERSE's write volume, so tying this key to CREATOR's version would
+    # invalidate every cached Character detail on essentially any creator
+    # create/edit/delete anywhere on the site, reproducing the same
+    # cache-thrashing problem already confirmed in production for
+    # ModelLabel.SERIES (see IssueViewSet). Creator-rename staleness stays
+    # bounded (TTL-limited) as the tradeoff.
+    cache_detail_dependent_labels = (ModelLabel.TEAM, ModelLabel.UNIVERSE)
 
     # issue_list embeds fields from Issue rows (and their Series) that don't
     # cascade a `modified` bump onto this Character except on M2M add/
@@ -596,9 +597,11 @@ class IssueViewSet(
     filterset_class = IssueFilter
     parser_classes = (JSONParser, MultiPartParser, FormParser)
     cache_model_label = ModelLabel.ISSUE
-    # Issue retrieve embeds its Series/Publisher/Imprint names, which don't
-    # cascade a `modified` bump onto this Issue when renamed. Only
-    # PUBLISHER/IMPRINT are tracked here:
+    # Issue retrieve embeds its Series/Publisher/Imprint/Arc/Character/Team/
+    # Universe/Creator names, none of which cascade a `modified` bump onto
+    # this Issue when renamed. PUBLISHER/IMPRINT/UNIVERSE are tracked here --
+    # all low write volume historically (a few hundred saves each, total,
+    # site-wide), so tying the key to them costs little:
     # - SERIES is deliberately excluded even though it's also embedded --
     #   ModelLabel.SERIES is bumped by update_series_modified_on_issue_save()
     #   on *every* issue write anywhere (PublisherViewSet.series_list needs
@@ -607,12 +610,16 @@ class IssueViewSet(
     #   affecting this issue's own Series (confirmed in production: a
     #   single unrelated issue write elsewhere flipped an otherwise-stable
     #   X-Cache HIT to a MISS).
-    # - Arc/Character/Team/Universe/Creator names are also embedded but
-    #   excluded for the same reason -- edited/created far more often than
-    #   Publisher/Imprint, so mixing them in would cost far more cache
-    #   churn than the staleness they'd prevent.
+    # - Arc/Character/Team/Creator names are also embedded but excluded for
+    #   the same reason -- their write volume (thousands to tens of
+    #   thousands of historical saves, Character highest of all) would cost
+    #   far more cache churn than the staleness they'd prevent.
     # Both cases accept staleness up to DETAIL_CACHE_TTL as the tradeoff.
-    cache_detail_dependent_labels = (ModelLabel.PUBLISHER, ModelLabel.IMPRINT)
+    cache_detail_dependent_labels = (
+        ModelLabel.PUBLISHER,
+        ModelLabel.IMPRINT,
+        ModelLabel.UNIVERSE,
+    )
 
     def get_modified_queryset(self):
         # get_queryset() annotates average_rating/rating_count for the

--- a/api/views.py
+++ b/api/views.py
@@ -437,13 +437,18 @@ class CharacterViewSet(
     parser_classes = (MultiPartParser, FormParser)
     cache_model_label = ModelLabel.CHARACTER
     # retrieve also embeds Creator/Universe names (CharacterReadSerializer)
-    # that don't cascade a `modified` bump onto this Character either, but
-    # those are deliberately left as bounded (TTL-limited) staleness rather
-    # than a cache_detail_dependent_labels dependency -- Creators in
-    # particular are edited/added far more often than Publishers/Imprints,
+    # that don't cascade a `modified` bump onto this Character either.
+    # UNIVERSE is tracked here: only ~180 rows site-wide and genuinely
+    # low-churn (~1.03 saves/row historically), so tying the key to it costs
+    # little. CREATOR is deliberately NOT tracked -- ~17.8k rows and ~100x
+    # UNIVERSE's total write volume (measured via historical save counts),
     # so tying this key to CREATOR's version would invalidate every cached
-    # Character detail on essentially any creator edit anywhere.
-    #
+    # Character detail on essentially any creator create/edit/delete
+    # anywhere on the site, reproducing the same cache-thrashing problem
+    # already confirmed in production for ModelLabel.SERIES (see IssueViewSet).
+    # Creator-rename staleness stays bounded (TTL-limited) as the tradeoff.
+    cache_detail_dependent_labels = (ModelLabel.UNIVERSE,)
+
     # issue_list embeds fields from Issue rows (and their Series) that don't
     # cascade a `modified` bump onto this Character except on M2M add/
     # remove/clear. ModelLabel.ISSUE/SERIES are deliberately NOT used as
@@ -647,6 +652,14 @@ class IssueViewSet(
                     queryset=Issue.objects.select_related("series", "series__series_type"),
                 ),
             )
+            # average_rating/rating_count deliberately do NOT cascade a
+            # `modified` bump on IssueRating changes (no such signal exists
+            # anywhere in the codebase). Ratings churn far more than any
+            # other field on a popular issue -- one vote per user, every
+            # time -- so invalidating on every rating change would defeat
+            # detail caching for exactly the issues most worth caching.
+            # Accepted staleness up to DETAIL_CACHE_TTL for these two
+            # fields specifically.
             .annotate(
                 average_rating=Avg(
                     "ratings__rating", output_field=DecimalField(max_digits=3, decimal_places=2)
@@ -871,13 +884,18 @@ class TeamViewSet(
     cache_model_label = ModelLabel.TEAM
     parser_classes = (MultiPartParser, FormParser)
     # retrieve also embeds Creator/Universe names (TeamReadSerializer) that
-    # don't cascade a `modified` bump onto this Team either, but those are
-    # deliberately left as bounded (TTL-limited) staleness rather than a
-    # cache_detail_dependent_labels dependency -- Creators in particular
-    # are edited/added far more often than Publishers/Imprints, so tying
-    # this key to CREATOR's version would invalidate every cached Team
-    # detail on essentially any creator edit anywhere.
-    #
+    # don't cascade a `modified` bump onto this Team either. UNIVERSE is
+    # tracked here: only ~180 rows site-wide and genuinely low-churn (~1.03
+    # saves/row historically), so tying the key to it costs little. CREATOR
+    # is deliberately NOT tracked -- ~17.8k rows and ~100x UNIVERSE's total
+    # write volume (measured via historical save counts), so tying this key
+    # to CREATOR's version would invalidate every cached Team detail on
+    # essentially any creator create/edit/delete anywhere on the site,
+    # reproducing the same cache-thrashing problem already confirmed in
+    # production for ModelLabel.SERIES (see IssueViewSet). Creator-rename
+    # staleness stays bounded (TTL-limited) as the tradeoff.
+    cache_detail_dependent_labels = (ModelLabel.UNIVERSE,)
+
     # issue_list embeds fields from Issue rows (and their Series) that don't
     # cascade a `modified` bump onto this Team except on M2M add/remove/
     # clear. ModelLabel.ISSUE/SERIES are deliberately NOT used as

--- a/comicsdb/apps.py
+++ b/comicsdb/apps.py
@@ -10,14 +10,21 @@ from comicsdb.signals import (
     pre_delete_image,
     update_arc_modified,
     update_character_modified,
+    update_character_modified_on_creator_change,
+    update_character_modified_on_team_change,
+    update_character_modified_on_universe_change,
     update_issue_modified_on_credit_change,
     update_issue_modified_on_credit_role_change,
     update_issue_modified_on_reprint_change,
     update_issue_modified_on_universe_change,
     update_issue_modified_on_variant_change,
+    update_series_modified_on_associated_change,
+    update_series_modified_on_genre_change,
     update_series_modified_on_issue_delete,
     update_series_modified_on_issue_save,
     update_team_modified,
+    update_team_modified_on_creator_change,
+    update_team_modified_on_universe_change,
 )
 
 
@@ -31,6 +38,21 @@ class ComicsdbConfig(AppConfig):
 
         character = self.get_model("Character")
         pre_delete.connect(pre_delete_image, sender=character, dispatch_uid="pre_delete_character")
+        m2m_changed.connect(
+            update_character_modified_on_creator_change,
+            sender=character.creators.through,
+            dispatch_uid="m2m_changed_character_creator_modified",
+        )
+        m2m_changed.connect(
+            update_character_modified_on_team_change,
+            sender=character.teams.through,
+            dispatch_uid="m2m_changed_character_team_modified",
+        )
+        m2m_changed.connect(
+            update_character_modified_on_universe_change,
+            sender=character.universes.through,
+            dispatch_uid="m2m_changed_character_universe_modified",
+        )
 
         creator = self.get_model("Creator")
         pre_delete.connect(pre_delete_image, sender=creator, dispatch_uid="pre_delete_creator")
@@ -79,9 +101,29 @@ class ComicsdbConfig(AppConfig):
         pre_delete.connect(pre_delete_image, sender=publisher, dispatch_uid="pre_delete_publisher")
 
         series = self.get_model("Series")
+        m2m_changed.connect(
+            update_series_modified_on_genre_change,
+            sender=series.genres.through,
+            dispatch_uid="m2m_changed_series_genre_modified",
+        )
+        m2m_changed.connect(
+            update_series_modified_on_associated_change,
+            sender=series.associated.through,
+            dispatch_uid="m2m_changed_series_associated_modified",
+        )
 
         team = self.get_model("Team")
         pre_delete.connect(pre_delete_image, sender=team, dispatch_uid="pre_delete_team")
+        m2m_changed.connect(
+            update_team_modified_on_creator_change,
+            sender=team.creators.through,
+            dispatch_uid="m2m_changed_team_creator_modified",
+        )
+        m2m_changed.connect(
+            update_team_modified_on_universe_change,
+            sender=team.universes.through,
+            dispatch_uid="m2m_changed_team_universe_modified",
+        )
 
         universe = self.get_model("Universe")
 

--- a/comicsdb/signals.py
+++ b/comicsdb/signals.py
@@ -91,7 +91,9 @@ def update_issue_modified_on_universe_change(sender, instance, action, pk_set, *
     """Issue.universes is a M2M, but -- unlike arcs/characters/teams --
     Universe has no issue_list-style action needing its own side bumped,
     so only the Issue side needs updating here for the issue's cached
-    detail response (which embeds `universes`) to invalidate."""
+    detail response (which embeds `universes`) to invalidate. The ISSUE
+    cache version is also bumped since IssueListSerializer embeds
+    `modified`, and that field just changed for this issue."""
     if action not in ("post_add", "post_remove", "post_clear"):
         return
 
@@ -102,13 +104,15 @@ def update_issue_modified_on_universe_change(sender, instance, action, pk_set, *
         Issue.objects.filter(pk=instance.pk).update(modified=now)
     elif pk_set:
         Issue.objects.filter(pk__in=pk_set).update(modified=now)
+    bump_model_version(ModelLabel.ISSUE)
 
 
 def update_issue_modified_on_reprint_change(sender, instance, action, pk_set, **kwargs):
     """Issue.reprints is a symmetric self-referential M2M -- both sides of
     a reprints.add()/.remove() are Issue instances, so bump both the issue
     the change was made through and the affected issue(s) on the other
-    side; both cached detail responses embed `reprints`."""
+    side; both cached detail responses embed `reprints`. The ISSUE cache
+    version is also bumped since IssueListSerializer embeds `modified`."""
     if action not in ("post_add", "post_remove", "post_clear"):
         return
 
@@ -118,15 +122,18 @@ def update_issue_modified_on_reprint_change(sender, instance, action, pk_set, **
     Issue.objects.filter(pk=instance.pk).update(modified=now)
     if pk_set:
         Issue.objects.filter(pk__in=pk_set).update(modified=now)
+    bump_model_version(ModelLabel.ISSUE)
 
 
 def update_issue_modified_on_variant_change(sender, instance, **kwargs):
     """Variant changes aren't reflected on the parent Issue's `modified` by
     default; bump it explicitly so the issue's cached detail response
-    (which embeds variants) invalidates."""
+    (which embeds variants) invalidates. The ISSUE cache version is also
+    bumped since IssueListSerializer embeds `modified`."""
     from comicsdb.models import Issue  # noqa: PLC0415
 
     Issue.objects.filter(pk=instance.issue_id).update(modified=timezone.now())
+    bump_model_version(ModelLabel.ISSUE)
 
 
 def update_issue_modified_on_credit_change(sender, instance, **kwargs):
@@ -155,6 +162,84 @@ def update_issue_modified_on_credit_role_change(sender, instance, action, pk_set
 
     Issue.objects.filter(pk=instance.issue_id).update(modified=timezone.now())
     bump_model_version(ModelLabel.ISSUE)
+
+
+def bump_owner_modified_on_m2m_change(owner_model, cache_label, instance, action, pk_set):
+    """Shared logic for m2m_changed signals on a plain (non-Issue) m2m field
+    where only the owning side's own cached response embeds the relation --
+    Character.creators/teams/universes, Team.creators/universes,
+    Series.genres. Bumps the owner's `modified` (self-invalidates its
+    detail cache, which embeds the relation) and its cache version (its
+    list response also embeds `modified`, which just changed).
+    """
+    if action not in ("post_add", "post_remove", "post_clear"):
+        return
+
+    now = timezone.now()
+    if isinstance(instance, owner_model):
+        # e.g. character.creators.add(...) -- instance is the owner.
+        owner_model.objects.filter(pk=instance.pk).update(modified=now)
+        bump_model_version(cache_label)
+    elif pk_set:
+        # e.g. creator.characters.add(...) -- instance is the related
+        # object; pk_set holds the affected owner pk(s). pk_set is None
+        # for post_clear from this side, so skip (affected owners unknown).
+        owner_model.objects.filter(pk__in=pk_set).update(modified=now)
+        bump_model_version(cache_label)
+
+
+def update_character_modified_on_creator_change(sender, instance, action, pk_set, **kwargs):
+    from comicsdb.models import Character  # noqa: PLC0415
+
+    bump_owner_modified_on_m2m_change(Character, ModelLabel.CHARACTER, instance, action, pk_set)
+
+
+def update_character_modified_on_team_change(sender, instance, action, pk_set, **kwargs):
+    from comicsdb.models import Character  # noqa: PLC0415
+
+    bump_owner_modified_on_m2m_change(Character, ModelLabel.CHARACTER, instance, action, pk_set)
+
+
+def update_character_modified_on_universe_change(sender, instance, action, pk_set, **kwargs):
+    from comicsdb.models import Character  # noqa: PLC0415
+
+    bump_owner_modified_on_m2m_change(Character, ModelLabel.CHARACTER, instance, action, pk_set)
+
+
+def update_team_modified_on_creator_change(sender, instance, action, pk_set, **kwargs):
+    from comicsdb.models import Team  # noqa: PLC0415
+
+    bump_owner_modified_on_m2m_change(Team, ModelLabel.TEAM, instance, action, pk_set)
+
+
+def update_team_modified_on_universe_change(sender, instance, action, pk_set, **kwargs):
+    from comicsdb.models import Team  # noqa: PLC0415
+
+    bump_owner_modified_on_m2m_change(Team, ModelLabel.TEAM, instance, action, pk_set)
+
+
+def update_series_modified_on_genre_change(sender, instance, action, pk_set, **kwargs):
+    from comicsdb.models import Series  # noqa: PLC0415
+
+    bump_owner_modified_on_m2m_change(Series, ModelLabel.SERIES, instance, action, pk_set)
+
+
+def update_series_modified_on_associated_change(sender, instance, action, pk_set, **kwargs):
+    """Series.associated is a self-referential m2m -- both sides of an
+    associated.add()/.remove() are Series instances (like Issue.reprints),
+    so bump both the series the change was made through and the affected
+    series on the other side; both cached detail responses embed
+    `associated`."""
+    if action not in ("post_add", "post_remove", "post_clear"):
+        return
+
+    from comicsdb.models import Series  # noqa: PLC0415
+
+    now = timezone.now()
+    Series.objects.filter(pk=instance.pk).update(modified=now)
+    bump_model_version(ModelLabel.SERIES)
+    if pk_set:
+        Series.objects.filter(pk__in=pk_set).update(modified=now)
 
 
 def bump_cache(label, sender, instance, **kwargs):

--- a/tests/comicsdb/test_api_response_caching.py
+++ b/tests/comicsdb/test_api_response_caching.py
@@ -14,6 +14,8 @@ from rest_framework.request import Request
 from api import views as api_views
 from api.views import CollectionViewSet, PullListViewSet, WishListViewSet
 from comicsdb.models import Credits, Issue, Variant
+from comicsdb.models.genre import Genre
+from issue_ratings.models import IssueRating
 
 
 @pytest.fixture
@@ -431,6 +433,225 @@ def test_issue_retrieve_reflects_variant_added(
     assert resp.status_code == status.HTTP_200_OK
     assert len(resp.json()["variants"]) == 1
     assert resp.json()["variants"][0]["name"] == "Foil Variant"
+
+
+def test_character_retrieve_reflects_creator_added(
+    api_client_with_staff_credentials, superman, john_byrne, local_cache
+):
+    """Character.creators had no m2m_changed wiring at all -- unlike the
+    Issue-side m2m fields, adding a creator didn't even bump Character's own
+    `modified`, so the character's own listed creators would stay wrong
+    (not just cosmetically stale) until the 24h TTL lapsed."""
+    url = reverse("api:character-detail", kwargs={"pk": superman.pk})
+    resp = api_client_with_staff_credentials.get(url)
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.json()["creators"] == []
+
+    superman.creators.add(john_byrne)
+
+    resp = api_client_with_staff_credentials.get(url)
+    assert resp.status_code == status.HTTP_200_OK
+    assert len(resp.json()["creators"]) == 1
+    assert resp.json()["creators"][0]["name"] == "John Byrne"
+
+
+def test_character_retrieve_reflects_team_added(
+    api_client_with_staff_credentials, superman, teen_titans, local_cache
+):
+    url = reverse("api:character-detail", kwargs={"pk": superman.pk})
+    resp = api_client_with_staff_credentials.get(url)
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.json()["teams"] == []
+
+    superman.teams.add(teen_titans)
+
+    resp = api_client_with_staff_credentials.get(url)
+    assert resp.status_code == status.HTTP_200_OK
+    assert len(resp.json()["teams"]) == 1
+
+
+def test_character_retrieve_reflects_universe_added(
+    api_client_with_staff_credentials, superman, earth_2_universe, local_cache
+):
+    url = reverse("api:character-detail", kwargs={"pk": superman.pk})
+    resp = api_client_with_staff_credentials.get(url)
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.json()["universes"] == []
+
+    superman.universes.add(earth_2_universe)
+
+    resp = api_client_with_staff_credentials.get(url)
+    assert resp.status_code == status.HTTP_200_OK
+    assert len(resp.json()["universes"]) == 1
+
+
+def test_team_retrieve_reflects_creator_added(
+    api_client_with_staff_credentials, teen_titans, john_byrne, local_cache
+):
+    """Team.creators had the same missing-wiring gap as Character.creators."""
+    url = reverse("api:team-detail", kwargs={"pk": teen_titans.pk})
+    resp = api_client_with_staff_credentials.get(url)
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.json()["creators"] == []
+
+    teen_titans.creators.add(john_byrne)
+
+    resp = api_client_with_staff_credentials.get(url)
+    assert resp.status_code == status.HTTP_200_OK
+    assert len(resp.json()["creators"]) == 1
+
+
+def test_team_retrieve_reflects_universe_added(
+    api_client_with_staff_credentials, teen_titans, earth_2_universe, local_cache
+):
+    url = reverse("api:team-detail", kwargs={"pk": teen_titans.pk})
+    resp = api_client_with_staff_credentials.get(url)
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.json()["universes"] == []
+
+    teen_titans.universes.add(earth_2_universe)
+
+    resp = api_client_with_staff_credentials.get(url)
+    assert resp.status_code == status.HTTP_200_OK
+    assert len(resp.json()["universes"]) == 1
+
+
+def test_character_retrieve_after_universe_rename_is_not_stale(
+    api_client_with_staff_credentials, superman, earth_2_universe, local_cache
+):
+    """CharacterViewSet.cache_detail_dependent_labels includes UNIVERSE --
+    unlike CREATOR, Universe is low-churn (~180 rows site-wide) so tying the
+    detail cache to it doesn't reproduce the SERIES-style thrashing
+    problem."""
+    superman.universes.add(earth_2_universe)
+    url = reverse("api:character-detail", kwargs={"pk": superman.pk})
+    resp = api_client_with_staff_credentials.get(url)
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.json()["universes"][0]["name"] == "Earth 2"
+
+    earth_2_universe.name = "Earth 2 Renamed"
+    earth_2_universe.save()
+
+    resp = api_client_with_staff_credentials.get(url)
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.json()["universes"][0]["name"] == "Earth 2 Renamed"
+
+
+def test_character_retrieve_after_creator_rename_is_accepted_staleness(
+    api_client_with_staff_credentials, superman, john_byrne, local_cache
+):
+    """CREATOR is deliberately NOT one of CharacterViewSet's
+    cache_detail_dependent_labels (see the comment there) -- Creator's
+    write volume is ~100x Universe's, so tying the key to it would
+    invalidate every cached Character detail on essentially any creator
+    edit anywhere. This test guards against re-adding CREATOR and
+    reintroducing that regression."""
+    superman.creators.add(john_byrne)
+    url = reverse("api:character-detail", kwargs={"pk": superman.pk})
+    resp = api_client_with_staff_credentials.get(url)
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.json()["creators"][0]["name"] == "John Byrne"
+
+    john_byrne.name = "John Byrne Renamed"
+    john_byrne.save()
+
+    resp = api_client_with_staff_credentials.get(url)
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.json()["creators"][0]["name"] == "John Byrne"
+
+
+def test_team_retrieve_after_universe_rename_is_not_stale(
+    api_client_with_staff_credentials, teen_titans, earth_2_universe, local_cache
+):
+    teen_titans.universes.add(earth_2_universe)
+    url = reverse("api:team-detail", kwargs={"pk": teen_titans.pk})
+    resp = api_client_with_staff_credentials.get(url)
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.json()["universes"][0]["name"] == "Earth 2"
+
+    earth_2_universe.name = "Earth 2 Renamed"
+    earth_2_universe.save()
+
+    resp = api_client_with_staff_credentials.get(url)
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.json()["universes"][0]["name"] == "Earth 2 Renamed"
+
+
+def test_team_retrieve_after_creator_rename_is_accepted_staleness(
+    api_client_with_staff_credentials, teen_titans, john_byrne, local_cache
+):
+    """CREATOR is deliberately NOT one of TeamViewSet's
+    cache_detail_dependent_labels; see
+    test_character_retrieve_after_creator_rename_is_accepted_staleness."""
+    teen_titans.creators.add(john_byrne)
+    url = reverse("api:team-detail", kwargs={"pk": teen_titans.pk})
+    resp = api_client_with_staff_credentials.get(url)
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.json()["creators"][0]["name"] == "John Byrne"
+
+    john_byrne.name = "John Byrne Renamed"
+    john_byrne.save()
+
+    resp = api_client_with_staff_credentials.get(url)
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.json()["creators"][0]["name"] == "John Byrne"
+
+
+def test_series_retrieve_reflects_genre_added(
+    api_client_with_staff_credentials, fc_series, local_cache
+):
+    """Series.genres had the same missing-wiring gap as Character.creators."""
+    url = reverse("api:series-detail", kwargs={"pk": fc_series.pk})
+    resp = api_client_with_staff_credentials.get(url)
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.json()["genres"] == []
+
+    genre = Genre.objects.create(name="Superhero")
+    fc_series.genres.add(genre)
+
+    resp = api_client_with_staff_credentials.get(url)
+    assert resp.status_code == status.HTTP_200_OK
+    assert len(resp.json()["genres"]) == 1
+
+
+def test_series_retrieve_reflects_associated_added(
+    api_client_with_staff_credentials, fc_series, bat_sups_series, local_cache
+):
+    """Series.associated is a self-referential m2m; the same missing-wiring
+    gap applied here too."""
+    url = reverse("api:series-detail", kwargs={"pk": fc_series.pk})
+    resp = api_client_with_staff_credentials.get(url)
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.json()["associated"] == []
+
+    fc_series.associated.add(bat_sups_series)
+
+    resp = api_client_with_staff_credentials.get(url)
+    assert resp.status_code == status.HTTP_200_OK
+    assert len(resp.json()["associated"]) == 1
+
+
+def test_issue_retrieve_does_not_invalidate_on_rating_change(
+    api_client_with_staff_credentials, basic_issue, create_user, local_cache
+):
+    """average_rating/rating_count are annotated aggregates over IssueRating,
+    but rating changes are deliberately excluded from cache invalidation --
+    see the comment on IssueViewSet.get_queryset(). Ratings churn far more
+    than any other field on a popular issue (every user's vote), so
+    cascading a `modified` bump here would defeat detail caching for
+    exactly the issues most worth caching. This test locks in that
+    intentional tradeoff."""
+    url = reverse("api:issue-detail", kwargs={"pk": basic_issue.pk})
+    resp = api_client_with_staff_credentials.get(url)
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.json()["rating_count"] == 0
+
+    user = create_user()
+    IssueRating.objects.create(issue=basic_issue, user=user, rating=5)
+
+    resp = api_client_with_staff_credentials.get(url)
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.json()["rating_count"] == 0
 
 
 def test_issue_retrieve_x_cache_header(api_client_with_credentials, basic_issue, local_cache):

--- a/tests/comicsdb/test_api_response_caching.py
+++ b/tests/comicsdb/test_api_response_caching.py
@@ -298,6 +298,27 @@ def test_issue_retrieve_after_publisher_rename_is_not_stale(
     assert resp.json()["publisher"]["name"] == "DC Comics Renamed"
 
 
+def test_issue_retrieve_after_universe_rename_is_not_stale(
+    api_client_with_staff_credentials, basic_issue, earth_2_universe, local_cache
+):
+    """IssueViewSet.cache_detail_dependent_labels includes UNIVERSE --
+    Universe's total write volume (~180 historical saves site-wide) is
+    actually lower than Publisher's, which was already tracked here, so
+    this costs no more cache churn than the Publisher/Imprint dependency."""
+    basic_issue.universes.add(earth_2_universe)
+    url = reverse("api:issue-detail", kwargs={"pk": basic_issue.pk})
+    resp = api_client_with_staff_credentials.get(url)
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.json()["universes"][0]["name"] == "Earth 2"
+
+    earth_2_universe.name = "Earth 2 Renamed"
+    earth_2_universe.save()
+
+    resp = api_client_with_staff_credentials.get(url)
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.json()["universes"][0]["name"] == "Earth 2 Renamed"
+
+
 def test_imprint_retrieve_after_publisher_rename_is_not_stale(
     api_client_with_staff_credentials, vertigo_imprint, dc_comics, local_cache
 ):
@@ -535,6 +556,27 @@ def test_character_retrieve_after_universe_rename_is_not_stale(
     resp = api_client_with_staff_credentials.get(url)
     assert resp.status_code == status.HTTP_200_OK
     assert resp.json()["universes"][0]["name"] == "Earth 2 Renamed"
+
+
+def test_character_retrieve_after_team_rename_is_not_stale(
+    api_client_with_staff_credentials, superman, teen_titans, local_cache
+):
+    """CharacterViewSet.cache_detail_dependent_labels includes TEAM --
+    moderate write volume (~3.1k historical saves site-wide) but nowhere
+    near Creator's (~18.6k), so tying the detail cache to it is a
+    reasonable tradeoff, unlike CREATOR."""
+    superman.teams.add(teen_titans)
+    url = reverse("api:character-detail", kwargs={"pk": superman.pk})
+    resp = api_client_with_staff_credentials.get(url)
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.json()["teams"][0]["name"] == "Teen Titans"
+
+    teen_titans.name = "Teen Titans Renamed"
+    teen_titans.save()
+
+    resp = api_client_with_staff_credentials.get(url)
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.json()["teams"][0]["name"] == "Teen Titans Renamed"
 
 
 def test_character_retrieve_after_creator_rename_is_accepted_staleness(

--- a/user_collection/signals.py
+++ b/user_collection/signals.py
@@ -1,5 +1,12 @@
 def sync_issue_rating_from_collection_item(sender, instance, **kwargs):
-    """Keep the community IssueRating in sync with a user's personal collection rating."""
+    """Keep the community IssueRating in sync with a user's personal collection rating.
+
+    Deliberately does not bump the Issue's `modified`/cache -- see the
+    comment on IssueViewSet.get_queryset()'s average_rating/rating_count
+    annotation in api/views.py. Ratings change far more often than any
+    other Issue field, so invalidating the API cache here would defeat
+    detail caching for exactly the issues most worth caching.
+    """
     from issue_ratings.models import IssueRating  # noqa: PLC0415
 
     if instance.rating is not None:


### PR DESCRIPTION
## Description

Follow-up to the Redis-backed API response caching added in #603: closes the staleness gaps that were left as known follow-ups, and tunes the detail-cache TTL based on production observation.

**Missing invalidation wiring** (not just cosmetic staleness -- these relations had no `m2m_changed` signal at all, so an object's own cached response could show wrong data, not just stale nested fields, until the cache TTL lapsed):
- `Character.creators`/`teams`/`universes`
- `Team.creators`/`universes`
- `Series.genres`/`associated`

**Consistency fix**: the variant/universe/reprint Issue cascades now bump the `ISSUE` list-cache version, matching the credits/credit-role cascades -- `IssueListSerializer` embeds `modified`, so list responses could show a stale timestamp for up to the (2 min) list TTL otherwise.

**Rename-cascade staleness**, evaluated per-model using actual write-volume data (row counts + `simple_history` save counts) rather than assumption:
- Added `UNIVERSE` to `IssueViewSet.cache_detail_dependent_labels` and `UNIVERSE`/`TEAM` to `CharacterViewSet`'s -- both low enough write volume (a few hundred to a few thousand historical saves site-wide) that tying the cache key to them costs little.
- `CREATOR` stays deliberately excluded everywhere -- ~100x Universe's write volume (17.8k rows / 18.6k saves), which would very likely reproduce the cache-thrashing regression already hit and fixed for `SERIES` in production.
- Genre rename staleness (Series detail) was intentionally left alone -- since genre names are effectively static.

**Explicitly locked in**: `IssueRating`/`CollectionItem` rating changes do NOT invalidate the Issue cache, on purpose -- ratings churn far more than any other field on a popular issue, so cascading here would defeat detail caching for exactly the issues most worth caching. Documented at both call sites and guarded by a regression test.

**Tuning**: `DETAIL_CACHE_TTL` raised 6h -> 24h -> 48h. Since detail keys are self-versioning (embed the object's `modified` timestamp), this is purely a memory-reclamation knob with no staleness cost -- watching Redis memory in production to find the right ceiling.

