### PR TITLE
Add publisher and series_type to the series list endpoint

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -2544,6 +2544,11 @@ For questions, issues, or feature requests:
 
 ## Changelog
 
+### Version 1.11
+
+- Added `publisher` (object with `id`/`name`) and `series_type` (object with `id`/`name`) fields to the Series list endpoint
+- `GET /api/publisher/{id}/series_list/` now returns the same response shape as the top-level Series list endpoint (previously a separate serializer that omitted `cv_id`, `gcd_id`, `publisher`, and `series_type`)
+
 ### Version 1.10
 
 - Italian comics support: Issue and Variant `price` fields now support larger cover price amounts (up to 6 digits before the decimal point)

--- a/api/README.md
+++ b/api/README.md
@@ -670,11 +670,22 @@ Comic book series.
   "year_end": null,
   "volume": 1,
   "issue_count": 900,
+  "publisher": {
+    "id": 1,
+    "name": "Marvel"
+  },
+  "series_type": {
+    "id": 1,
+    "name": "Single Issue"
+  },
   "cv_id": 18693,
   "gcd_id": 621,
   "modified": "2025-01-15T10:30:00Z"
 }
 ```
+
+- `publisher` - Object with `id`/`name` for the series' publisher
+- `series_type` - Object with `id`/`name` (e.g. Single Issue, Trade Paperback, Hardcover)
 
 **Detail Response Fields:**
 

--- a/api/v1_0/serializers/__init__.py
+++ b/api/v1_0/serializers/__init__.py
@@ -29,7 +29,6 @@ from api.v1_0.serializers.issue import (
 from api.v1_0.serializers.rating import RatingSerializer
 from api.v1_0.serializers.series import (
     AssociatedSeriesSerializer,
-    PublisherSeriesListSerializer,
     SeriesListSerializer,
     SeriesReadSerializer,
     SeriesSerializer,
@@ -94,7 +93,6 @@ __all__ = [
     "MissingSeriesSerializer",
     "PublisherListSerializer",
     "PublisherSerializer",
-    "PublisherSeriesListSerializer",
     "RatingSerializer",
     "ReadingListItemSerializer",
     "ReadingListListSerializer",

--- a/api/v1_0/serializers/series.py
+++ b/api/v1_0/serializers/series.py
@@ -6,9 +6,17 @@ from api.v1_0.serializers.publisher import BasicPublisherSerializer
 from comicsdb.models import Series, SeriesType
 
 
+class SeriesTypeSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = SeriesType
+        fields = ("id", "name")
+
+
 class SeriesListSerializer(serializers.ModelSerializer):
     series = serializers.CharField(source="__str__")
     issue_count = serializers.IntegerField(source="num_issues", read_only=True)
+    publisher = BasicPublisherSerializer(read_only=True)
+    series_type = SeriesTypeSerializer(read_only=True)
 
     class Meta:
         model = Series
@@ -19,21 +27,12 @@ class SeriesListSerializer(serializers.ModelSerializer):
             "year_end",
             "volume",
             "issue_count",
+            "publisher",
+            "series_type",
             "cv_id",
             "gcd_id",
             "modified",
         )
-
-
-class PublisherSeriesListSerializer(SeriesListSerializer):
-    class Meta(SeriesListSerializer.Meta):
-        fields = ("id", "series", "year_began", "year_end", "volume", "issue_count", "modified")
-
-
-class SeriesTypeSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = SeriesType
-        fields = ("id", "name")
 
 
 class AssociatedSeriesSerializer(serializers.ModelSerializer):

--- a/api/views.py
+++ b/api/views.py
@@ -56,7 +56,6 @@ from api.v1_0.serializers import (
     MissingSeriesSerializer,
     PublisherListSerializer,
     PublisherSerializer,
-    PublisherSeriesListSerializer,
     ReadingListItemSerializer,
     ReadingListListSerializer,
     ReadingListReadSerializer,
@@ -717,11 +716,11 @@ class PublisherViewSet(
             case "list":
                 return PublisherListSerializer
             case "series_list":
-                return PublisherSeriesListSerializer
+                return SeriesListSerializer
             case _:
                 return PublisherSerializer
 
-    @extend_schema(responses={200: PublisherSeriesListSerializer(many=True)}, filters=False)
+    @extend_schema(responses={200: SeriesListSerializer(many=True)}, filters=False)
     @action(detail=True)
     def series_list(self, request, pk=None):
         """
@@ -749,14 +748,14 @@ class PublisherViewSet(
             return _mark_cache_status(Response(cached), hit=True)
 
         queryset = (
-            publisher.series.select_related("series_type")
+            publisher.series.select_related("series_type", "publisher")
             .annotate(num_issues=Count("issues", distinct=True))
             .order_by("sort_name", "year_began")
         )
         page = self.paginate_queryset(queryset)
         if page is None:
             raise Http404
-        serializer = PublisherSeriesListSerializer(page, many=True, context={"request": request})
+        serializer = SeriesListSerializer(page, many=True, context={"request": request})
         response = self.get_paginated_response(serializer.data)
         cache.set(key, response.data, LIST_CACHE_TTL)
         return _mark_cache_status(response, hit=False)

--- a/tests/comicsdb/test_api_publisher.py
+++ b/tests/comicsdb/test_api_publisher.py
@@ -3,7 +3,7 @@ from django.db.models import Count
 from django.urls import reverse
 from rest_framework import status
 
-from api.v1_0.serializers import PublisherSeriesListSerializer
+from api.v1_0.serializers import SeriesListSerializer
 from comicsdb.models import Series
 
 
@@ -199,7 +199,7 @@ def test_publisher_series_list_view(api_client_with_credentials, dc_comics, fc_s
         .annotate(num_issues=Count("issues", distinct=True))
         .first()
     )
-    serializer = PublisherSeriesListSerializer(series)
+    serializer = SeriesListSerializer(series)
     assert resp.data["count"] == 1
     assert resp.data["next"] is None
     assert resp.data["previous"] is None


### PR DESCRIPTION
## Summary
- Adds `publisher` (id/name) and `series_type` (id/name) to `SeriesListSerializer`, exposed on `GET /api/series/`.
- Removes `PublisherSeriesListSerializer` and switches `GET /api/publisher/{id}/series_list/` to use `SeriesListSerializer` directly, since the added `publisher` field made the two serializers equivalent.
- Updates `api/README.md` with the new list response fields.
