### PR TITLE
Fix pull_list series endpoint regression and stale README example

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -1592,17 +1592,12 @@ Track ongoing comic book series a user is following — the digital equivalent o
       "id": 7,
       "series": {
         "id": 123,
-        "name": "Amazing Spider-Man",
+        "series": "Amazing Spider-Man (1963)",
+        "year_began": 1963,
+        "year_end": null,
         "volume": 1,
-        "series_type": {
-          "id": 1,
-          "name": "Ongoing Series"
-        },
-        "publisher": {
-          "id": 2,
-          "name": "Marvel"
-        },
-        "year_began": 1963
+        "issue_count": 900,
+        "modified": "2025-01-15T10:30:00Z"
       },
       "added_on": "2026-04-15T09:30:00Z"
     }

--- a/api/v1_0/serializers/pull_list.py
+++ b/api/v1_0/serializers/pull_list.py
@@ -10,8 +10,21 @@ class PullListIssueSerializer(IssueListSerializer):
         fields = tuple(f for f in IssueListSerializer.Meta.fields if f != "cover_hash")
 
 
+class PullListSeriesInfoSerializer(SeriesListSerializer):
+    class Meta(SeriesListSerializer.Meta):
+        fields = (
+            "id",
+            "series",
+            "year_began",
+            "year_end",
+            "volume",
+            "issue_count",
+            "modified",
+        )
+
+
 class PullListSeriesSerializer(serializers.ModelSerializer):
-    series = SeriesListSerializer(read_only=True)
+    series = PullListSeriesInfoSerializer(read_only=True)
 
     class Meta:
         model = PullListSeries


### PR DESCRIPTION
## Summary
- Fixes a regression from #618: adding `publisher`/`series_type` to `SeriesListSerializer` leaked into `GET /api/pull_list/series/`, which nested that serializer directly. Introduces `PullListSeriesInfoSerializer` to pin the pull_list series field back to its original shape (`id`, `series`, `year_began`, `year_end`, `volume`, `issue_count`, `modified`) — also dropping `cv_id`/`gcd_id`, which were never meant to be exposed there either.
- Corrects the `GET /api/pull_list/series/` example in `api/README.md`, which documented fields (`name`, `series_type`, `publisher`) that this endpoint never actually returned, predating this change.
